### PR TITLE
docs: remove the em dashes from docs/

### DIFF
--- a/docs/decisions/0001-openssl-native-with-cli-fallback.md
+++ b/docs/decisions/0001-openssl-native-with-cli-fallback.md
@@ -1,4 +1,4 @@
-# 0001 — Read certificates through `ext-openssl`, keep the CLI as a fallback
+# 0001: Read certificates through `ext-openssl`, keep the CLI as a fallback
 
 **Status:** accepted, implemented.
 **Supersedes** the v1 behaviour of shelling out for every certificate read.
@@ -11,7 +11,7 @@ the machine, and wrote the decrypted private key to a file inside the consuming
 application's `vendor/`.
 
 `openssl_pkcs12_read()` does the PKCS#12 → PEM conversion natively: no password
-in `ps`, no key on disk, and no dependency on the binary being in `PATH` — along
+in `ps`, no key on disk, and no dependency on the binary being in `PATH`, along
 with the whole `$usePathEnv` complication.
 
 **The caveat:** under OpenSSL 3.x, `openssl_pkcs12_read()` **fails** on old PFX
@@ -38,13 +38,13 @@ that need it keep working, while the majority of cases stop touching disk and
   reader and `Validation\SignatureVerifier`.
 - `ReaderFactory` holds the container rather than the `A1PdfSign` contract.
   Resolving the contract there creates a cycle that recurses until the process
-  segfaults with no output — see [the invariants](../spec/invariants.md).
+  segfaults with no output. See [the invariants](../spec/invariants.md).
 
 ## Outcome
 
 `ProcessRunner` was rebuilt on `Illuminate\Process\Factory` rather than
-`Symfony\Component\Process`. This does **not** remove Symfony from the tree —
-`illuminate/process` requires `symfony/process` — so the honest framing is not
+`Symfony\Component\Process`. This does **not** remove Symfony from the tree, since
+`illuminate/process` requires `symfony/process`, so the honest framing is not
 "one less dependency" but two concrete gains: the direct require becomes an
 Illuminate one, matching every other dependency the package declares, and a host
 application can `Process::fake()` the call in its own suite, which is impossible

--- a/docs/decisions/0002-asn1-parsed-in-package.md
+++ b/docs/decisions/0002-asn1-parsed-in-package.md
@@ -1,13 +1,13 @@
-# 0002 — Parse the CMS in-package, by declared length
+# 0002: Parse the CMS in-package, by declared length
 
-**Status:** accepted, implemented — and the decision changed during
+**Status:** accepted, implemented, and the decision changed during
 implementation. Read the outcome.
 
 ## Context
 
 There is no clean native replacement for reading a detached PDF signature:
 `openssl_pkcs7_verify()` needs the signed message reassembled, which is fragile.
-v1 sidestepped the problem entirely — it extracted the PKCS#7 blob with a
+v1 sidestepped the problem entirely: it extracted the PKCS#7 blob with a
 `ByteRange` regex, ran three `preg_replace` calls over the `openssl` text
 output, and reported a document as validated when the parsed subject happened to
 contain a `CN` or `OU` field. A tampered document still has those.
@@ -17,14 +17,14 @@ Two options were weighed:
 1. **Keep the CLI**, encapsulated, but parse certificates with
    `openssl_x509_parse()` instead of regex. No new dependency, immediate
    robustness gain. Recommended for 2.0 at the time.
-2. **Add `phpseclib/phpseclib ^3`** and decode the CMS through ASN.1 — removes
+2. **Add `phpseclib/phpseclib ^3`** and decode the CMS through ASN.1, which removes
    the CLI entirely and opens the way to actually verifying the signature. New
    dependency, more work. Pencilled in for 2.1.
 
 ## Decision
 
-Neither, as written. The package reads ASN.1 itself — `Validation\DerReader` and
-`Validation\Pkcs7Reader` — and verifies cryptographically, without taking
+Neither, as written. The package reads ASN.1 itself, in `Validation\DerReader` and
+`Validation\Pkcs7Reader`, and verifies cryptographically, without taking
 `phpseclib` as a dependency.
 
 `Validation\SignatureVerifier` remains a deliberate shell-out: verifying the CMS
@@ -36,15 +36,15 @@ worth it.
 - `SignatureReport::isValid()` means the CMS actually verifies against the bytes
   each signature covers. It is not a metadata check.
 - **Every structure is read by its declared length.** Trimming trailing `0`
-  bytes cuts legitimate DER — see [the invariants](../spec/invariants.md).
+  bytes cuts legitimate DER. See [the invariants](../spec/invariants.md).
 - DocTimeStamps are classified separately (`isTimestamp`) and excluded from
   `isValid()`: they are timestamps over the file, not signatures by a signer.
 - All signatures in a document are reported, not only the first.
 
 ## Outcome
 
-The honest note the plan carried — "the current method does not verify the
+The honest note the plan carried, "the current method does not verify the
 signature cryptographically, and the v2 naming must reflect that limitation
-until option (ii) exists" — is obsolete. Verification landed in 2.0, ahead of
+until option (ii) exists", is obsolete. Verification landed in 2.0, ahead of
 the schedule the plan set, and without the dependency the plan expected to pay
 for it.

--- a/docs/decisions/0003-temporary-files-outside-the-package.md
+++ b/docs/decisions/0003-temporary-files-outside-the-package.md
@@ -1,4 +1,4 @@
-# 0003 — Temporary files live outside the package, with guaranteed cleanup
+# 0003: Temporary files live outside the package, with guaranteed cleanup
 
 **Status:** accepted, implemented.
 
@@ -6,7 +6,7 @@
 
 v1 wrote its temporary files to `src/Temp/`, inside the consuming application's
 `vendor/`. That required `vendor/` to be writable, behaved differently per
-environment, and — because `File::delete()` always ran on the happy path only —
+environment, and, because `File::delete()` always ran on the happy path only, it
 left files behind on every exception path. One of those files was a decrypted
 private key.
 

--- a/docs/decisions/0004-in-memory-seal.md
+++ b/docs/decisions/0004-in-memory-seal.md
@@ -1,7 +1,7 @@
-# 0004 — The seal is rendered in memory
+# 0004: The seal is rendered in memory
 
 **Status:** accepted, implemented. The plan marked this "to be confirmed during
-implementation — the imaging bridge may impose restrictions"; it was confirmed.
+implementation, the imaging bridge may impose restrictions"; it was confirmed.
 
 ## Context
 
@@ -19,8 +19,8 @@ The `SealRenderer` contract returns bytes.
 ## Consequences
 
 - No intermediate file between generating the seal and stamping it.
-- Everything v1 hard-coded — driver, font path, size, colour, background,
-  placement — comes from configuration, with `SealPlacement` carrying position
+- Everything v1 hard-coded (driver, font path, size, colour, background,
+  placement) comes from configuration, with `SealPlacement` carrying position
   and page.
 - Omitting `seal()` produces an invisible signature, which is still a valid one:
   the seal is an appearance, not part of the cryptography.

--- a/docs/decisions/0005-php-and-laravel-floor.md
+++ b/docs/decisions/0005-php-and-laravel-floor.md
@@ -1,6 +1,6 @@
-# 0005 — PHP 8.4 and Laravel 13 as the floor
+# 0005: PHP 8.4 and Laravel 13 as the floor
 
