### PR TITLE
Accept special characters in certificate password.

### DIFF
--- a/src/Sign/ManageCert.php
+++ b/src/Sign/ManageCert.php
@@ -65,7 +65,7 @@ class ManageCert
 
         $this->password = $password;
         $output         = a1TempDir(true, '.crt');
-        $openSslCommand = "openssl pkcs12 -in {$pfxPath} -out {$output} -nodes -password pass:{$this->password}";
+        $openSslCommand = "openssl pkcs12 -in {$pfxPath} -out {$output} -nodes -password pass:'{$this->password}'";
 
         runCliCommandProcesses($openSslCommand);
 


### PR DESCRIPTION
Hello! 

I fix a issue when a certificate password contains special chars. Ex.: A4c&6(2p24@89K.

Hugs! 