### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ class ExampleController() {
         
         // Returning signed resource string
         try {
-            $pdf = new SignaturePdf('path/to/pdf/file.pdf', $cert->getCert(), SignaturePdf::MODE_RESOURCE) // Resource mode is default
+            $pdf = new SignaturePdf('path/to/pdf/file.pdf', $cert, SignaturePdf::MODE_RESOURCE) // Resource mode is default
             $resource = $pdf->signature();
             // TODO necessary
         } catch (\Throwable $th) {
@@ -192,8 +192,17 @@ class ExampleController() {
         
         // Downloading signed file
         try {
-            $pdf = new SignaturePdf('path/to/pdf/file.pdf', $cert->getCert(), SignaturePdf::MODE_DOWNLOAD)
+            $pdf = new SignaturePdf('path/to/pdf/file.pdf', $cert, SignaturePdf::MODE_DOWNLOAD)
             return $pdf->signature(); // The file will be downloaded
+        } catch (\Throwable $th) {
+            // TODO necessary
+        }
+	
+	// Returning signed resource from upload
+        try {
+            $pdf = new SignaturePdf($request->file('PDFfile'), $cert, SignaturePdf::MODE_RESOURCE) // Resource mode is default
+            $resource = $pdf->signature();
+            // TODO necessary
         } catch (\Throwable $th) {
             // TODO necessary
         }


### PR DESCRIPTION
Change `$cert->getCert()` to `$cert` in section "1. Sign PDF with certificate from file or upload."
Add how to sign pdf from upload file (no path).

Note: It's just a tiny contribution, but I hope it can help to make it better.