-**Status:** accepted, implemented. Revised once during the work — the first
+**Status:** accepted, implemented. Revised once during the work: the first
 answer was Laravel 12.
 
 ## Context
@@ -27,11 +27,11 @@ The floor is not an aesthetic choice; the tooling imposes it. Surveyed
 | 13 | 8.3 – 8.5 | Q3 2027 | 2028-03-17 | active |
 
 PHP 8.3, required by Laravel 13, sits inside the range supported by L10 through
-L13 — it excludes no version and is not the limiting factor.
+L13, so it excludes no version and is not the limiting factor.
 
 **What determines the floor is the ceiling.** Supporting PHP 8.5 means only
 versions that reach it qualify: L10 stops at 8.3, L11 at 8.4. Only L12 and L13
-cover 8.5 — and they are also the only two still under security support. Two
+cover 8.5, and they are also the only two still under security support. Two
 independent criteria converging on the same point gave: floor Laravel 12.
 
 ### The PHP floor
@@ -43,7 +43,7 @@ independent criteria converging on the same point gave: floor Laravel 12.
 | 8.5 | 2027-12-31 | 2029-12-31 |
 
 An 8.3 floor is defensible on lifecycle grounds, but it forces **two Pest majors
-in parallel** — Pest 4 on the 8.3 jobs, Pest 5 on 8.4 and 8.5. An 8.4 floor puts
+in parallel**: Pest 4 on the 8.3 jobs, Pest 5 on 8.4 and 8.5. An 8.4 floor puts
 Pest 5 and every plugin on every job.
 
 ## Decision
@@ -53,14 +53,14 @@ Pest 5 and every plugin on every job.
 Laravel 12 was the original answer and was dropped: the analysis above weighs
 the framework alone and misses the test stack. **Pest 5 requires
 `symfony/process ^8.1` while Laravel 12 requires `^7.2`**, so the two cannot be
-installed in the same tree — the Laravel 12 cell fails at `composer update`,
+installed in the same tree: the Laravel 12 cell fails at `composer update`,
 before a single test runs. Keeping it would mean either Pest 4 for that cell,
 which is the split stack this decision exists to avoid, or shipping support CI
 never exercises.
 
 ## Consequences
 
-- A two-cell matrix — PHP 8.4 and 8.5 against Laravel 13 — down from eleven.
+- A two-cell matrix (PHP 8.4 and 8.5 against Laravel 13), down from eleven.
 - The local development floor sits above what is typically installed on a
   developer machine, which is why `.docker/` reproduces any cell.
 - v1's constraint `">=8.1 <8.5"` actively blocked PHP 8.5; that is fixed.

--- a/docs/decisions/0006-incremental-revision.md
+++ b/docs/decisions/0006-incremental-revision.md
@@ -1,11 +1,11 @@
-# 0006 — Sign by appending a revision, written in-package
+# 0006: Sign by appending a revision, written in-package
 
 **Status:** accepted, implemented. The most consequential decision in the
 package.
 
 ## Context
 
