### PR TITLE
docs(claude): ban the em dash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,20 @@ Conventional Commits, in English (`feat:`, `fix:`, `chore(deps):`, `test:`, `doc
 
 ## Conventions
 
-- **Everything in English** — code, comments, docblocks, commit messages, documentation. The package is used internationally.
+### Writing
+
+- **No em dashes.** Not in prose, comments, docblocks, commit messages, documentation, pull request bodies or issue replies. Use a comma, a colon, parentheses, or two sentences.
+
+  | Instead of | Write |
+  |---|---|
+  | `the score is not reproducible — it tracks timeouts` | `the score is not reproducible: it tracks timeouts` |
+  | `PEM ships as .pem, .crt — so gate on content` | `PEM ships as .pem and .crt, so gate on content` |
+  | `two reasons — cost and reproducibility` | `two reasons: cost and reproducibility` |
+  | `the fix — which is uniform — needs no branch` | `the fix (which is uniform) needs no branch` |
+
+  A colon carries the same "here is the reason" weight the em dash was doing, and reads the same to someone skimming. Ranges keep the en dash: `8.4 – 8.5`.
+
+- **Everything in English:** code, comments, docblocks, commit messages, documentation. The package is used internationally.
 - PER-CS via Pint; grouped `use` imports with braces are used throughout.
 - `final readonly` classes by default; fluent setters returning `self`; named arguments at call sites.
 - Modern PHP is expected: typed class constants, `#[\SensitiveParameter]` on every password argument, `#[\Override]`, enums instead of class constants.


### PR DESCRIPTION
Records the rule as a repository convention, under Conventions → Writing, so it binds anything written here: prose, comments, docblocks, commit messages, pull request bodies, issue replies.

| Instead of | Write |
|---|---|
| `the score is not reproducible — it tracks timeouts` | `the score is not reproducible: it tracks timeouts` |
| `two reasons — cost and reproducibility` | `two reasons: cost and reproducibility` |
| `the fix — which is uniform — needs no branch` | `the fix (which is uniform) needs no branch` |

Ranges keep the en dash: `8.4 – 8.5`.

## Scope of this pull request

**It states the rule and nothing else.** The tree currently holds 283 em dashes:

| Area | Count |
|---|---|
| `docs/` | 159 |
| `src/` | 45 |
| `CLAUDE.md` | 31 |
| `UPGRADE.md` | 18 |
| `.github/` | 11 |
| `tests/` | 10 |
| `README.md` | 5 |
| `ARCHITECTURE.md` | 4 |

Most were added over the last two days. They are left for a separate pass on purpose: replacing one is a judgement per sentence, since the right substitute is sometimes a comma, sometimes a colon, sometimes parentheses and sometimes a full stop. A blind `sed` would produce worse prose than it removes, and would touch 45 docblocks in `src/` in the same commit as documentation, which is not a diff anyone can review.

No release: `CLAUDE.md` is `export-ignore`d.