### PR TITLE
Fixing 'openssl' is not recognized as internal or external command on windows

### DIFF
--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -111,7 +111,10 @@ if (!function_exists('runCliCommandProcesses')) {
      */
     function runCliCommandProcesses(string $command): void
     {
-        $process = Process::fromShellCommandline($command);
+        $process = Process::fromShellCommandline($command,null, [
+            'PATH' => getenv("PATH")
+        ]);
+        
         $process->run();
         while ($process->isRunning()) continue;
 

--- a/src/Sign/ManageCert.php
+++ b/src/Sign/ManageCert.php
@@ -77,7 +77,7 @@ class ManageCert
         $this->password = $password;
         $output = a1TempDir(true, '.crt');
         $legacyFlag = $this->isLegacy ? self::LEGACY_FLAG : '';
-        $openSslCommand = "openssl pkcs12 -in {$pfxPath} -out {$output} -nodes -password pass:'{$this->password}' {$legacyFlag}";
+        $openSslCommand = "openssl pkcs12 -in {$pfxPath} -out {$output} -nodes -password pass:{$this->password} {$legacyFlag}";
 
         runCliCommandProcesses($openSslCommand);
 


### PR DESCRIPTION
I had similar issues of the the issue #102 and I'm pushing an update for it. 