-A second signature destroyed the first — [TCPDF#430](https://github.com/tecnickcom/TCPDF/issues/430),
+A second signature destroyed the first, reported as [TCPDF#430](https://github.com/tecnickcom/TCPDF/issues/430),
 open since 2021. v1 imported every page through FPDI and rebuilt the document,
 which discarded annotations, form fields and any signature already present.
 
@@ -16,10 +16,10 @@ the kind of mistake that looks like a fix.
 Tracing the only three usages of `signature['approval']` in tc-lib-pdf, the flag
 does exactly one thing: it suppresses the `/Reference << /Type /SigRef … /DocMDP >>`
 dictionary and the corresponding `/Perms` entries. It toggles between a
-**certification** and an **approval** signature — ISO 32000-1 semantics, nothing
+**certification** and an **approval** signature, ISO 32000-1 semantics, nothing
 more. Nowhere does it read the original file's bytes to append a revision:
 `$startxref = strlen($out)` is computed over the freshly built output.
-`Import\Importer` confirms the model — `importPage()` allocates a Form XObject
+`Import\Importer` confirms the model: `importPage()` allocates a Form XObject
 and clones resources, architecture identical to FPDI's. **That is rebuilding.**
 
 The decisive proof was in this package already: v1's `SignaturePdf` passed `'A'`
@@ -80,4 +80,4 @@ Verified with poppler's `pdfsig` on a six-signature document: all six report
 that document.
 
 `approval()`, `certify()` and `ltv()` were never built as separate builder
-methods — the PAdES level chosen by `profile()` determines all three.
+methods: the PAdES level chosen by `profile()` determines all three.

--- a/docs/decisions/0007-pem-second-entry-one-pipeline.md
+++ b/docs/decisions/0007-pem-second-entry-one-pipeline.md
@@ -1,4 +1,4 @@
-# 0007 — PEM as a second entry point onto one pipeline
+# 0007: PEM as a second entry point onto one pipeline
 
 **Status:** accepted, implemented in 2.1.0.
 Answers [discussion #147](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/discussions/147),
@@ -14,7 +14,7 @@ or `openssl pkcs12`. The contract's own docblock said "the raw bytes of a
 
 ### The pipeline is already PEM
 
-That closed door hid how little had to change. **PKCS#12 is not a peer of PEM —
+That closed door hid how little had to change. **PKCS#12 is not a peer of PEM,
 it is a container that gets converted into PEM** before anything else runs. PEM
 is the destination format, not a sibling:
 
@@ -25,8 +25,8 @@ is the destination format, not a sibling:
 | `CertificateVault::open()` | reparses the stored PEM directly |
 | `Cades\CadesBuilder` | extracts the chain with a PEM regex |
 
-A caller could already reach this by hand — `parse($pem, $pw)` into
-`usingCertificate()` — an undocumented back door, and a broken one.
+A caller could already reach this by hand, `parse($pem, $pw)` into
+`usingCertificate()`, an undocumented back door, and a broken one.
 
 ### The defect this uncovered
 
@@ -36,12 +36,12 @@ real `.pem` usually carries. Measured against ext-openssl:
 
 | Call | Result |
 |---|---|
-| `check_private_key($x509, $pem)` — encrypted key | **FAIL** |
-| `check_private_key($x509, [$pem, $password])` — encrypted key | OK |
+| `check_private_key($x509, $pem)`, encrypted key | **FAIL** |
+| `check_private_key($x509, [$pem, $password])`, encrypted key | OK |
 | `check_private_key($x509, [$pem, 'wrong'])` | FAIL, as it must |
-| `check_private_key($x509, [$pem, $password])` — unencrypted key | OK |
-| `x509_read()` with the key written before the certificate | OK — order is irrelevant |
-| `x509_read()` on DER bytes | FAIL — detectable, so reportable as a format error |
+| `check_private_key($x509, [$pem, $password])`, unencrypted key | OK |
+| `x509_read()` with the key written before the certificate | OK, order is irrelevant |
+| `x509_read()` on DER bytes | FAIL, detectable, so reportable as a format error |
 
 The array form is correct for encrypted and unencrypted keys alike, so the fix
 is uniform and needs no branch. PKCS#12 never exposed the bug because
@@ -53,7 +53,7 @@ is uniform and needs no branch. PKCS#12 never exposed the bug because
 second pipeline.
 
 `Certificates\PemCertificateReader` implements the existing `CertificateReader`
-as its degenerate case — the reader whose conversion step is empty. Everything
+as its degenerate case, the reader whose conversion step is empty. Everything
 downstream of the parsed certificate is untouched.
 
 A parallel contract, DTO and pipeline was rejected: it would fork `CadesBuilder`,
@@ -75,7 +75,7 @@ Divergence is confined to where it is real:
 
 - The contract's parameter became `$contents`, since PKCS#12 is no longer the
   only encoding it reads. Every call site in the package is positional.
-- `signFromPem()` joins the `A1PdfSign` contract — a breaking change for anyone
+- `signFromPem()` joins the `A1PdfSign` contract, a breaking change for anyone
   implementing it, mapped in `UPGRADE.md`.
 - `encryptCertificate()` detects the encoding rather than gaining a sibling: it
   takes "a certificate" generically, where signing keeps explicit entry points.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,6 +1,6 @@
 # Decisions
 
-One file per decision, numbered. The number is the identifier — it is what code
+One file per decision, numbered. The number is the identifier: it is what code
 cites, so it never changes and is never reused.
 
 Each records the context that forced a choice, the alternatives weighed, and an
@@ -19,4 +19,4 @@ document drifts away from the code it describes.
 | [0007](0007-pem-second-entry-one-pipeline.md) | PEM as a second entry point onto one pipeline |
 
 Rules that break the product when violated are not decisions and do not live
-here — they are in [the invariants](../spec/invariants.md).
+here. They are in [the invariants](../spec/invariants.md).

--- a/docs/history/decision-log.md
+++ b/docs/history/decision-log.md
@@ -4,7 +4,7 @@ Questions that were put, and how they were answered. Append-only: an entry is
 never edited once its answer is recorded, only superseded by a later one.
 
 Where a decision produced a design still in force, the reasoning lives in
-[docs/decisions/](../decisions/README.md) — this log records *that it was
+[docs/decisions/](../decisions/README.md). This log records *that it was
 decided*, and when. The two are not duplicates: a decision record explains a
 design, a log entry dates a choice.
 
@@ -13,15 +13,15 @@ design, a log entry dates a choice.
 
 | # | Question | Decision |
 |---|---|---|
-| 1 | Laravel floor | **Laravel 13** — revised in PR 12. Laravel 12 reaches PHP 8.5 and is still supported, but it pins `symfony/process ^7.2` while Pest 5 needs `^8.1`, so the cell cannot even be installed ([0005](../decisions/0005-php-and-laravel-floor.md)) |
-| 2 | Mutation: Infection or Pest? | **`pest-plugin-mutate`** — one tool fewer, one runner, one report ([the quality policy](../spec/quality-policy.md)) |
+| 1 | Laravel floor | **Laravel 13**, revised in PR 12. Laravel 12 reaches PHP 8.5 and is still supported, but it pins `symfony/process ^7.2` while Pest 5 needs `^8.1`, so the cell cannot even be installed ([0005](../decisions/0005-php-and-laravel-floor.md)) |
+| 2 | Mutation: Infection or Pest? | **`pest-plugin-mutate`**: one tool fewer, one runner, one report ([the quality policy](../spec/quality-policy.md)) |
 | 3 | Attributes and modern features | **Adopt**, under the criterion "removes code or removes a class of bug" ([the quality policy](../spec/quality-policy.md)). `#[\SensitiveParameter]` enters as a security fix |
-| 4 | PDF engine | **Migrate to `tc-lib-pdf`** — TCPDF 6 is officially deprecated; the migration unlocks LTV and TSA (the engine migration below). Legacy driver kept as optional |
-| 5 | Multi-signature | **Our own incremental writer**, clean-room from ISO 32000-1 — no dependency delivers this ([0006](../decisions/0006-incremental-revision.md)) |
-| 6 | Use `ddn/sapp`? | **No, under no circumstances** — not `require`, not `require-dev`, not `suggest`. LGPL is incompatible with porting code into an MIT package, and it is a legacy project. **Conceptual** reference only; clean-room implementation over tc-lib-pdf's building blocks, with an arch test enforcing the rule ([0006](../decisions/0006-incremental-revision.md)) |
+| 4 | PDF engine | **Migrate to `tc-lib-pdf`**: TCPDF 6 is officially deprecated; the migration unlocks LTV and TSA (the engine migration below). Legacy driver kept as optional |
+| 5 | Multi-signature | **Our own incremental writer**, clean-room from ISO 32000-1, since no dependency delivers this ([0006](../decisions/0006-incremental-revision.md)) |
+| 6 | Use `ddn/sapp`? | **No, under no circumstances**: not `require`, not `require-dev`, not `suggest`. LGPL is incompatible with porting code into an MIT package, and it is a legacy project. **Conceptual** reference only; clean-room implementation over tc-lib-pdf's building blocks, with an arch test enforcing the rule ([0006](../decisions/0006-incremental-revision.md)) |
 | 7 | PHP floor: 8.4 or 8.3? | ✅ **8.4**, applied in PR 1. Keeps the toolchain on one Pest major and unlocks property hooks, `private(set)` and `#[\Deprecated]` |
-| 8 | Multi-signature in v2.0 or v2.1? | ✅ **v2.0.** PR 0b closed with 3/3 valid signatures ([0006](../decisions/0006-incremental-revision.md)) — the risk that would justify deferring did not materialize |
-| 15 | PEM: parallel pipeline, or a second entry onto the existing one? | ✅ **Second entry, one pipeline.** A separate contract and DTO would fork `CadesBuilder`, `CertificateVault`, `SealRenderer` and the public `Data\*` shape to gain nothing: PKCS#12 is *converted into* PEM before anything downstream runs, so the two are not peers. Divergence is confined to the entry point, where it is real — PEM may be two files, and its key is often unencrypted ([0007](../decisions/0007-pem-second-entry-one-pipeline.md)) |
+| 8 | Multi-signature in v2.0 or v2.1? | ✅ **v2.0.** PR 0b closed with 3/3 valid signatures ([0006](../decisions/0006-incremental-revision.md)), so the risk that would justify deferring did not materialize |
+| 15 | PEM: parallel pipeline, or a second entry onto the existing one? | ✅ **Second entry, one pipeline.** A separate contract and DTO would fork `CadesBuilder`, `CertificateVault`, `SealRenderer` and the public `Data\*` shape to gain nothing: PKCS#12 is *converted into* PEM before anything downstream runs, so the two are not peers. Divergence is confined to the entry point, where it is real, since PEM may be two files, and its key is often unencrypted ([0007](../decisions/0007-pem-second-entry-one-pipeline.md)) |
 
 ## Left open by the plan, and how they actually landed
 
@@ -31,14 +31,14 @@ what this reorganisation exists to close.
 
 | # | Question | Outcome |
 |---|---|---|
-| 9 | `IncrementalSigner` as the default, or only for the second signature? | **Default.** Preserving the original bytes from the first signature onward is what removes the silent destruction of annotations and form fields — making it conditional would have kept the defect for anyone signing once. |
+| 9 | `IncrementalSigner` as the default, or only for the second signature? | **Default.** Preserving the original bytes from the first signature onward is what removes the silent destruction of annotations and form fields, so making it conditional would have kept the defect for anyone signing once. |
 | 10 | Keep the legacy driver? | **Reframed and kept.** Not a driver: `SignatureProfile::Legacy` reproduces the 1.x `/SubFilter` through the same pipeline, so byte-for-byte-comparable output survives without carrying deprecated dependencies. |
-| 11 | phpseclib now or later? | **Never.** `Validation\DerReader` and `Pkcs7Reader` read ASN.1 in-package, and cryptographic verification shipped in 2.0 rather than 2.1 — see [0002](../decisions/0002-asn1-parsed-in-package.md). |
+| 11 | phpseclib now or later? | **Never.** `Validation\DerReader` and `Pkcs7Reader` read ASN.1 in-package, and cryptographic verification shipped in 2.0 rather than 2.1. See [0002](../decisions/0002-asn1-parsed-in-package.md). |
 | 12 | Full BC layer or a clean v2? | ✅ **Clean break.** A 3.0 is far enough out that a shim kept "until then" is kept indefinitely, and each one constrains the design it wraps. The PHP 8.4 / Laravel 13 floor already forces a deliberate upgrade, so the marginal cost of renaming call sites is small. [UPGRADE.md](../../UPGRADE.md) carries the mapping. |
-| 13 | PHPStan `level: max` from the start, or a baseline? | **Both, then neither.** Measured at the time: 95 errors at level 5, 159 at level 8, 216 at max — so max cost only 57 extra baseline entries over level 8 while gating all new code at the strictest setting. The baseline was then **deleted rather than shrunk**; the gate is "no errors", not "no new errors". |
+| 13 | PHPStan `level: max` from the start, or a baseline? | **Both, then neither.** Measured at the time: 95 errors at level 5, 159 at level 8, 216 at max, so max cost only 57 extra baseline entries over level 8 while gating all new code at the strictest setting. The baseline was then **deleted rather than shrunk**; the gate is "no errors", not "no new errors". |
 | 14 | Line-coverage gate? | **No.** Type coverage at 100% and mutation testing are more honest gates; line coverage stays informational. |
 
 > The original plan proposed a PHP 8.2 / Laravel 10 floor. It was invalidated
-> twice — first by the real tooling requirements, then by the realisation that
+> twice: first by the real tooling requirements, then by the realisation that
 > the PHP *ceiling* of older Laravel versions, not the floor, is the limiting
 > factor. See [0005](../decisions/0005-php-and-laravel-floor.md).

--- a/docs/history/v2-modernization.md
+++ b/docs/history/v2-modernization.md
@@ -1,7 +1,7 @@
 # The v2 modernisation, as planned
 
 A record, not a specification. Nothing here is authoritative about how the
-package behaves today — for that, read [the public API](../spec/public-api.md),
+package behaves today. For that, read [the public API](../spec/public-api.md),
 [the invariants](../spec/invariants.md) and [the quality policy](../spec/quality-policy.md).
 
 It is kept because it answers questions the current code cannot: why v1 was
@@ -16,7 +16,7 @@ The full original text of the plan is preserved at tag `2.0.0`, as
 ## The planned architecture, and what was built instead
 
 The plan's §2 sketched a target layout before any of it existed. Four parts of
-that sketch were never built, and the sketch was never reconciled — which is the
+that sketch were never built, and the sketch was never reconciled, which is the
 drift this reorganisation exists to stop.
 
 | Planned | Built | Why it diverged |
@@ -45,18 +45,18 @@ not been adopted *yet*. That removal was reverted, and what left instead was
 `tecnickcom/tcpdf` and, with it, `setasign/fpdi`.
 
 Then the destination moved as well. PR 7c swapped `tc-lib-pdf` for
-`tc-lib-pdf-sign` — thirteen transitive dependencies down to one — because the
+`tc-lib-pdf-sign`, thirteen transitive dependencies down to one, because the
 package had stopped needing a PDF *engine* at all. Once signing became
 [appending a revision](../decisions/0006-incremental-revision.md), nothing
 renders a document: the bytes already exist and only get extended.
 
 The proof-of-concept that preceded all of this answered the one question that
-could have invalidated the plan — whether tc-lib-pdf delivered LTV and
+could have invalidated the plan: whether tc-lib-pdf delivered LTV and
 timestamping in practice rather than in a docblock. It did: 15/15 checks, with a
 live TSA round-trip. A second spike proved the incremental writer on its own,
 3/3 signatures valid. Both live in `poc/`.
 
-## Fonts — a blocker that evaporated
+## Fonts, a blocker that evaporated
 
 tc-lib-pdf could not emit any PDF without a generated font definition, not even
 a signature-only document containing no text:
@@ -92,7 +92,7 @@ it shipped; these did not.
 - **A `bc-check` CI job and a `test:arch` script.** Neither exists; arch tests
   run as part of the ordinary suite.
 - **The arch rules as first drafted.** `legacy stays contained` expected
-  `LSNepomuceno\LaravelA1PdfSign\Sign` to be deprecated — that namespace was
+  `LSNepomuceno\LaravelA1PdfSign\Sign` to be deprecated, but that namespace was
   deleted outright rather than deprecated, so the rule became
   `no deprecated namespace lingers`. `no shell-out outside the CLI driver`
   pinned the exception to `OpenSslCliCertificateReader`; PR 12 rebuilt
@@ -101,8 +101,8 @@ it shipped; these did not.
 
 Several PHP-8.4 features were listed as targets and deliberately not taken:
 asymmetric visibility on the value objects, property hooks on `Certificate`, and
-`#[\NoDiscard]` on the fluent methods. The criterion the plan set for itself —
-a feature earns adoption when it removes code or removes a class of bug — ruled
+`#[\NoDiscard]` on the fluent methods. The criterion the plan set for itself,
+that a feature earns adoption when it removes code or removes a class of bug, ruled
 them out on its own terms.
 
 ## The PHPUnit → Pest migration, and a codemod that failed
@@ -120,18 +120,18 @@ codemod is worth it at scale, not at this size.
 
 ## Where v1 stood
 
-Real problems imposed by the current architecture — not matters of taste.
+Real problems imposed by the current architecture, not matters of taste.
 
 ### Security / robustness
 
 1. `ManageCert::fromPfx()` writes the **PEM containing the private key in plain text** into
-   `src/Temp/` — that is, inside the consuming application's `vendor/` — and the certificate
+   `src/Temp/`, that is, inside the consuming application's `vendor/`, and the certificate
    password travels on the command line (`-password pass:...`), visible through `ps` to any
    user on the machine.
 2. Temp files are not removed on exception paths. `File::delete()` always comes after code
    that can throw; the test `tearDown()` only masks the leak.
 3. `a1TempDir()` requires the package directory to be writable, with a silent fallback to
-   `sys_get_temp_dir()` — non-deterministic behaviour across environments.
+   `sys_get_temp_dir()`: non-deterministic behaviour across environments.
 
 ### Coupling / testability
 
@@ -140,28 +140,28 @@ Real problems imposed by the current architecture — not matters of taste.
 5. Zero contracts, zero container bindings, zero facade. The `ServiceProvider` only registers
    two commands. Nothing is swappable by the consumer.
 6. `ManageCert` carries three responsibilities: PKCS#12 conversion, x509 parsing/validation
-   and blob encryption. `makeDebugCertificate()` — test code — lives in a production class.
+   and blob encryption. `makeDebugCertificate()`, which is test code, lives in a production class.
 
 ### Design
 
 7. String constants (`MODE_RESOURCE`, `FONT_SIZE_LARGE`, `IMAGE_DRIVER_GD`) where PHP 8.1+
    offers enums.
 8. `SignaturePdf` mixes *producing* and *delivering*: `signature()` calls `File::put()` and
-   immediately `File::get()` back in `MODE_RESOURCE` — a pointless disk round-trip, since
+   immediately `File::get()` back in `MODE_RESOURCE`, a pointless disk round-trip, since
    `TCPDF::output(..., 'S')` already returns the complete string.
 9. `ValidatePdfSignature` extracts the PKCS#7 blob with a `ByteRange` regex and then does
    *text parsing* of `openssl pkcs7 -print_certs` output through three chained
    `preg_replace` calls. Fragile and coupled to the binary's output format.
-10. No publishable config — nothing is configurable: temp disk, image driver, default seal,
+10. No publishable config: nothing is configurable: temp disk, image driver, default seal,
     legacy flag.
 
 ### Hygiene
 
 11. `tecnickcom/tc-lib-pdf: ^8` sits in `composer.json` and is **used nowhere** in `src/` or
-    `tests/`. ⚠️ **Do not remove** — see the engine migration below: this "dead" dependency is precisely the
+    `tests/`. ⚠️ **Do not remove**. See the engine migration below: this "dead" dependency is precisely the
     official successor to TCPDF, and becomes the v2 engine.
 12. **The PDF engine is officially deprecated.** `tecnickcom/tcpdf` 6 was discontinued by its
-    author on 2026-05-30. See the engine migration below — the highest-impact change in this plan.
+    author on 2026-05-30. See the engine migration below, the highest-impact change in this plan.
 13. No Pint, no PHPStan. `CONTRIBUTING.md` still asks for PSR-2 (deprecated since 2019).
 
 ### Defects found while executing the plan
@@ -181,7 +181,7 @@ Real problems imposed by the current architecture — not matters of taste.
 
     The fix belongs to **PR 6**: `ManageCert` needs a path that ingests already-decrypted PEM
     content instead of shelling out to `pkcs12`, which also removes a temp file and a process
-    spawn. It carries a compatibility question that needs an explicit decision — the
+    spawn. It carries a compatibility question that needs an explicit decision: the
     `$isBase64` flag suggests some callers may be storing the raw PFX binary rather than the
     PEM, and those callers are served correctly by the current code path.
 
@@ -196,37 +196,37 @@ Independent PRs on the `v2.x-dev` branch.
 
 | # | PR | Scope | Risk |
 |---|---|---|---|
-| 0 | ✅ **tc-lib-pdf PoC** | **done** — 15/15 checks, live TSA round-trip. See `poc/tc-lib-pdf-ltv-tsa/` and the engine migration below | — |
-| 0b | ✅ **Incremental update PoC** | **done** — 3/3 signatures valid. See `poc/incremental-signature/` and [0006](../decisions/0006-incremental-revision.md) | — |
-| 1 | ✅ PHP/Laravel floor | **done** — `">=8.4 <8.6"` / L12+, 4-job matrix, tc-lib-pdf `^8.67`, `.gitattributes`, PHP 8.4 nullable fixes. Suite green on 8.4 and 8.5 (21 passed) | — |
-| 2 | ✅ Formatting + static analysis | **done** — Pint (PER-CS), PHPStan `level: max` + Larastan + strict/deprecation rules, **216-error baseline**, `quality` job, `composer check`, `CONTRIBUTING.md` | — |
-| 3 | ✅ PHPUnit → Pest | **done** — Pest 5, `tests/Pest.php`, named datasets, **arch tests**, type coverage 94.3% gated in CI. `drift` tried and discarded (the codemod that failed, below) | — |
-| 4 | ✅ Data + Enums | **done** — `Data/` readonly VOs, `Enums/` carrying behaviour, `Entities\*` as deprecated subclasses, `#[\SensitiveParameter]` on passwords, type coverage 95.7%. `SignatureInfo`, `SealPlacement` and `SignedPdf` deferred to PR 7, where they gain consumers | — |
-| 5 | ✅ Package infrastructure | **done** — publishable config, `Contracts\A1PdfSign` bound as a singleton, facade, helpers delegating to the container, 4 more arch rules, **type coverage 100%**. Found defect finding 14 above. The finer-grained contracts land with their implementations in PRs 6-9 | — |
-| 5b | ✅ Remove deprecated API, part 1 | **done** — `Entities\*` and the legacy constants dropped, `Data\*` final, idiomatic enum backing values, arch rule guarding the removal, `UPGRADE.md` ([UPGRADE.md](../../UPGRADE.md)) | — |
-| 6 | ✅ Certificates | **done** — `NativeCertificateReader` default, CLI fallback for legacy only, `CertificateVault` (fixes finding 14 above), `TemporaryFile`, `DebugCertificate` in `Testing/`, global helpers removed. 63 tests, no skips | — |
-| 7 | ✅ Signing | **done** — `IncrementalSigner` bound to `PdfSigner`, `PendingSignature` + `SignedPdf`, FPDI and TCPDF dropped, disk round-trip gone. **No `TcLibPdfSigner`/`TcpdfSigner` pair**: 7c swapped tc-lib-pdf for tc-lib-pdf-sign, so the package no longer renders PDFs and the core fonts of the fonts blocker below became moot — `K_PATH_FONTS` is deliberately left undefined | — |
-| 7b | ✅ Multi-signature | **done** — `Incremental/*` from PoC 0b, the fallback path: with tc-lib-pdf gone there was no `appendIncrementalRevision()` left to inherit. Closes TCPDF#430; `samples/` carries a six-signature document. `approval()` / `certify()` / `ltv()` were **not** built — the level is chosen by `profile()`, and `timestamp()` survives as its shorthand | — |
-| 7c | ✅ PAdES profiles | **done** — CAdES builder replaces openssl_pkcs7_sign, B-B/B-T live, tc-lib-pdf swapped for tc-lib-pdf-sign (13 deps → 1) | — |
-| 7d | ✅ DSS | **done** — B-LT, store in its own revision | — |
-| 7e | ✅ DocTimeStamp | **done** — B-LTA, archive timestamp over the whole file | — |
-| 8 | ✅ Seal | **done** — `InterventionSealRenderer` on Intervention Image v3 rather than the tc-lib-pdf API, which left with 7c. In-memory seal, driver/font/colour/background from config, `SealPlacement` + `Incremental\SealAppearance` stamping the widget | — |
-| 9 | ✅ Validation | **done** — signatures verified cryptographically, all of them reported, text parsing gone | — |
-| 10 | ✅ Mutation | **done** — 71.7% covered-MSI, gate at 70; found the ASN.1 boundary gaps | — |
-| 11 | ✅ Cleanup + tooling | **done** — `ManageCert` retired, dependency-analyser and normalize wired in, README. Roave BC check deferred: it compares against a released tag, so it only becomes meaningful from 2.0.0 | — |
-| 12 | ✅ Hardening | **done** — Laravel floor raised to 13, once Pest 5 and Laravel 12 proved uninstallable together ([0005](../decisions/0005-php-and-laravel-floor.md)); `ProcessRunner` rebuilt on `Illuminate\Process\Factory`, with the shell-out arch rule widened to match ([0001](../decisions/0001-openssl-native-with-cli-fallback.md)); mutation widened to `src/Signing/` and the `--covered-min` → `--min` flag corrected ([the quality policy](../spec/quality-policy.md)); Husky pre-commit hook adopted for Pint ([the quality policy](../spec/quality-policy.md)) | — |
-| 13 | ✅ PEM certificates | **done** — `certificatePem()` / `certificateFromPem()` / `signFromPem()` onto the existing pipeline, `PemCertificateReader`, and the `check_private_key` fix they depended on. `pdf:sign` routes by content and takes `--key`; the vault detects the encoding; `.gitignore` covers `*.pem` / `*.key` and `samples/certificate.pem` is the PFX's own identity re-encoded. Verified in poppler ([0007](../decisions/0007-pem-second-entry-one-pipeline.md)) | — |
+| 0 | ✅ **tc-lib-pdf PoC** | **done**: 15/15 checks, live TSA round-trip. See `poc/tc-lib-pdf-ltv-tsa/` and the engine migration below | n/a |
+| 0b | ✅ **Incremental update PoC** | **done**: 3/3 signatures valid. See `poc/incremental-signature/` and [0006](../decisions/0006-incremental-revision.md) | n/a |
+| 1 | ✅ PHP/Laravel floor | **done**: `">=8.4 <8.6"` / L12+, 4-job matrix, tc-lib-pdf `^8.67`, `.gitattributes`, PHP 8.4 nullable fixes. Suite green on 8.4 and 8.5 (21 passed) | n/a |
+| 2 | ✅ Formatting + static analysis | **done**: Pint (PER-CS), PHPStan `level: max` + Larastan + strict/deprecation rules, **216-error baseline**, `quality` job, `composer check`, `CONTRIBUTING.md` | n/a |
+| 3 | ✅ PHPUnit → Pest | **done**: Pest 5, `tests/Pest.php`, named datasets, **arch tests**, type coverage 94.3% gated in CI. `drift` tried and discarded (the codemod that failed, below) | n/a |
+| 4 | ✅ Data + Enums | **done**: `Data/` readonly VOs, `Enums/` carrying behaviour, `Entities\*` as deprecated subclasses, `#[\SensitiveParameter]` on passwords, type coverage 95.7%. `SignatureInfo`, `SealPlacement` and `SignedPdf` deferred to PR 7, where they gain consumers | n/a |
+| 5 | ✅ Package infrastructure | **done**: publishable config, `Contracts\A1PdfSign` bound as a singleton, facade, helpers delegating to the container, 4 more arch rules, **type coverage 100%**. Found defect finding 14 above. The finer-grained contracts land with their implementations in PRs 6-9 | n/a |
+| 5b | ✅ Remove deprecated API, part 1 | **done**: `Entities\*` and the legacy constants dropped, `Data\*` final, idiomatic enum backing values, arch rule guarding the removal, `UPGRADE.md` ([UPGRADE.md](../../UPGRADE.md)) | n/a |
+| 6 | ✅ Certificates | **done**: `NativeCertificateReader` default, CLI fallback for legacy only, `CertificateVault` (fixes finding 14 above), `TemporaryFile`, `DebugCertificate` in `Testing/`, global helpers removed. 63 tests, no skips | n/a |
+| 7 | ✅ Signing | **done**: `IncrementalSigner` bound to `PdfSigner`, `PendingSignature` + `SignedPdf`, FPDI and TCPDF dropped, disk round-trip gone. **No `TcLibPdfSigner`/`TcpdfSigner` pair**: 7c swapped tc-lib-pdf for tc-lib-pdf-sign, so the package no longer renders PDFs and the core fonts of the fonts blocker below became moot, so `K_PATH_FONTS` is deliberately left undefined | n/a |
+| 7b | ✅ Multi-signature | **done**: `Incremental/*` from PoC 0b, the fallback path: with tc-lib-pdf gone there was no `appendIncrementalRevision()` left to inherit. Closes TCPDF#430; `samples/` carries a six-signature document. `approval()` / `certify()` / `ltv()` were **not** built: the level is chosen by `profile()`, and `timestamp()` survives as its shorthand | n/a |
+| 7c | ✅ PAdES profiles | **done**: CAdES builder replaces openssl_pkcs7_sign, B-B/B-T live, tc-lib-pdf swapped for tc-lib-pdf-sign (13 deps → 1) | n/a |
+| 7d | ✅ DSS | **done**: B-LT, store in its own revision | n/a |
+| 7e | ✅ DocTimeStamp | **done**: B-LTA, archive timestamp over the whole file | n/a |
+| 8 | ✅ Seal | **done**: `InterventionSealRenderer` on Intervention Image v3 rather than the tc-lib-pdf API, which left with 7c. In-memory seal, driver/font/colour/background from config, `SealPlacement` + `Incremental\SealAppearance` stamping the widget | n/a |
+| 9 | ✅ Validation | **done**: signatures verified cryptographically, all of them reported, text parsing gone | n/a |
+| 10 | ✅ Mutation | **done**: 71.7% covered-MSI, gate at 70; found the ASN.1 boundary gaps | n/a |
+| 11 | ✅ Cleanup + tooling | **done**: `ManageCert` retired, dependency-analyser and normalize wired in, README. Roave BC check deferred: it compares against a released tag, so it only becomes meaningful from 2.0.0 | n/a |
+| 12 | ✅ Hardening | **done**: Laravel floor raised to 13, once Pest 5 and Laravel 12 proved uninstallable together ([0005](../decisions/0005-php-and-laravel-floor.md)); `ProcessRunner` rebuilt on `Illuminate\Process\Factory`, with the shell-out arch rule widened to match ([0001](../decisions/0001-openssl-native-with-cli-fallback.md)); mutation widened to `src/Signing/` and the `--covered-min` → `--min` flag corrected ([the quality policy](../spec/quality-policy.md)); Husky pre-commit hook adopted for Pint ([the quality policy](../spec/quality-policy.md)) | n/a |
+| 13 | ✅ PEM certificates | **done**: `certificatePem()` / `certificateFromPem()` / `signFromPem()` onto the existing pipeline, `PemCertificateReader`, and the `check_private_key` fix they depended on. `pdf:sign` routes by content and takes `--key`; the vault detects the encoding; `.gitignore` covers `*.pem` / `*.key` and `samples/certificate.pem` is the PFX's own identity re-encoded. Verified in poppler ([0007](../decisions/0007-pem-second-entry-one-pipeline.md)) | n/a |
 
 **PR 0 comes before everything else** and is a throwaway proof of concept, not production
 code. It answers the one question that could invalidate the plan: does tc-lib-pdf deliver LTV
 and timestamping in practice, and not just in a docblock? Until that answer exists, PRs 7 and
 8 are speculation.
 
-PRs 1–4 can land immediately without touching behaviour — and **order matters**: the
+PRs 1–4 can land immediately without touching behaviour, and **order matters**: the
 toolchain (2–3) precedes the refactor so that arch tests, PHPStan and mutation act as a
 safety net for PRs 5–9 rather than as a post-hoc audit.
 
-PR 6 needs the most care. Before it, freeze the current suite as a baseline — including a
+PR 6 needs the most care. Before it, freeze the current suite as a baseline, including a
 case with a real legacy PFX, which the tests do not have today.
 
 PR 10 comes after the refactor on purpose: running mutation over the legacy code would yield
@@ -256,12 +256,12 @@ Two things the plan set out to do are not done, and neither is covered by a pass
    its own `/ByteRange` covers.
 
    **Still not done:** Adobe Reader and the ITI Validar. Both need a real ICP-Brasil
-   certificate to say anything meaningful about trust — poppler already reports
+   certificate to say anything meaningful about trust: poppler already reports
    *Certificate issuer isn't Trusted* for the self-signed test certificate, which is correct
    and expected. `pdfsig` cannot verify `ETSI.RFC3161` document timestamps either, so that
    part rests on the OpenSSL check above.
 2. **Roave BC check is not wired in.** It compares the public API against a released tag;
    with 2.0.0 unreleased and everything breaking against `^1`, it would only produce noise.
-   It becomes meaningful — and should be added — once 2.0.0 ships.
+   It becomes meaningful, and should be added, once 2.0.0 ships.
 
 ---

--- a/docs/spec/invariants.md
+++ b/docs/spec/invariants.md
@@ -1,6 +1,6 @@
 # Invariants
 
-Rules that break the product, or the project, when violated. Short on purpose —
+Rules that break the product, or the project, when violated. Short on purpose:
 this file is meant to be read whole before touching `src/Signing`, `src/Validation`
 or the dependency list.
 
@@ -13,7 +13,7 @@ it is not, that is noted.
 
 **`ddn/sapp` is LGPL-3.0-or-later; this package is MIT.**
 
-Porting or adapting SAPP code into `src/` is a licence violation — an adapted
+Porting or adapting SAPP code into `src/` is a licence violation, since an adapted
 excerpt is still a derivative work and would drag the whole package into LGPL.
 
 Studying the technique is legitimate: algorithms and file-format mechanics are
@@ -21,7 +21,7 @@ not protected by copyright, and incremental update is specified in ISO 32000-1
 §7.5.6 and §12.8, a public standard. The implementation is clean-room, written
 from that standard. In practice: keep ISO 32000-1 open, not `vendor/ddn/sapp`.
 
-**It is not taken as a dependency either** — not in `require`, not in
+**It is not taken as a dependency either**, not in `require`, not in
 `require-dev`, not as `suggest`. That would be legal, since LGPL permits library
 use without contaminating the consumer, but it is ruled out: it is a legacy
 project and we would inherit its maintenance.
@@ -31,7 +31,7 @@ project and we would inherit its maintenance.
 
 ---
 
-## 2. Signing appends a revision — it never rebuilds the document
+## 2. Signing appends a revision, never rebuilds the document
 
 `Signing\IncrementalSigner` writes a new revision onto the end of the file
 (ISO 32000-1 §7.5.6). The original bytes survive byte for byte.
@@ -55,7 +55,7 @@ on `samples/six-signatures.pdf`.
 multi-signature document belongs to an **earlier signature**. Writing there
 corrupts it.
 
-Every read of those structures uses `preg_match_all` + `end()` — `readLast()`,
+Every read of those structures uses `preg_match_all` + `end()`: `readLast()`,
 `lastContentsOffset()`.
 
 A bug of exactly this shape passed the entire suite and was caught only by
@@ -86,7 +86,7 @@ header declares. Trimming trailing `0` bytes cuts legitimate DER.
 ## 6. `K_PATH_FONTS` stays undefined
 
 tc-lib-pdf and TCPDF 6 read it in different formats, and defining it globally
-**kills TCPDF silently** — no error, no output.
+**kills TCPDF silently**, with no error and no output.
 
 The package appends revisions to bytes it already has and never emits a
 document, so no font definition is ever loaded and nothing needs the constant.
@@ -96,7 +96,7 @@ document, so no font definition is ever loaded and nothing needs the constant.
 ## 7. `Certificates\ReaderFactory` holds the container, not the `A1PdfSign` contract
 
 Resolving the contract inside the factory creates a cycle that recurses until
-the process **segfaults with no output** (exit 139) — no exception, no stack
+the process **segfaults with no output** (exit 139), with no exception, no stack
 trace, nothing to read.
 
 ---

--- a/docs/spec/public-api.md
+++ b/docs/spec/public-api.md
@@ -6,7 +6,7 @@ consumers: adding to it is a minor release, changing it is a major one.
 > Written from the code, not from the v2 plan. The plan's §2 described a
 > `TcLibPdfSigner` / `TcpdfSigner` pair, an `Enums\SealPage`, a `Console\`
 > namespace and `approval()` / `certify()` / `ltv()` builder methods. None of
-> them were built — see [the modernisation record](../history/v2-modernization.md).
+> them were built. See [the modernisation record](../history/v2-modernization.md).
 > This file supersedes that section.
 
 ## Namespace layout
@@ -53,7 +53,7 @@ $signed = A1PdfSign::newSignature()
     ->sign();
 ```
 
-Certificate input — one of:
+Certificate input, one of:
 
 | Method | Takes |
 |---|---|
@@ -63,7 +63,7 @@ Certificate input — one of:
 | `certificateFromPem($contents, $key, $password)` | PEM bytes already in hand |
 | `usingCertificate($certificate)` | an already-parsed `Data\Certificate` |
 
-Document input — `pdf($path)` or `pdfContents($bytes, $fileName)`.
+Document input: `pdf($path)` or `pdfContents($bytes, $fileName)`.
 
 Everything else is optional: `info()`, `seal()`, `sealFrom()`, `profile()`,
 `timestamp()`, `fieldName()`. `sign()` closes the chain and returns a
@@ -86,7 +86,7 @@ A1PdfSign::newSignature();          // Signing\PendingSignature
 A1PdfSign::tempPath($tempFile, $fileExt);
 ```
 
-Prefer injecting `Contracts\A1PdfSign` where you can — it is what makes the
+Prefer injecting `Contracts\A1PdfSign` where you can: it is what makes the
 package mockable in a consuming application's tests.
 
 ## Output
@@ -94,11 +94,11 @@ package mockable in a consuming application's tests.
 **`sign()` does not decide transport.** The same result answers all of these:
 
 ```php
-$signed->contents();          // string — the signed bytes
+$signed->contents();          // string, the signed bytes
 $signed->size();              // int
-$signed->save($path);         // string — the path written
-$signed->download('doc.pdf'); // BinaryFileResponse — forces a download
-$signed->toResponse();        // Response — renders inline
+$signed->save($path);         // string, the path written
+$signed->download('doc.pdf'); // BinaryFileResponse, forces a download
+$signed->toResponse();        // Response, renders inline
 (string) $signed;             // same as contents()
 ```
 
@@ -116,7 +116,7 @@ $report->latest();       // ?Data\SignatureDetails
 ```
 
 `isValid()` answers "does this signature match these bytes". It does not check
-the issuer against a trust store — that decision stays with the application.
+the issuer against a trust store: that decision stays with the application.
 
 ## Signature profiles
 
@@ -173,7 +173,7 @@ Both map a `Throwable` to a failure exit code, so they compose in a pipeline.
 
 ## Stability
 
-`Data\*` are `final readonly` and are public return types — **adding a property
+`Data\*` are `final readonly` and are public return types, so **adding a property
 changes the public shape**. The contracts in `Contracts\` may be implemented by
 consumers, so adding a method to one is a breaking change for them even though
 callers are unaffected.

--- a/docs/spec/quality-policy.md
+++ b/docs/spec/quality-policy.md
@@ -28,11 +28,11 @@ The gates a change has to pass, and why each one is set where it is.
 ## PHPStan runs at `level: max` with no baseline
 
 The baseline was deleted, not shrunk. **The gate is "no errors", not "no new
-errors"** — a baseline must only ever track debt that can actually be paid down,
+errors"**: a baseline must only ever track debt that can actually be paid down,
 and this one had none left.
 
 The single exception is scoped and documented in `phpstan.neon`: Pest's fluent
-API — `arch()`, `expect()->and()->not`, dataset chains — is runtime magic that
+API (`arch()`, `expect()->and()->not`, dataset chains) is runtime magic that
 PHPStan cannot type without a dedicated extension. Those are ignored by
 identifier under `tests/*`, because they are limits of the tooling rather than
 defects.
@@ -43,7 +43,7 @@ defects.
 
 ## Mutation testing
 
-Covers `src/Certificates`, `src/Signing` and `src/Validation` — the three
+Covers `src/Certificates`, `src/Signing` and `src/Validation`, the three
 namespaces where a test that only asserts "it did not throw" would keep passing
 with broken cryptography.
 
@@ -70,7 +70,7 @@ measurement, and never lower one to make a run pass.
 
 **Never split with `--shard`.** It divides the *test suite*, and every mutation
 needs the whole suite: a mutation killed by a test that landed in another shard
-is reported as uncovered. Measured on `src/Certificates` — the full run scores
+is reported as uncovered. Measured on `src/Certificates`, the full run scores
 64.71% with 8 uncovered, while shard 1/2 reports 61.76% with 26 uncovered and
 shard 2/2 reports 69.12%. Faster precisely because it is wrong. Split by mutated
 path instead.
@@ -82,14 +82,14 @@ consume the newer format.**
 
 14.2.4 changed the shape of `lineCoverage()`: the plugin expects each covered
 line to carry a list of test identifiers, and gets integers instead. It dies
-before scoring anything —
+before scoring anything:
 
 ```
 TypeError: preg_match(): Argument #2 ($subject) must be of type string, int given
   at vendor/pestphp/pest-plugin-mutate/src/MutationTest.php:54
 ```
 
-— and reproduces with and without `--parallel`, on both `pest-plugin-mutate`
+It reproduces with and without `--parallel`, on both `pest-plugin-mutate`
 5.0.0 and 5.0.1, so it is neither the plugin version nor the parallel runner.
 
 This is the only pinned dependency in the package, and it exists because the
@@ -106,24 +106,24 @@ or updates a tracking issue per namespace.
 
 **The schedule is when it may run, not what it measures.** A `changed` job
 compares the default branch against the commit of the last run that reached a
-verdict, and skips when nothing has landed since — so a given commit is scored
+verdict, and skips when nothing has landed since, so a given commit is scored
 once, not once per night.
 
 Re-scoring identical code answers a question already answered, and answers it
 *differently*: the score is not reproducible, so a quiet week would produce a
 week of contradictory numbers for the same tree, and any of them could trip a
-floor. Cancelled runs are excluded from the comparison — concurrency cancels
+floor. Cancelled runs are excluded from the comparison: concurrency cancels
 them mid-flight, so their commit was never actually scored.
 
 The cost is that this job stops doubling as a canary for the unpinned
 dependency resolution. It was playing that role by accident, and playing it
-well — the `php-code-coverage` break of 2026-08-08 arrived with no commit
+well: the `php-code-coverage` break of 2026-08-08 arrived with no commit
 behind it and was caught by a nightly on untouched code. During a quiet period
 that break would now surface only at the next merge.
 
 ## CI
 
-`.github/workflows/main_action.yml`, on pull requests to `main` only — every
+`.github/workflows/main_action.yml`, on pull requests to `main` only, since every
 change reaches `main` through a pull request, so building branch pushes as well
 duplicated each run.
 
@@ -142,7 +142,7 @@ fail offline. Exclude them with `--exclude-group=network`.
 ## Tests
 
 Orchestra Testbench, not a host application. **`openssl` on `PATH` is not
-required to run the suite** — `Testing\DebugCertificate` generates throwaway
+required to run the suite**: `Testing\DebugCertificate` generates throwaway
 PKCS#12 and PEM bundles through the ext-openssl functions.
 
 Helpers shared across test files must live in `tests/Pest.php`. A helper defined
@@ -150,11 +150,11 @@ inside one test file is invisible to the others under `--parallel`, which fails
 as `Call to undefined function`.
 
 Patches are expected to come with tests. `tests/ArchTest.php` enforces the
-structural rules — read it before adding a class.
+structural rules, so read it before adding a class.
 
 Independent verification is done with poppler's `pdfsig`; it has caught bugs the
 suite passed straight through. `samples/` holds one signed PDF per profile plus
-a six-signature document — regenerate them with `poc/sign-samples.php` and
+a six-signature document. Regenerate them with `poc/sign-samples.php` and
 re-check after any change to `src/Signing/`.
 
 ## Development environment
@@ -196,10 +196,10 @@ Node is **not** a dependency of the package: `package.json` is private and
 The criterion: a feature gets adopted when it **removes code or removes a class
 of bug**.
 
-- `#[\SensitiveParameter]` on every password argument — a security fix disguised
+- `#[\SensitiveParameter]` on every password argument, a security fix disguised
   as modernisation, one line per signature, keeping certificate passwords out of
   stack traces and logs.
-- `#[\Override]` on contract implementations — the compiler guarantees the
+- `#[\Override]` on contract implementations: the compiler guarantees the
   signature still matches.
 - Typed class constants, `final readonly` by default, enums carrying behaviour
   instead of class constants.


### PR DESCRIPTION
Second pass of the convention added in #214, after #215 cleared `src/` and `tests/`.

**159 occurrences across 13 files. 130 insertions against 130 deletions**, so nothing was lost or added beyond the punctuation.

## Three shapes, treated as shapes

Most replacements are per sentence, as in #215. Three patterns repeated often enough to handle as patterns:

**The decision record titles.** `# 0003 — Temporary files live outside…` now reads `# 0003: Temporary files live outside…`, for all seven. `docs/decisions/README.md` links them by filename, so nothing else moved, and `tests/SpecTest.php` confirms every link still resolves.

**The roadmap rows.** All twenty in the modernisation record read `**done** — …` and now read `**done**: …`. Their Risk column held a bare `—` meaning "none", which is a typographic placeholder rather than punctuation, so it now reads `n/a`.

**A sentence split by a code fence.** The quality policy opened with `It dies before scoring anything —`, then a fenced `TypeError`, then resumed `— and reproduces with and without --parallel`. A dash cannot span a fence and stay readable. It is now a colon before the block and a fresh sentence after it:

> It dies before scoring anything:
>
> ```
> TypeError: preg_match(): Argument #2 ($subject) must be of type string, int given
> ```
>
> It reproduces with and without `--parallel`, on both `pest-plugin-mutate` 5.0.0 and 5.0.1, so it is neither the plugin version nor the parallel runner.

## Verification

`composer check` on PHP 8.5 through `.docker`: green, 135 tests. That includes `SpecTest`, which fails if any documentation reference stops resolving, so the retitled decision records are confirmed still reachable from the index.

## Remaining

The root files hold **73**: `CLAUDE.md` 35, `UPGRADE.md` 18, `.github/` 11, `README.md` 5, `ARCHITECTURE.md` 4. That is the last pass. Four of the ones in `CLAUDE.md` are the counter-examples in the convention table itself and stay.