### PR TITLE
chore: remove the em dashes from src and tests

### DIFF
--- a/src/A1PdfSignManager.php
+++ b/src/A1PdfSignManager.php
@@ -108,7 +108,7 @@ final readonly class A1PdfSignManager implements A1PdfSign
     /**
      * encryptCertificate() stores the PEM bundle, so this parses it directly.
      * The v1 helper wrote it to a .pfx and fed it to `openssl pkcs12 -in`,
-     * which expects binary PKCS#12 and always failed — see
+     * which expects binary PKCS#12 and always failed. See
      * docs/history/v2-modernization.md.
      */
     public function decryptCertificate(
@@ -160,7 +160,7 @@ final readonly class A1PdfSignManager implements A1PdfSign
     /**
      * Reads whichever encoding turned up.
      *
-     * Signing keeps explicit siblings — signFromFile() and signFromPem() — so
+     * Signing keeps explicit siblings, signFromFile() and signFromPem(), so
      * the caller states what it holds. encryptCertificate() has no sibling and
      * takes "a certificate" generically, so it detects instead. The two
      * encodings are trivially distinguishable, text marker against binary, so

--- a/src/Certificates/CertificateParser.php
+++ b/src/Certificates/CertificateParser.php
@@ -33,7 +33,7 @@ final class CertificateParser
         // The key is passed as [bundle, password] rather than as a bare string:
         // the string form cannot decrypt a passphrase-protected private key, so
         // a PEM carrying one failed here with an exception naming the wrong
-        // cause. PKCS#12 never exposed it — openssl_pkcs12_read() hands back an
+        // cause. PKCS#12 never exposed it: openssl_pkcs12_read() hands back an
         // already-decrypted key. The array form is correct for both, so there is
         // nothing to branch on. See docs/decisions/0007-pem-second-entry-one-pipeline.md.
         if (! openssl_x509_check_private_key($x509, [$pem, $password])) {

--- a/src/Certificates/CertificateVault.php
+++ b/src/Certificates/CertificateVault.php
@@ -13,7 +13,7 @@ use SensitiveParameter;
  * Encrypts a parsed certificate for storage, and reads it back.
  *
  * Each vault carries its own key. seal() returns that key alongside the
- * ciphertext, and open() needs it — losing it means losing the certificate.
+ * ciphertext, and open() needs it: losing it means losing the certificate.
  */
 final readonly class CertificateVault
 {
@@ -62,7 +62,7 @@ final readonly class CertificateVault
     /**
      * Restores a sealed certificate.
      *
-     * What seal() stored is the PEM bundle, so it is parsed directly — no
+     * What seal() stored is the PEM bundle, so it is parsed directly: no
      * PKCS#12 conversion, no temporary file and no shell-out. The v1 pair
      * wrote the PEM to a .pfx and fed it back to `openssl pkcs12 -in`, which
      * expects binary PKCS#12 and always failed. See docs/history/v2-modernization.md.

--- a/src/Certificates/NativeCertificateReader.php
+++ b/src/Certificates/NativeCertificateReader.php
@@ -52,7 +52,7 @@ final readonly class NativeCertificateReader implements CertificateReader
     /**
      * Rebuilds the bundle as the combined PEM the signer expects.
      *
-     * The order — certificate, private key, then the CA chain — matches what
+     * The order (certificate, private key, then the CA chain) matches what
      * `openssl pkcs12 -nodes` writes, so output stays interchangeable with the
      * legacy reader's.
      *

--- a/src/Certificates/PemCertificateReader.php
+++ b/src/Certificates/PemCertificateReader.php
@@ -10,12 +10,12 @@ use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidX509PrivateKeyException;
 use SensitiveParameter;
 
 /**
- * Reads PEM — the degenerate case of {@see CertificateReader}.
+ * Reads PEM, the degenerate case of {@see CertificateReader}.
  *
  * The other two readers exist to convert PKCS#12 into PEM before handing it to
  * {@see CertificateParser}. PEM is already that destination format, so this
  * reader has no conversion step: it checks the input is what it claims to be,
- * and delegates. Everything downstream is unchanged, which is the whole point —
+ * and delegates. Everything downstream is unchanged, which is the whole point:
  * one pipeline, reached through a second entry (docs/decisions/0007-pem-second-entry-one-pipeline.md).
  *
  * It carries no legacy/native axis, so it is not built by {@see ReaderFactory};
@@ -36,7 +36,7 @@ final readonly class PemCertificateReader implements CertificateReader
     /**
      * Whether these bytes carry a PEM certificate.
      *
-     * Callers that accept either encoding — the pdf:sign command, the vault —
+     * Callers that accept either encoding (the pdf:sign command, the vault)
      * route on this, so "what counts as PEM" is decided in one place rather
      * than re-implemented per entry point.
      */
@@ -49,7 +49,7 @@ final readonly class PemCertificateReader implements CertificateReader
      * Reads a bundle holding both the certificate and its private key.
      *
      * The password defaults to empty because, unlike PKCS#12, a PEM private key
-     * is frequently unencrypted — and OpenSSL ignores a passphrase given for a
+     * is frequently unencrypted, and OpenSSL ignores a passphrase given for a
      * key that does not need one, so the default is safe either way.
      *
      * @param  string  $contents  A PEM bundle: certificate and private key, in any order.
@@ -72,7 +72,7 @@ final readonly class PemCertificateReader implements CertificateReader
     /**
      * Reads a certificate and a private key that arrived as separate files.
      *
-     * The two are checked separately so the message names the file at fault —
+     * The two are checked separately so the message names the file at fault:
      * passing the same path twice is a real mistake, and it reads as "no
      * private key" rather than as something about the certificate.
      *
@@ -105,7 +105,7 @@ final readonly class PemCertificateReader implements CertificateReader
         // on DER without saying why, and a .pfx handed to the PEM entry point
         // would otherwise be reported as malformed rather than as misrouted.
         throw new InvalidPemContentException(str_starts_with($contents, self::DER_PREFIX)
-            ? "Expected PEM in {$label}, found binary DER or PKCS#12 bytes — read those through certificate() instead."
+            ? "Expected PEM in {$label}, found binary DER or PKCS#12 bytes. Read those through certificate() instead."
             : "No PEM certificate block found in {$label}.");
     }
 

--- a/src/Certificates/ReaderFactory.php
+++ b/src/Certificates/ReaderFactory.php
@@ -12,14 +12,14 @@ use LSNepomuceno\LaravelA1PdfSign\Support\ProcessRunner;
  * Picks the certificate reader.
  *
  * Native is the default. The CLI is only reached when legacy mode is on,
- * because that is the single capability ext-openssl cannot provide — reading
+ * because that is the single capability ext-openssl cannot provide: reading
  * RC2/40-bit bundles under OpenSSL 3.x. See docs/decisions/0001-openssl-native-with-cli-fallback.md.
  */
 final readonly class ReaderFactory
 {
     /**
      * The temp path comes from the A1PdfSign contract, but resolving it here
-     * would close a cycle — the manager depends on this factory. The container
+     * would close a cycle: the manager depends on this factory. The container
      * is held instead and the contract resolved only when the CLI reader is
      * actually built, which is the rare path.
      */

--- a/src/Commands/ValidatePdfSignatureCommand.php
+++ b/src/Commands/ValidatePdfSignatureCommand.php
@@ -29,7 +29,7 @@ class ValidatePdfSignatureCommand extends Command
                 $status = $signature->verified ? 'verified' : 'NOT verified';
                 $scope = $signature->coversWholeDocument ? 'covers the whole file' : 'covers its own revision';
 
-                $this->line(sprintf('  %d. %s — %s, %s', $index + 1, $signer, $status, $scope), 'info');
+                $this->line(sprintf('  %d. %s: %s, %s', $index + 1, $signer, $status, $scope), 'info');
             }
 
             return $validated->isValid() ? self::SUCCESS : self::INVALID;

--- a/src/Contracts/CertificateReader.php
+++ b/src/Contracts/CertificateReader.php
@@ -8,7 +8,7 @@ use SensitiveParameter;
 /**
  * Turns encoded certificate bytes into a parsed certificate.
  *
- * Implementations differ only in the encoding they ingest — PKCS#12, whether
+ * Implementations differ only in the encoding they ingest: PKCS#12, whether
  * read natively or through the CLI, and PEM, which needs no conversion at all.
  * All of them converge on the same PEM bundle and the same
  * {@see \LSNepomuceno\LaravelA1PdfSign\Certificates\CertificateParser}.

--- a/src/Exceptions/InvalidPemContentException.php
+++ b/src/Exceptions/InvalidPemContentException.php
@@ -8,7 +8,7 @@ use Stringable;
 /**
  * The input is not the PEM it was supposed to be.
  *
- * This covers only what can be decided before parsing — a missing block, or
+ * This covers only what can be decided before parsing: a missing block, or
  * binary bytes handed to the PEM entry point. A certificate and key that are
  * both present but do not belong together is a different failure, and keeps
  * its own class: {@see InvalidX509PrivateKeyException}.

--- a/src/Seal/InterventionSealRenderer.php
+++ b/src/Seal/InterventionSealRenderer.php
@@ -15,8 +15,8 @@ use LSNepomuceno\LaravelA1PdfSign\Enums\ImageDriver;
 /**
  * Renders the seal with Intervention Image.
  *
- * Everything the v1 code hard-coded — driver, font file, size, colour and the
- * background image — now comes from configuration, and the result is returned
+ * Everything the v1 code hard-coded (driver, font file, size, colour and the
+ * background image) now comes from configuration, and the result is returned
  * as bytes rather than written to a temporary file.
  */
 final readonly class InterventionSealRenderer implements SealRenderer

--- a/src/Signing/Cades/HttpTransport.php
+++ b/src/Signing/Cades/HttpTransport.php
@@ -9,7 +9,7 @@ use LSNepomuceno\LaravelA1PdfSign\Exceptions\ProcessRunTimeException;
  * The HTTP the signature primitives deliberately do not do.
  *
  * tc-lib-pdf-sign keeps its codecs pure and takes transports as callables, so
- * the host owns networking — and therefore owns the SSRF surface. Every URL
+ * the host owns networking, and therefore owns the SSRF surface. Every URL
  * reached here comes from configuration or from an extension inside the
  * signer's own certificate, never from the document being signed.
  */

--- a/src/Signing/Incremental/ByteRangeCalculator.php
+++ b/src/Signing/Incremental/ByteRangeCalculator.php
@@ -63,7 +63,7 @@ final class ByteRangeCalculator
      * The spacing is not fixed: this package writes "/Contents <" while
      * tc-lib-pdf-sign writes "/Contents<". Matching a literal meant the
      * document timestamp revision found the *signature's* placeholder instead
-     * of its own and overwrote it — poppler reported the signer as the
+     * of its own and overwrote it: poppler reported the signer as the
      * timestamp authority and the digest as mismatched.
      *
      * @throws InvalidPdfFileException
@@ -84,7 +84,7 @@ final class ByteRangeCalculator
      * Reads back the /ByteRange of the revision just written.
      *
      * An already-signed document holds several; ours is always the last. Taking
-     * the first would overwrite a previous signature's /Contents — the bug that
+     * the first would overwrite a previous signature's /Contents, the bug that
      * PoC 0b surfaced, which is why this is a named method with its own test.
      *
      * @return array{0: int, 1: int, 2: int} Offset of '<', offset past '>', trailing length.

--- a/src/Signing/Incremental/DocTimeStampWriter.php
+++ b/src/Signing/Incremental/DocTimeStampWriter.php
@@ -15,13 +15,13 @@ use Throwable;
  * Appends the archive timestamp that makes a document PAdES B-LTA.
  *
  * B-LT proves the certificate was good when it was used. B-LTA proves the
- * whole file — signature and validation material together — existed at a point
+ * whole file, signature and validation material together, existed at a point
  * in time attested by an authority, which is what keeps it verifiable once the
  * signing algorithms themselves age out.
  *
  * Unlike a signature timestamp, which covers only the signature bytes, this one
  * covers the entire file through its own /ByteRange, and it is a bare RFC 3161
- * token rather than a CAdES structure — hence /SubFilter /ETSI.RFC3161.
+ * token rather than a CAdES structure, hence /SubFilter /ETSI.RFC3161.
  *
  * @internal
  */

--- a/src/Signing/Incremental/DssWriter.php
+++ b/src/Signing/Incremental/DssWriter.php
@@ -60,7 +60,7 @@ final readonly class DssWriter
      *
      * A self-signed certificate has neither an OCSP responder nor a CRL
      * distribution point, and an unreachable responder must not fail the
-     * signature — in both cases the document simply stays at B-T.
+     * signature: in both cases the document simply stays at B-T.
      *
      * @return array{certs: list<string>, ocsp: list<string>, crls: list<string>}|null
      */

--- a/src/Signing/Incremental/SealAppearance.php
+++ b/src/Signing/Incremental/SealAppearance.php
@@ -11,7 +11,7 @@ use LSNepomuceno\LaravelA1PdfSign\Data\SealPlacement;
  * A visible signature is a widget whose /AP points at a form XObject, which in
  * turn draws an image XObject (ISO 32000-1 §12.5.5 and §12.7.4.5). The JPEG is
  * embedded through /DCTDecode, so the bytes Intervention produced are stored
- * as they are — no decode and re-encode.
+ * as they are: no decode and re-encode.
  *
  * @internal
  */

--- a/src/Signing/IncrementalSigner.php
+++ b/src/Signing/IncrementalSigner.php
@@ -23,7 +23,7 @@ use LSNepomuceno\LaravelA1PdfSign\Signing\Incremental\RevisionWriter;
  * This is the default path, and it is what makes multiple signatures possible:
  * each one covers the file up to its own revision, so signing again does not
  * invalidate what came before. It also stops the silent damage the v1 flow
- * caused — rebuilding a document through FPDI discarded annotations, form
+ * caused: rebuilding a document through FPDI discarded annotations, form
  * fields and any signature already present. See docs/decisions/0006-incremental-revision.md.
  *
  * Proven by poc/incremental-signature: three signatures, all valid.

--- a/src/Signing/PendingSignature.php
+++ b/src/Signing/PendingSignature.php
@@ -98,7 +98,7 @@ final class PendingSignature
      * as .pem, .crt, .cer, .key and .txt, so the format is decided by content
      * (docs/decisions/0007-pem-second-entry-one-pipeline.md).
      *
-     * @param  string  $password  Empty when the private key is unencrypted — legal and
+     * @param  string  $password  Empty when the private key is unencrypted, legal and
      *                            common for PEM, impossible for PKCS#12.
      *
      * @throws FileNotFoundException
@@ -118,7 +118,7 @@ final class PendingSignature
     }
 
     /**
-     * The same, from bytes the caller already holds — an upload, a secret
+     * The same, from bytes the caller already holds: an upload, a secret
      * manager, a database column.
      *
      * @throws InvalidPemContentException

--- a/src/Support/ProcessRunner.php
+++ b/src/Support/ProcessRunner.php
@@ -14,7 +14,7 @@ use LSNepomuceno\LaravelA1PdfSign\Exceptions\ProcessRunTimeException;
  * docs/decisions/0001-openssl-native-with-cli-fallback.md.
  *
  * It runs through Laravel's process factory rather than Symfony's Process
- * directly: the behaviour is identical — the factory builds the same object —
+ * directly: the behaviour is identical (the factory builds the same object)
  * but a host application can fake it in its own tests, which is impossible
  * when the class is instantiated inline.
  */

--- a/src/Support/TemporaryFile.php
+++ b/src/Support/TemporaryFile.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Str;
  * A file that deletes itself.
  *
  * The v1 code deleted its temporary files with a call placed after the work
- * that might throw, so any failure leaked them — including PEM files holding
+ * that might throw, so any failure leaked them, including PEM files holding
  * a private key. Here deletion happens in a finally block, with the destructor
  * as a backstop. See docs/history/v2-modernization.md.
  */

--- a/src/Testing/DebugCertificate.php
+++ b/src/Testing/DebugCertificate.php
@@ -47,7 +47,7 @@ final class DebugCertificate
      * fixtures rather than one (docs/decisions/0007-pem-second-entry-one-pipeline.md).
      *
      * @return array{0: string, 1: string, 2: string} Certificate PEM, private key PEM, and the
-     *                                                key's password — empty when it is unencrypted.
+     *                                                key's password, empty when it is unencrypted.
      */
     public static function makePem(bool $encryptKey = true, int $daysValid = 600): array
     {

--- a/src/Validation/DerReader.php
+++ b/src/Validation/DerReader.php
@@ -7,7 +7,7 @@ namespace LSNepomuceno\LaravelA1PdfSign\Validation;
  *
  * A signature's /Contents is a fixed-width placeholder padded with zeros, so
  * the CMS has to be cut at its declared length. Trimming the padding with
- * rtrim() instead would cut legitimate 0x00 bytes off the end of the DER — a
+ * rtrim() instead would cut legitimate 0x00 bytes off the end of the DER, a
  * bug PoC 0b hit and this exists to keep fixed.
  *
  * ISO/IEC 8825-1 §8.1.3: a first length byte below 0x80 is the length itself;

--- a/src/Validation/PdfSignatureExtractor.php
+++ b/src/Validation/PdfSignatureExtractor.php
@@ -5,7 +5,7 @@ namespace LSNepomuceno\LaravelA1PdfSign\Validation;
 /**
  * Pulls every signature out of a document.
  *
- * The 1.x code read `$result[2][0]` — the first match only — so a document
+ * The 1.x code read `$result[2][0]`, the first match only, so a document
  * with more than one signature reported on the first and ignored the rest.
  * Now that the package emits multi-signature documents, that would mean it
  * could not describe its own output.
@@ -51,7 +51,7 @@ final class PdfSignatureExtractor
      * Whether the entry is an archive timestamp rather than a signature.
      *
      * A /DocTimeStamp carries an RFC 3161 token, whose SignedData signs the
-     * TSTInfo holding the document's hash — not the document itself. Verifying
+     * TSTInfo holding the document's hash, not the document itself. Verifying
      * it the way a signature is verified always fails, so it has to be told
      * apart before anything tries.
      */

--- a/src/Validation/Pkcs7Reader.php
+++ b/src/Validation/Pkcs7Reader.php
@@ -8,7 +8,7 @@ use LSNepomuceno\LaravelA1PdfSign\Data\Signer;
  * Reads the certificates embedded in a detached CMS.
  *
  * 1.x shelled out to `openssl pkcs7 -print_certs` and parsed the human-readable
- * output with three chained preg_replace calls — which broke outright when
+ * output with three chained preg_replace calls, which broke outright when
  * OpenSSL 3.5 changed its field separator (§1.9, §1.14). Here the DER is
  * scanned for certificate structures and each one is handed to
  * openssl_x509_parse(), so the result is structured data rather than text.
@@ -55,7 +55,7 @@ final class Pkcs7Reader
      *
      * Certificates sit inside the SignedData's certificate set as DER
      * SEQUENCEs. Rather than walking the whole CMS grammar, candidates are
-     * offered to openssl_x509_read() and kept when it accepts them — the
+     * offered to openssl_x509_read() and kept when it accepts them: the
      * parser itself decides what is a certificate.
      *
      * @return list<string>

--- a/src/Validation/SignatureVerifier.php
+++ b/src/Validation/SignatureVerifier.php
@@ -11,8 +11,8 @@ use Throwable;
  * Decides whether a detached CMS matches the bytes it covers.
  *
  * This is the one part of validation that shells out, and deliberately so.
- * PHP's openssl_pkcs7_verify() cannot take detached content — it only writes
- * the verified content out — and reconstructing an S/MIME envelope around
+ * PHP's openssl_pkcs7_verify() cannot take detached content (it only writes
+ * the verified content out) and reconstructing an S/MIME envelope around
  * binary PDF bytes fails on MIME canonicalisation. The alternative is walking
  * the CMS grammar by hand to check the message-digest attribute and verify the
  * signed attributes, which is exactly the kind of code whose bugs produce a

--- a/tests/CertificatesTest.php
+++ b/tests/CertificatesTest.php
@@ -117,7 +117,7 @@ it('rejects a bundle whose key does not match its certificate', function () {
 | PEM bundles
 |--------------------------------------------------------------------------
 |
-| The parser has always accepted PEM — every reader converges on it. What it
+| The parser has always accepted PEM: every reader converges on it. What it
 | could not do is validate a passphrase-protected private key, because the
 | bundle was handed to openssl_x509_check_private_key() as a bare string.
 | PKCS#12 never reached that path: openssl_pkcs12_read() returns a key that is
@@ -211,7 +211,7 @@ it('rejects text that is neither PEM nor binary', function () {
 })->throws(InvalidPemContentException::class, 'No PEM certificate block found in the bundle');
 
 it('still reports a key that does not match its certificate as such', function () {
-    // The format is fine here, so this is not a PEM problem — it keeps the
+    // The format is fine here, so this is not a PEM problem: it keeps the
     // exception that already says exactly this, rather than a second one.
     [$certificate] = DebugCertificate::makePem();
     [, $otherKey, $otherPassword] = DebugCertificate::makePem();

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -33,7 +33,7 @@ it('reports failure from the pdf:sign command when the inputs are invalid', func
 });
 
 it('signs with a PEM certificate through the pdf:sign command', function () {
-    // No flag says "this is PEM" — the command reads the encoding from the
+    // No flag says "this is PEM": the command reads the encoding from the
     // bytes, because PEM ships under half a dozen extensions.
     [, , $bundlePath, $pass] = pemCertificate();
 

--- a/tests/DssTest.php
+++ b/tests/DssTest.php
@@ -112,7 +112,7 @@ it('embeds a document security store at PAdES B-LT', function () {
         ->sign();
 
     // A self-signed certificate has no OCSP responder and no CRL distribution
-    // point, so only the chain itself is embedded — which is still worth
+    // point, so only the chain itself is embedded, which is still worth
     // carrying, since a verifier then needs to fetch nothing.
     expect($longTerm->contents)->toContain('/Type /DSS')
         ->toContain('/Certs')

--- a/tests/PadesTest.php
+++ b/tests/PadesTest.php
@@ -58,7 +58,7 @@ it('embeds the ESS signing-certificate-v2 attribute openssl cannot produce', fun
     $hex = rtrim($matches[1] ?? '', '0');
     $der = (string) hex2bin(strlen($hex) % 2 === 1 ? $hex . '0' : $hex);
 
-    // OID 1.2.840.113549.1.9.16.2.47 — id-aa-signingCertificateV2.
+    // OID 1.2.840.113549.1.9.16.2.47, id-aa-signingCertificateV2.
     $oid = hex2bin('2A864886F70D010910022F');
 
     expect($der)->toContain((string) $oid);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -41,7 +41,7 @@ function debugCertificate(): array
  *
  * @return array{0: string, 1: string, 2: string, 3: string} Certificate path, private key
  *                                                           path, combined bundle path, and
- *                                                           the key's password — empty when
+ *                                                           the key's password, empty when
  *                                                           it is unencrypted.
  */
 function pemCertificate(bool $encryptKey = true): array

--- a/tests/SigningTest.php
+++ b/tests/SigningTest.php
@@ -85,7 +85,7 @@ it('signs a pdf using a combined PEM bundle', function () {
 });
 
 it('signs a pdf using an unencrypted PEM key', function () {
-    // No password at all — the case PKCS#12 cannot express.
+    // No password at all, the case PKCS#12 cannot express.
     [, , $bundlePath, $pass] = pemCertificate(encryptKey: false);
 
     $pdfPath = A1PdfSign::tempPath(true, '.pdf');

--- a/tests/SpecTest.php
+++ b/tests/SpecTest.php
@@ -9,7 +9,7 @@
  * section of its own, and three roadmap rows shipped unmarked, all noticed by
  * hand months later.
  *
- * The gate landed before the split and earned its keep during it — it failed
+ * The gate landed before the split and earned its keep during it: it failed
  * four times on references that had rotted mid-move, twice on this file's own
  * assertions.
  *
@@ -18,7 +18,7 @@
  * "§3i" did not survive this one.
  *
  * The helpers stay local to this file. They are used nowhere else, and the
- * shared-helper rule in tests/Pest.php exists for the opposite problem — a
+ * shared-helper rule in tests/Pest.php exists for the opposite problem: a
  * helper needed by a second file, which is invisible to it under --parallel.
  */
 
@@ -45,7 +45,7 @@ function specDocReferences(string $contents, string $from): array
     }
 
     // Inside docs/, links are ordinary Markdown and resolve against the file
-    // that carries them — "../spec/invariants.md" names no docs/ segment at all,
+    // that carries them, since "../spec/invariants.md" names no docs/ segment at all,
     // and the decision index links its records as bare siblings.
     if (str_starts_with($from, packageRoot() . '/docs/')
         && preg_match_all('#\]\(([\w./-]+\.md)\)#', $contents, $links) > 0) {


### PR DESCRIPTION
First pass of the convention added in #214.

**49 occurrences across 31 files.** Every change is inside a comment, a docblock, or one of two user-facing strings. No behaviour changes, and the diff is 49 insertions against 49 deletions.

## Not a mechanical substitution

The right replacement depends on what the dash was doing:

| Dash was doing | Replacement | Example |
|---|---|---|
| introducing an explanation | colon | `never exposed it: openssl_pkcs12_read() hands back an already-decrypted key` |
| adding a detail | comma | `the key's password, empty when it is unencrypted` |
| starting a new thought | full stop | `and always failed. See docs/history/…` |
| fencing an aside that already had commas | parentheses | `The order (certificate, private key, then the CA chain) matches what …` |

That last case is why a `sed` would not have worked. `NativeCertificateReader` had `The order — certificate, private key, then the CA chain — matches`, where turning the pair into commas produces four commas in a row and loses the grouping.

## Two that are not prose

Both are text a user reads, so the rule applies, and neither is asserted by any test. I checked before touching them.

- `pdf:validate-signature` printed `1. Name — valid, covers the whole file`, now prints `1. Name: valid, covers the whole file`.
- `InvalidPemContentException` said `found binary DER or PKCS#12 bytes — read those through certificate() instead`, now ends the sentence: `… bytes. Read those through certificate() instead.`

## Remaining

`docs/` and the root files still hold **234**, left for the next pass so this diff stays reviewable and does not mix documentation prose with 45 docblocks.

`composer check` on PHP 8.5 through `.docker`: green, 135 tests.