### PR TITLE
ci(mutation): score a commit once, not once per night

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -17,6 +17,12 @@ name: Mutation testing
 #
 # It still fails loudly when the score drops, and workflow_dispatch runs it on
 # demand before a release.
+#
+# The schedule is when it may run, not what it measures: the `changed` job below
+# compares the default branch against the last run that reached a verdict and
+# skips when nothing has moved. Re-scoring identical code answers a question
+# already answered — and answers it differently, since the score is not
+# reproducible, so a quiet week would produce a week of contradictory numbers.
 on:
   schedule:
     - cron: '0 4 * * *'
@@ -24,6 +30,8 @@ on:
 
 permissions:
   contents: read
+  # To read this workflow's own history and find the commit last scored.
+  actions: read
   # Only to file the failure. A red job notifies whoever last touched the cron
   # and nobody else, and a scheduled run nobody watches is discovered whenever
   # someone next opens the Actions tab.
@@ -34,9 +42,53 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changed:
+    name: Has main moved?
+    runs-on: ubuntu-latest
+
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+
+    steps:
+      # Compared against the last run that reached a verdict, not against a
+      # 24-hour window: a cancelled or delayed run would make a window lie, and
+      # GitHub delays scheduled runs under load. Cancelled runs are excluded
+      # deliberately — concurrency cancels them mid-flight, so their commit was
+      # never actually scored.
+      - name: Compare against the commit last scored
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          scored=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/mutation.yml/runs?per_page=30" \
+            --jq '[.workflow_runs[]
+                   | select(.id != ${{ github.run_id }})
+                   | select(.conclusion == "success" or .conclusion == "failure")][0].head_sha // ""')
+
+          echo "last scored: ${scored:-none}"
+          echo "current:     ${{ github.sha }}"
+
+          # A manual dispatch always runs — it is the escape hatch, used before
+          # a release and to re-check after a toolchain fix.
+          if [ "${{ github.event_name }}" != 'schedule' ]; then
+            echo 'run=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$scored" = "${{ github.sha }}" ]; then
+            echo 'run=false' >> "$GITHUB_OUTPUT"
+            echo "Skipped: \`${GITHUB_SHA:0:7}\` was already scored, and nothing has landed since." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'run=true' >> "$GITHUB_OUTPUT"
+          fi
+
   mutate:
     name: ${{ matrix.namespace }}
     runs-on: ubuntu-latest
+
+    needs: changed
+    if: needs.changed.outputs.run == 'true'
 
     strategy:
       fail-fast: false

--- a/docs/spec/quality-policy.md
+++ b/docs/spec/quality-policy.md
@@ -104,6 +104,23 @@ changed nothing. A gate contributors learn to re-run has stopped being a gate.
 `workflow_dispatch` runs it on demand before a release, and a failing run opens
 or updates a tracking issue per namespace.
 
+**The schedule is when it may run, not what it measures.** A `changed` job
+compares the default branch against the commit of the last run that reached a
+verdict, and skips when nothing has landed since — so a given commit is scored
+once, not once per night.
+
+Re-scoring identical code answers a question already answered, and answers it
+*differently*: the score is not reproducible, so a quiet week would produce a
+week of contradictory numbers for the same tree, and any of them could trip a
+floor. Cancelled runs are excluded from the comparison — concurrency cancels
+them mid-flight, so their commit was never actually scored.
+
+The cost is that this job stops doubling as a canary for the unpinned
+dependency resolution. It was playing that role by accident, and playing it
+well — the `php-code-coverage` break of 2026-08-08 arrived with no commit
+behind it and was caught by a nightly on untouched code. During a quiet period
+that break would now surface only at the next merge.
+
 ## CI
 
 `.github/workflows/main_action.yml`, on pull requests to `main` only — every


### PR DESCRIPTION
The schedule said *when* the job may run; it did not say *what it measures*. A tree nobody touched was re-scored every night.

## Why that is worse than it sounds

Re-scoring identical code does not answer the same question twice — it answers it **differently**. The score is not reproducible: it tracks how many mutations time out, which tracks machine load, and `Certificates` swings about three points between identical runs.

So a quiet week produced a week of contradictory numbers for one unchanged tree, and any one of them could trip a floor on its own. That is the failure mode the floors were set low to avoid, arriving through the back door.

## What changes

A `changed` job compares the default branch against the commit of the **last run that reached a verdict**, and the matrix runs only when they differ.

```yaml
needs: changed
if: needs.changed.outputs.run == 'true'
```

Two details that are deliberate:

- **Compared against a run, not a 24-hour window.** GitHub delays scheduled runs under load, so a window would silently miss commits.
- **Cancelled runs are excluded.** `concurrency` cancels them mid-flight, so their commit was never actually scored — treating one as the baseline would suppress the next real run.

`workflow_dispatch` is unaffected and always runs: it is the escape hatch, used before a release and to re-check after a toolchain fix. It also logs the comparison it *would* have made, so the logic is observable without waiting for a schedule.

Needs `actions: read` to look up this workflow's own history.

## The cost, recorded rather than glossed

**This job stops doubling as a canary for the unpinned dependency resolution.** It was playing that role by accident and playing it well: the `php-code-coverage` 14.2.4 break of 2026-08-08 arrived with no commit behind it, and a nightly caught it on untouched 2.0.0 code. During a quiet period, that class of break now surfaces only at the next merge.

That is a real trade, and it is written into `docs/spec/quality-policy.md` rather than left for someone to rediscover. If it bites, the cheap mitigation is a floor on staleness — run anyway when the last verdict is older than N days — which keeps both properties for one extra run a week.

## Verification

`composer check` on PHP 8.5 through `.docker`: green, 135 tests. The workflow parses, and `mutate` correctly declares `needs: changed`.

The skip path cannot be exercised by `workflow_dispatch` by design, so it will be confirmed on the first scheduled run after this merges — the one following it should skip.