### PR TITLE
chore: remove the last em dashes

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -3,7 +3,7 @@ name: Mutation testing
 # Nightly rather than per pull request, for two measured reasons
 # (docs/spec/quality-policy.md):
 #
-#   Cost. Timeouts dominate the run — a mutation that breaks a loop condition
+#   Cost. Timeouts dominate the run: a mutation that breaks a loop condition
 #   burns the full timeout, which the plugin derives from the suite duration
 #   and cannot be configured down. Locally that is ~2600 process-seconds; on a
 #   four-core runner, over ten minutes for a job every other check beats by an
@@ -21,7 +21,7 @@ name: Mutation testing
 # The schedule is when it may run, not what it measures: the `changed` job below
 # compares the default branch against the last run that reached a verdict and
 # skips when nothing has moved. Re-scoring identical code answers a question
-# already answered — and answers it differently, since the score is not
+# already answered, and answers it differently, since the score is not
 # reproducible, so a quiet week would produce a week of contradictory numbers.
 on:
   schedule:
@@ -53,7 +53,7 @@ jobs:
       # Compared against the last run that reached a verdict, not against a
       # 24-hour window: a cancelled or delayed run would make a window lie, and
       # GitHub delays scheduled runs under load. Cancelled runs are excluded
-      # deliberately — concurrency cancels them mid-flight, so their commit was
+      # deliberately: concurrency cancels them mid-flight, so their commit was
       # never actually scored.
       - name: Compare against the commit last scored
         id: check
@@ -69,7 +69,7 @@ jobs:
           echo "last scored: ${scored:-none}"
           echo "current:     ${{ github.sha }}"
 
-          # A manual dispatch always runs — it is the escape hatch, used before
+          # A manual dispatch always runs, since it is the escape hatch, used before
           # a release and to re-check after a toolchain fix.
           if [ "${{ github.event_name }}" != 'schedule' ]; then
             echo 'run=true' >> "$GITHUB_OUTPUT"
@@ -94,13 +94,13 @@ jobs:
       fail-fast: false
       matrix:
         # One runner per namespace: wall-clock becomes the slowest namespace
-        # instead of the sum. src/Signing is by far the slowest — every test
+        # instead of the sum. src/Signing is by far the slowest, since every test
         # covering it signs a real PDF.
         #
         # Splitting by mutated path, not by --shard. --shard divides the test
         # suite, and mutation testing needs the whole suite available for every
         # mutation: a mutation killed by a test that landed in another shard is
-        # reported as uncovered. Measured on src/Certificates — the full run
+        # reported as uncovered. Measured on src/Certificates, the full run
         # scores 64.71% with 8 uncovered, while shard 1/2 reports 61.76% with
         # 26 uncovered and shard 2/2 reports 69.12%. Faster, and wrong.
         #
@@ -135,7 +135,7 @@ jobs:
       # Raise a floor as its score improves; never lower one to make a run
       # pass.
       #
-      # shell: bash for pipefail — the default shell would let tee's exit code
+      # shell: bash for pipefail: the default shell would let tee's exit code
       # mask a failing run.
       - name: Run mutation testing
         id: mutate
@@ -150,7 +150,7 @@ jobs:
 
       # The score lives nowhere but the log, so a red job cannot tell a
       # three-point timeout wobble from a real regression without someone
-      # opening it — and calibrating a floor means reading two runs by hand.
+      # opening it, and calibrating a floor means reading two runs by hand.
       # Both become a glance at the run summary.
       - name: Record the score
         id: score
@@ -195,7 +195,7 @@ jobs:
 
             const run = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`
 
-            // A run that produced no score did not score badly — it crashed, and
+            // A run that produced no score did not score badly: it crashed, and
             // the two need different titles. Reporting a crash as a regression
             // sends whoever opens it hunting for a test that never weakened;
             // that happened on 2026-08-08, when php-code-coverage 14.2.4 broke
@@ -214,7 +214,7 @@ jobs:
                   ``,
                   `**This is not a score regression.** No number was reported, so nothing can be`,
                   `said about coverage quality from this run. Read the log before touching any`,
-                  `test — the usual cause is the toolchain rather than this repository, since`,
+                  `test. The usual cause is the toolchain rather than this repository, since`,
                   `the job resolves its dependencies unpinned on every run.`,
                 ].join('\n')
               : [
@@ -227,7 +227,7 @@ jobs:
                   `three points between identical runs. One or two points is noise; a sustained`,
                   `drop, or one that survives a re-run, is not.`,
                   ``,
-                  `**Do not lower the floor to make this pass** — docs/spec/quality-policy.md.`,
+                  `**Do not lower the floor to make this pass**, see docs/spec/quality-policy.md.`,
                 ].join('\n')
 
             // One open issue per namespace, commented on rather than reopened

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ Temp
 *.pem
 *.key
 
-# Committed on purpose — see samples/README.md.
+# Committed on purpose. See samples/README.md.
 !/samples/*.pdf
 !/samples/*.pfx
 !/samples/*.pem

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,7 +7,7 @@ built, and cited a §12 that never had a section.
 
 `tests/SpecTest.php` fails when a reference into any of these stops resolving.
 
-## Living — must be true of the code today
+## Living: must be true of the code today
 
 | | |
 |---|---|
@@ -15,9 +15,9 @@ built, and cited a §12 that never had a section.
 | [docs/spec/public-api.md](docs/spec/public-api.md) | What the package exposes, and what changing it costs. |
 | [docs/spec/quality-policy.md](docs/spec/quality-policy.md) | The gates a change has to pass, and why each sits where it does. |
 
-## Decisions — why the design is what it is
+## Decisions: why the design is what it is
 
-[docs/decisions/](docs/decisions/README.md) — one numbered file per decision.
+[docs/decisions/](docs/decisions/README.md), one numbered file per decision.
 The number is the identifier, so it survives the next reorganisation; `§3i` did
 not survive this one.
 
@@ -25,7 +25,7 @@ Each carries an outcome section when what shipped differed from what was
 decided. A decision record whose outcome is never written back is how a document
 drifts away from the code it describes.
 
-## History — frozen, kept because it answers what the code cannot
+## History: frozen, kept because it answers what the code cannot
 
 | | |
 |---|---|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-A standalone Laravel package (not an application) that signs PDF files with A1/x509 certificates — PKCS#12 or PEM — and cryptographically verifies existing PDF signatures. Published on Packagist as `lsnepomuceno/laravel-a1-pdf-sign`.
+A standalone Laravel package (not an application) that signs PDF files with A1/x509 certificates, PKCS#12 or PEM, and cryptographically verifies existing PDF signatures. Published on Packagist as `lsnepomuceno/laravel-a1-pdf-sign`.
 
 The invariants are imported rather than summarised, so they are in context for every session instead of being a link someone has to decide to follow:
 
 @docs/spec/invariants.md
 
-The v1 surface — the global helper functions, `src/Sign/*`, `src/Entities/*` — is **gone**, not deprecated. `UPGRADE.md` maps every removed API to its replacement.
+The v1 surface, the global helper functions plus `src/Sign/*` and `src/Entities/*`, is **gone**, not deprecated. `UPGRADE.md` maps every removed API to its replacement.
 
 Documentation is split by lifecycle, and `tests/SpecTest.php` fails when a reference into it stops resolving:
 
@@ -19,11 +19,11 @@ Documentation is split by lifecycle, and `tests/SpecTest.php` fails when a refer
 | `docs/spec/invariants.md` | the rules that break the product or the project. **Read before touching `src/Signing`, `src/Validation` or the dependency list** |
 | `docs/spec/public-api.md` | what the package exposes, and what changing it costs |
 | `docs/spec/quality-policy.md` | the gates, and why each sits where it does |
-| `docs/decisions/` | why the design is what it is — one numbered file per decision |
+| `docs/decisions/` | why the design is what it is: one numbered file per decision |
 | `docs/history/v2-modernization.md` | why v1 was shaped as it was, and where the build diverged from the plan |
 | `docs/history/decision-log.md` | which questions were put, and when they were answered |
 
-`ARCHITECTURE.md` is the index. When you change behaviour that a decision record justifies, update that record's outcome section too — a record whose outcome is never written back is how the previous document drifted away from the code.
+`ARCHITECTURE.md` is the index. When you change behaviour that a decision record justifies, update that record's outcome section too: a record whose outcome is never written back is how the previous document drifted away from the code.
 
 ## Commands
 
@@ -43,7 +43,7 @@ vendor/bin/pest --exclude-group=network                  # skip live TSA tests
 vendor/bin/pest --parallel                               # 16 processes here; mutation needs it
 ```
 
-Tests run on Orchestra Testbench, not a host app. `openssl` on `PATH` is **not** required to run the suite — `Testing\DebugCertificate` generates throwaway PKCS#12 bundles through the ext-openssl functions. The binary is only needed by `OpenSslCliCertificateReader` and `Validation\SignatureVerifier`.
+Tests run on Orchestra Testbench, not a host app. `openssl` on `PATH` is **not** required to run the suite: `Testing\DebugCertificate` generates throwaway PKCS#12 bundles through the ext-openssl functions. The binary is only needed by `OpenSslCliCertificateReader` and `Validation\SignatureVerifier`.
 
 Tests in the `network` group hit a live timestamp authority (freetsa.org) and fail offline.
 
@@ -62,7 +62,7 @@ The local floor is PHP 8.4 and the matrix reaches 8.5, so version-specific work 
 docker compose -f .docker/compose.yaml run --rm php85 composer check
 ```
 
-Services `php83` / `php` (8.4) / `php85`, each keeping `vendor/` in its own named volume. That volume **masks the host `vendor/`**, which is why PhpStorm reports missing classes after a Docker-only install — fix it with `composer install --ignore-platform-reqs` on the host (documented in `CONTRIBUTING.md`).
+Services `php83` / `php` (8.4) / `php85`, each keeping `vendor/` in its own named volume. That volume **masks the host `vendor/`**, which is why PhpStorm reports missing classes after a Docker-only install. Fix it with `composer install --ignore-platform-reqs` on the host (documented in `CONTRIBUTING.md`).
 
 CI (`.github/workflows/main_action.yml`) runs PHP 8.4 and 8.5 against Laravel 13, on pull
 requests to `main` only. Keep it in sync with `composer.json` and the compatibility table in
@@ -74,55 +74,55 @@ while Pest 5 requires `^8.1`, so the two cannot be installed together and the ce
 
 ## Architecture
 
-Everything resolves through the container. `LaravelA1PdfSignServiceProvider` binds five contracts (`Contracts/`) — `A1PdfSign`, `PdfSigner`, `SealRenderer`, `SignatureValidator`, `CertificateReader` — and registers the two commands. Consumers call the `A1PdfSign` facade; the fluent builder is the primary API:
+Everything resolves through the container. `LaravelA1PdfSignServiceProvider` binds five contracts (`Contracts/`), namely `A1PdfSign`, `PdfSigner`, `SealRenderer`, `SignatureValidator` and `CertificateReader`, and registers the two commands. Consumers call the `A1PdfSign` facade; the fluent builder is the primary API:
 
 ```php
 A1PdfSign::newSignature()->certificate($pfx, $pw)->pdf($path)->profile(...)->sign();
 ```
 
-### Signing — the core
+### Signing, the core
 
-`Signing\IncrementalSigner` (bound to `PdfSigner`) never rebuilds the document. It **appends a revision** (ISO 32000-1 §7.5.6), so the original bytes survive byte-for-byte and a second signature does not invalidate the first — this is what closes TCPDF#430, and it is the single most important invariant in the package. v1 re-imported every page through FPDI, silently destroying annotations, form fields and any signature already present.
+`Signing\IncrementalSigner` (bound to `PdfSigner`) never rebuilds the document. It **appends a revision** (ISO 32000-1 §7.5.6), so the original bytes survive byte-for-byte and a second signature does not invalidate the first: this is what closes TCPDF#430, and it is the single most important invariant in the package. v1 re-imported every page through FPDI, silently destroying annotations, form fields and any signature already present.
 
 The pipeline, all under `Signing/Incremental/`:
 
 1. `DocumentReader` → `DocumentInfo` (xref offset, `/Root`, `/Size`, page objects).
 2. `RevisionWriter::append()` writes the new objects: signature dictionary with a fixed-width `/Contents` placeholder, widget annotation, `/AcroForm` with `/SigFlags`, updated catalog and page, a 20-byte-entry xref table, and a trailer chained by `/Prev`.
 3. `ByteRangeCalculator::apply()` fills `/ByteRange` with the real offsets around the placeholder.
-4. `Cades\CadesBuilder` builds the detached CMS with `Com\Tecnick\Pdf\Sign\Signer` — **not** `openssl_pkcs7_sign()`, which cannot emit the ESS `signing-certificate-v2` attribute PAdES requires.
+4. `Cades\CadesBuilder` builds the detached CMS with `Com\Tecnick\Pdf\Sign\Signer`, **not** `openssl_pkcs7_sign()`, which cannot emit the ESS `signing-certificate-v2` attribute PAdES requires.
 5. The hex payload is written back with `substr_replace()` at a fixed width, so no offset moves.
 6. `DssWriter` (B-LT and above) appends the Document Security Store as a further revision; `DocTimeStampWriter` (B-LTA) closes with an archive timestamp over the whole file.
 
-Two traps this code has already fallen into — do not reintroduce them:
+Two traps this code has already fallen into, and they must not be reintroduced:
 
 - **Always operate on the *last* match.** `preg_match` finds the *first* `/ByteRange` or `/Contents`, which in a multi-signature document belongs to an earlier signature; writing there corrupts it. Everything uses `preg_match_all` + `end()` (`readLast()`, `lastContentsOffset()`). A bug of exactly this shape passed the entire suite and was caught only by poppler's `pdfsig`.
 - **Never assume whitespace in PDF syntax.** tc-lib-pdf-sign emits `/Contents<`, TCPDF emitted `/Contents <`. Match with `\s*`.
 
 `CONTENTS_HEX_LENGTH` is deliberately larger than tc-lib-pdf's reserve: overflowing the placeholder is a hard failure, and embedding the chain grows the CMS.
 
-Profiles live in `Enums\SignatureProfile` (Legacy, B-B, B-T, B-LT, B-LTA) and own their `/SubFilter` plus what each level requires. `Cades\HttpTransport` is the injected TSA/OCSP/CRL client — the host application owns that SSRF surface, so keep network access behind it.
+Profiles live in `Enums\SignatureProfile` (Legacy, B-B, B-T, B-LT, B-LTA) and own their `/SubFilter` plus what each level requires. `Cades\HttpTransport` is the injected TSA/OCSP/CRL client: the host application owns that SSRF surface, so keep network access behind it.
 
 ### Certificates
 
-`Certificates\ReaderFactory` picks between `NativeCertificateReader` (ext-openssl, the default) and `OpenSslCliCertificateReader` (shells out; needed for `-legacy` PFX files under OpenSSL 3.x). It holds the `Container` rather than the `A1PdfSign` contract — resolving the contract here created a cycle that recursed until the process **segfaulted with no output** (exit 139).
+`Certificates\ReaderFactory` picks between `NativeCertificateReader` (ext-openssl, the default) and `OpenSslCliCertificateReader` (shells out; needed for `-legacy` PFX files under OpenSSL 3.x). It holds the `Container` rather than the `A1PdfSign` contract, because resolving the contract here created a cycle that recursed until the process **segfaulted with no output** (exit 139).
 
 `CertificateVault` owns the AES encryption behind `encryptCertificate()`/`decryptCertificate()`. It stores the PEM bundle and parses it back directly; v1's helper wrote a `.pfx` and fed it to `openssl pkcs12 -in`, so the pair never round-tripped (§1.14).
 
 ### Validation
 
-`Validation\PdfSignatureValidator` returns a `SignatureReport`, and "valid" means the CMS actually verifies — v1 only checked that the parsed subject contained `OU` or `CN`. `PdfSignatureExtractor` locates each `/ByteRange`, `Pkcs7Reader`/`DerReader` parse ASN.1 by declared length (never by trimming trailing `0`s — that cuts legitimate DER bytes), and `SignatureVerifier` is the one remaining deliberate shell-out.
+`Validation\PdfSignatureValidator` returns a `SignatureReport`, and "valid" means the CMS actually verifies: v1 only checked that the parsed subject contained `OU` or `CN`. `PdfSignatureExtractor` locates each `/ByteRange`, `Pkcs7Reader`/`DerReader` parse ASN.1 by declared length (never by trimming trailing `0`s, which cuts legitimate DER bytes), and `SignatureVerifier` is the one remaining deliberate shell-out.
 
 DocTimeStamps are classified separately (`isTimestamp`) and excluded from `isValid()`; they are timestamps over the file, not signatures by a signer.
 
 ### Supporting pieces
 
-- `Data/` — `final readonly` DTOs extending `BaseData`. They are public return types, so adding a property changes the public shape.
-- `Support/` — `ProcessRunner` (the only place a child process is spawned; built on `Illuminate\Process\Factory` so a host app can `Process::fake()` it, and using `newPendingProcess()` because PHPStan cannot follow the factory's `__call` proxy), `TemporaryFile` (cleans up in `finally` and in the destructor), `Files` (throws `FileNotFoundException` instead of returning `false`).
-- `Exceptions/` — one class per failure mode. PSR-4 autoloading is case-sensitive: `InvalidX509PrivateKeyException` has a capital `X`.
-- `Seal/InterventionSealRenderer` — Intervention Image v3; everything v1 hard-coded now comes from config.
-- `Commands/` — `pdf:sign` and `pdf:validate-signature`; thin wrappers that map `Throwable` to exit codes.
-- `Testing/DebugCertificate` — test-only certificate generation, kept out of the production classes.
-- `poc/` — throwaway spikes, excluded from PHPStan and `export-ignore`d.
+- `Data/`: `final readonly` DTOs extending `BaseData`. They are public return types, so adding a property changes the public shape.
+- `Support/`: `ProcessRunner` (the only place a child process is spawned; built on `Illuminate\Process\Factory` so a host app can `Process::fake()` it, and using `newPendingProcess()` because PHPStan cannot follow the factory's `__call` proxy), `TemporaryFile` (cleans up in `finally` and in the destructor), `Files` (throws `FileNotFoundException` instead of returning `false`).
+- `Exceptions/`: one class per failure mode. PSR-4 autoloading is case-sensitive: `InvalidX509PrivateKeyException` has a capital `X`.
+- `Seal/InterventionSealRenderer`: Intervention Image v3; everything v1 hard-coded now comes from config.
+- `Commands/`: `pdf:sign` and `pdf:validate-signature`; thin wrappers that map `Throwable` to exit codes.
+- `Testing/DebugCertificate`: test-only certificate generation, kept out of the production classes.
+- `poc/`: throwaway spikes, excluded from PHPStan and `export-ignore`d.
 
 ## Quality gates
 
@@ -130,11 +130,11 @@ DocTimeStamps are classified separately (`isTimestamp`) and excluded from `isVal
 
 - **PHPStan `level: max`, no baseline.** The baseline was deleted, not shrunk (§7, decision 13); the gate is "no errors", not "no new errors". Only Pest's untypeable fluent API is ignored, scoped to `tests/*`.
 - **Type coverage gated at 100%.**
-- **Mutation testing** covers `src/Certificates`, `src/Signing` and `src/Validation`, nightly rather than on pull requests. The floors live in `.github/workflows/mutation.yml` and are explained in `docs/spec/quality-policy.md` — they are not repeated here, because a number kept in three places drifts in two of them. Raise a floor only after measuring; never set a target ahead of the measurement.
+- **Mutation testing** covers `src/Certificates`, `src/Signing` and `src/Validation`, nightly rather than on pull requests. The floors live in `.github/workflows/mutation.yml` and are explained in `docs/spec/quality-policy.md`. They are not repeated here, because a number kept in three places drifts in two of them. Raise a floor only after measuring; never set a target ahead of the measurement.
 - **Do not split mutation runs with `--shard`.** It divides the test suite, and every mutation needs the whole suite: a mutation killed by a test in another shard is reported as uncovered. Split by mutated path instead.
 - `composer-dependency-analyser.php` catches unused and shadow dependencies.
 
-Patches are expected to come with tests (`CONTRIBUTING.md`). `tests/ArchTest.php` enforces structural rules — read it before adding a class.
+Patches are expected to come with tests (`CONTRIBUTING.md`). `tests/ArchTest.php` enforces structural rules, so read it before adding a class.
 
 ## Commits
 
@@ -161,11 +161,11 @@ Conventional Commits, in English (`feat:`, `fix:`, `chore(deps):`, `test:`, `doc
 - PER-CS via Pint; grouped `use` imports with braces are used throughout.
 - `final readonly` classes by default; fluent setters returning `self`; named arguments at call sites.
 - Modern PHP is expected: typed class constants, `#[\SensitiveParameter]` on every password argument, `#[\Override]`, enums instead of class constants.
-- `@throws` docblocks are maintained on every method that can throw — keep them accurate when changing exception paths.
+- `@throws` docblocks are maintained on every method that can throw, so keep them accurate when changing exception paths.
 - Nullable config-backed arguments mean "use the configured default" rather than forcing every call site to repeat an infrastructure decision.
 
 ## Notes
 
-- `*.pdf`, `*.pfx` and `dist/` are gitignored — never commit generated certificates or signed output. `dist/` is a build of the separate docs site (https://laravel-a1-pdf-sign.netlify.app).
+- `*.pdf`, `*.pfx` and `dist/` are gitignored, so never commit generated certificates or signed output. `dist/` is a build of the separate docs site (https://laravel-a1-pdf-sign.netlify.app).
 - Do not define `K_PATH_FONTS` globally: tc-lib-pdf and TCPDF 6 read it with different formats, and defining it kills TCPDF silently.
-- Independent verification is done with poppler's `pdfsig`; it has caught bugs the suite passed straight through. `samples/` holds one signed PDF per profile plus a six-signature document — regenerate them with `poc/sign-samples.php` and re-check them after any change to `src/Signing/`.
+- Independent verification is done with poppler's `pdfsig`; it has caught bugs the suite passed straight through. `samples/` holds one signed PDF per profile plus a six-signature document. Regenerate them with `poc/sign-samples.php` and re-check them after any change to `src/Signing/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,13 +27,13 @@ We accept contributions via Pull Requests on [Github](https://github.com/lsnepom
 ## Running the checks
 
 ``` bash
-$ composer check       # style, static analysis and tests — the same as CI
+$ composer check       # style, static analysis and tests, the same as CI
 $ composer test        # tests only
 $ composer lint        # fix code style
 $ composer analyse     # static analysis only
 $ composer test:types  # type coverage across src/
 $ composer test:cov    # line coverage (needs pcov or xdebug)
-$ composer test:mutate # mutation testing (slow — runs nightly in CI, not on PRs)
+$ composer test:mutate # mutation testing (slow: runs nightly in CI, not on PRs)
 ```
 
 Tests are written with [Pest](https://pestphp.com). `tests/ArchTest.php` holds
@@ -53,7 +53,7 @@ files and stages the result, so style is never what a pull request gets blocked 
 $ npm install     # once, to install the hook
 ```
 
-Node is only used for the hook — it is not a dependency of the package, and skipping this
+Node is only used for the hook: it is not a dependency of the package, and skipping this
 step costs you nothing but the convenience. If your machine runs a PHP older than Pint
 requires, the hook detects it and routes through the Docker service described below.
 
@@ -63,7 +63,7 @@ Our validator shares its assumptions with the code it validates, so a green
 suite is not proof that Adobe Reader agrees. `samples/` holds one signed PDF per
 profile plus a six-signature document, with instructions for regenerating them
 and for reading what each one should show. **Regenerate and re-check them after
-any change to `src/Signing/`** — poppler's `pdfsig` has caught bugs the suite
+any change to `src/Signing/`**. Poppler's `pdfsig` has caught bugs the suite
 passed straight through.
 
 The package targets PHP 8.4+ and Laravel 13. If your machine runs an older PHP,
@@ -77,7 +77,7 @@ $ docker compose -f .docker/compose.yaml run --rm php composer check
 
 Each Docker service keeps `vendor/` in its own named volume, so switching PHP
 versions does not clobber the other install. The trade-off is that the
-`vendor/` your editor indexes — the one on your machine — is never touched by
+`vendor/` your editor indexes, the one on your machine, is never touched by
 those runs, and it goes stale as dependencies change. Classes then show up as
 "not found" even though the suite is green.
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ $signed->download('contract.pdf'); // BinaryFileResponse
 ```
 
 **Signing appends a revision rather than rebuilding the document.** The original bytes survive, so annotations and form
-fields are preserved and a document can carry more than one signature — the request in
+fields are preserved and a document can carry more than one signature, the request in
 [TCPDF#430](https://github.com/tecnickcom/TCPDF/issues/430), open since 2021.
 
 ### PEM certificates
@@ -112,18 +112,18 @@ A1PdfSign::signFromPem($pemPath, $password, $pdfPath);        // one-shot
 A1PdfSign::newSignature()->certificateFromPem($bytes);        // from an upload or a secret store
 ```
 
-The format is decided by content, not by extension — PEM ships as `.pem`, `.crt`, `.cer`, `.key` and `.txt`. The
+The format is decided by content, not by extension: PEM ships as `.pem`, `.crt`, `.cer`, `.key` and `.txt`. The
 `pdf:sign` command detects it the same way, and takes `--key` for the two-file form:
 
 ```bash
 php artisan pdf:sign contract.pdf certificate.pem "" signed.pdf --key=private.key
 ```
 
-Pass an empty password when the private key is unencrypted. **PEM permits that and PKCS#12 does not** — an unprotected
+Pass an empty password when the private key is unencrypted. **PEM permits that and PKCS#12 does not**, and an unprotected
 key on disk is readable by anything that can read the file, so prefer an encrypted one where you have the choice.
 
 Signed samples for every profile, including a document carrying six signatures, live in
-[`samples/`](samples/README.md) — open them in any reader to see what the package produces.
+[`samples/`](samples/README.md). Open them in any reader to see what the package produces.
 
 ### PAdES profiles
 
@@ -153,7 +153,7 @@ $report->count();       // how many signatures the document carries
 $report->signers();     // structured signer identity
 ```
 
-`isValid()` answers whether each signature matches the document. It does not check the issuer against a trust store —
+`isValid()` answers whether each signature matches the document. It does not check the issuer against a trust store:
 that decision stays with your application.
 
 Configuration is publishable:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,7 +3,7 @@
 ## From 2.0 to 2.1
 
 2.1 adds PEM as a second accepted certificate encoding. PKCS#12 behaviour is
-unchanged, and the PHP and Laravel requirements do not move — an application
+unchanged, and the PHP and Laravel requirements do not move, so an application
 that signs with `.pfx` and does not implement the package's contracts upgrades
 without editing anything.
 
@@ -13,7 +13,7 @@ Two changes reach code that extends the package rather than calls it.
 
 | | 2.0 | 2.1 |
 |---|---|---|
-| `Contracts\A1PdfSign` | — | gains `signFromPem()` |
+| `Contracts\A1PdfSign` | n/a | gains `signFromPem()` |
 | `Contracts\CertificateReader::read()` | `$pfxContents` | `$contents` |
 
 Injecting the contracts, or calling them, is unaffected. Implementing them is
@@ -37,7 +37,7 @@ $reader->read(contents: $bytes, password: $password);      // 2.1
 ```
 
 The parameter was named after PKCS#12 when that was the only encoding a reader
-could ingest. It no longer is — `PemCertificateReader` implements the same
+could ingest. It no longer is: `PemCertificateReader` implements the same
 contract as the degenerate case, the reader whose conversion step is empty.
 
 ### `pdf:sign` renamed its second argument
@@ -56,7 +56,7 @@ Artisan::call('pdf:sign', ['certificatePath' => $path, ...]);  // 2.1
 ```
 
 The command also takes `--key` for a PEM key in its own file. Passing it with a
-PKCS#12 bundle is rejected rather than ignored — the bundle already carries its
+PKCS#12 bundle is rejected rather than ignored: the bundle already carries its
 key, so the combination means the caller is mistaken about what they hold.
 
 ### New: PEM certificates
@@ -79,7 +79,7 @@ A1PdfSign::newSignature()
 ```
 
 `$password` defaults to empty, because **a PEM private key is frequently
-unencrypted — legal for PEM, impossible for PKCS#12**. OpenSSL ignores a
+unencrypted, legal for PEM and impossible for PKCS#12**. OpenSSL ignores a
 passphrase given for a key that does not need one, so the argument is safe to
 pass either way. Prefer an encrypted key where you have the choice: an
 unprotected one is readable by anything that can read the file.
@@ -88,8 +88,8 @@ unprotected one is readable by anything that can read the file.
 and detects the encoding, where signing keeps explicit entry points so the
 caller states what it holds.
 
-Content that is neither valid PEM nor routable — binary DER, or PKCS#12 bytes
-handed to the PEM entry point — raises the new
+Content that is neither valid PEM nor routable, whether binary DER or PKCS#12 bytes
+handed to the PEM entry point, raises the new
 `Exceptions\InvalidPemContentException`, naming the offending half rather than
 reporting a generic parse failure. A certificate and key that are both valid
 but unrelated keep raising `InvalidX509PrivateKeyException`.
@@ -99,7 +99,7 @@ but unrelated keep raising `InvalidX509PrivateKeyException`.
 Version 2.0 is a clean break: the deprecated API is removed rather than carried
 behind a shim. Upgrading requires editing your code.
 
-That was a deliberate reversal — the original plan kept a deprecation layer
+That was a deliberate reversal: the original plan kept a deprecation layer
 until 3.0. A 3.0 is far enough out that a shim living "until then" is a shim
 maintained indefinitely, and every one of them constrains the design it wraps:
 `Entities\*` could not be `final`, the enums would carry legacy backing values,
@@ -140,7 +140,7 @@ The trailing arguments are now optional and fall back to
 `config('a1-pdf-sign')`, so `usePathEnv` no longer has to be repeated at every
 call site.
 
-Prefer injecting the contract where you can — it is what makes the package
+Prefer injecting the contract where you can: it is what makes the package
 mockable in your own tests:
 
 ```php
@@ -174,14 +174,14 @@ array yourself.
 | `SealImage::FONT_SIZE_LARGE` | `Enums\FontSize::Large` |
 | `SealImage::IMAGE_DRIVER_GD` | `Enums\ImageDriver::Gd` |
 | `SealImage::IMAGE_DRIVER_IMAGICK` | `Enums\ImageDriver::Imagick` |
-| `SignaturePdf::MODE_RESOURCE` | removed — see below |
-| `SignaturePdf::MODE_DOWNLOAD` | removed — see below |
+| `SignaturePdf::MODE_RESOURCE` | removed, see below |
+| `SignaturePdf::MODE_DOWNLOAD` | removed, see below |
 
 Every entry point accepts either the enum case or its backing value
 (`'large'`, `'gd'`), so configuration can stay as plain strings.
 
 **The signing mode has no replacement, by design.** `sign()` returns a
-`SignedPdf` and no longer decides how the result is delivered — the same result
+`SignedPdf` and no longer decides how the result is delivered: the same result
 answers `contents()`, `save()`, `download()` and `toResponse()`. Drop the mode
 argument and call the method you want.
 
@@ -209,7 +209,7 @@ $signed->toResponse();       // inline
 **Signing no longer rebuilds the document.** v1 imported every page into a new
 file, which silently discarded annotations, form fields and any signature
 already present. v2 appends a revision instead, so the original bytes survive
-and a document can carry more than one signature — the request in
+and a document can carry more than one signature, the request in
 [TCPDF#430](https://github.com/tecnickcom/TCPDF/issues/430).
 
 The practical consequence is that output is no longer byte-comparable with 1.x.
@@ -221,7 +221,7 @@ Signatures are now PAdES baseline by default, carrying the ESS
 
 | Profile | Adds |
 |---|---|
-| `legacy` | ISO 32000-1 detached CMS — the 1.x behaviour |
+| `legacy` | ISO 32000-1 detached CMS, the 1.x behaviour |
 | `pades-b-b` | CAdES signed attributes. **The new default** |
 | `pades-b-t` | B-B plus an RFC 3161 timestamp |
 | `pades-b-lt` | B-T plus a Document Security Store, so the signature still verifies after the certificate expires |
@@ -245,7 +245,7 @@ php artisan vendor:publish --tag=a1-pdf-sign-config
 ```
 
 It controls the temporary path, the `openssl` PATH and legacy flags, and the
-seal defaults. Nothing is required — the defaults match 1.x behaviour, except
+seal defaults. Nothing is required: the defaults match 1.x behaviour, except
 that temporary files no longer need `vendor/` to be writable.
 
 ### Validation now verifies the signature
@@ -259,13 +259,13 @@ as validated.
 
 | 1.x | 2.0 |
 |---|---|
-| `$report->isValidated` | `$report->isValid()` — every signature verifies |
+| `$report->isValidated` | `$report->isValid()`, every signature verifies |
 | `$report->data` | `$report->signers()`, or `$report->signatures` for detail |
-| — | `$report->count()`, `isSigned()`, `latest()` |
+| n/a | `$report->count()`, `isSigned()`, `latest()` |
 
 Each entry carries the signer as structured data, whether it verified, and
 whether it covers the whole file. Documents with more than one signature are
 reported in full; 1.x read only the first.
 
 `isValid()` answers "does this signature match these bytes". It does not check
-the issuer against a trust store — that decision stays with your application.
+the issuer against a trust store: that decision stays with your application.

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -9,9 +9,9 @@ return (new Configuration())
     ->addPathToExclude(__DIR__ . '/poc')
 
     /*
-     * Extensions are used through the libraries that wrap them — gd by
+     * Extensions are used through the libraries that wrap them: gd by
      * Intervention, fileinfo by UploadedFile, mbstring by Laravel's string
-     * handling — so no direct symbol reference exists to detect. They stay
+     * handling, so no direct symbol reference exists to detect. They stay
      * declared because a host missing them fails at runtime.
      */
     ->ignoreErrorsOnExtensions(

--- a/config/a1-pdf-sign.php
+++ b/config/a1-pdf-sign.php
@@ -38,7 +38,7 @@ return [
     |
     | legacy     ISO 32000-1 detached CMS. Widest reader support.
     | pades-b-b  PAdES baseline. The default.
-    | pades-b-t  B-B plus an RFC 3161 timestamp — needs timestamp.url below.
+    | pades-b-t  B-B plus an RFC 3161 timestamp, needs timestamp.url below.
     | pades-b-lt B-T plus a Document Security Store.
     | pades-b-lta B-LT plus an archive timestamp.
     |

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,7 +19,7 @@ parameters:
     treatPhpDocTypesAsCertain: false
 
     ignoreErrors:
-        # Pest's fluent API — arch(), expect()->and()->not, dataset chains — is
+        # Pest's fluent API (arch(), expect()->and()->not, dataset chains) is
         # runtime magic that PHPStan cannot type without a dedicated extension.
         # These are limits of the tooling, not defects, so they are ignored
         # rather than baselined: the baseline must only track debt that can

--- a/poc/incremental-signature/IncrementalSigner.php
+++ b/poc/incremental-signature/IncrementalSigner.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * PoC 0b — incremental revision writer for PDF signatures.
+ * PoC 0b: incremental revision writer for PDF signatures.
  *
  * Clean-room implementation based on ISO 32000-1:
  *   §7.5.6  Incremental Updates
@@ -12,7 +12,7 @@ declare(strict_types=1);
  * No line is derived from ddn/sapp (LGPL). See docs/spec/invariants.md.
  *
  * Spike scope: classic cross-reference tables only. Cross-reference streams
- * (PDF 1.5+) are detected and explicitly rejected — support lands in the
+ * (PDF 1.5+) are detected and explicitly rejected: support lands in the
  * production implementation.
  */
 final class IncrementalSigner
@@ -93,7 +93,7 @@ final class IncrementalSigner
     private function readDocument(string $pdf): array
     {
         if (!preg_match_all('/startxref\s+(\d+)\s*%%EOF/', $pdf, $m)) {
-            throw new RuntimeException('startxref not found — invalid or truncated PDF.');
+            throw new RuntimeException('startxref not found: invalid or truncated PDF.');
         }
 
         $latest = (int) end($m[1]);
@@ -264,7 +264,7 @@ final class IncrementalSigner
     {
         return "{$num} 0 obj\n"
             . '<</Type/Annot/Subtype/Widget/FT/Sig'
-            . '/Rect[0 0 0 0]'          // invisible signature — the visual seal comes later
+            . '/Rect[0 0 0 0]'          // invisible signature; the visual seal comes later
             . "/T ({$name})"
             . "/V {$sigNum} 0 R"
             . "/P {$pageNum} 0 R"
@@ -405,7 +405,7 @@ final class IncrementalSigner
         );
 
         if (strlen($replacement) !== strlen($placeholder)) {
-            throw new RuntimeException('ByteRange would change length — offsets would be invalidated.');
+            throw new RuntimeException('ByteRange would change length, so offsets would be invalidated.');
         }
 
         $pos = strrpos($full, $placeholder);
@@ -420,7 +420,7 @@ final class IncrementalSigner
     private function applySignature(string $full, string $certPem, string $keyPem): string
     {
         // An already-signed document holds several /ByteRange entries. Ours is
-        // always the LAST one — the freshly appended revision. Taking the first
+        // always the LAST one, the freshly appended revision. Taking the first
         // would overwrite the /Contents of a previous signature.
         if (!preg_match_all('/\/ByteRange\[0 (\d+)\s+(\d+)\s+(\d+)\s*\]/', $full, $all, PREG_SET_ORDER)) {
             throw new RuntimeException('ByteRange could not be read back.');

--- a/poc/incremental-signature/README.md
+++ b/poc/incremental-signature/README.md
@@ -1,6 +1,6 @@
-# PoC 0b — incremental-revision signing
+# PoC 0b, incremental-revision signing
 
-Spike for PR 0b (see docs/spec/invariants.md). **This is not production code** — it exists
+Spike for PR 0b (see docs/spec/invariants.md). **This is not production code**: it exists
 to answer a single question before committing to the v2 architecture:
 
 > Can a PDF be signed several times without each new signature destroying the previous one?
@@ -38,7 +38,7 @@ signature 2: ByteRange[0 26442 42828 752] covers 27194 of 60861 bytes -> VALID
 signature 3: ByteRange[0 43709 60095 766] covers 44475 of 60861 bytes -> VALID
 ```
 
-Each signature covers exactly its own revision — 26313, 43580 and 60861 bytes respectively —
+Each signature covers exactly its own revision, at 26313, 43580 and 60861 bytes respectively,
 which is the correct ISO 32000-1 semantics. The original document bytes stay untouched
 across all three rounds.
 
@@ -47,7 +47,7 @@ across all three rounds.
 | Hypothesis | Status |
 |---|---|
 | Multiple signatures without overwriting | ✅ confirmed |
-| Original bytes preserved | ✅ confirmed — `substr($pdf, 0, $origLen)` identical to the source file |
+| Original bytes preserved | ✅ confirmed, `substr($pdf, 0, $origLen)` identical to the source file |
 | Correct `/Prev` chain across revisions | ✅ confirmed |
 | Detached PKCS#7 through `ext-openssl`, no shell-out | ✅ confirmed (`openssl_pkcs7_sign`) |
 | Certificate generated without the CLI | ✅ confirmed (`openssl_pkey_new` + `openssl_csr_sign`) |
@@ -60,7 +60,7 @@ across all three rounds.
   only and **explicitly rejects** xref streams. `test.pdf` is PDF-1.4.
 - **Encrypted PDFs**, linearized files, or a complex pre-existing `/AcroForm`.
 - **Visual seal.** Signatures are invisible (`/Rect [0 0 0 0]`).
-- **LTV and timestamping.** Out of scope here — those come from tc-lib-pdf (§3g).
+- **LTV and timestamping.** Out of scope here: those come from tc-lib-pdf (§3g).
 
 ## Two bugs found while building this
 
@@ -70,10 +70,10 @@ Both are worth keeping as regression tests in the production implementation:
    using the *first* makes the new signature overwrite a previous signature's `/Contents`.
    It must always be the **last** one.
 2. **Finding the end of the DER with `rtrim($hex, '0')`.** That cuts legitimate `0x00` bytes
-   belonging to the DER itself. The real length comes from the ASN.1 header — see
+   belonging to the DER itself. The real length comes from the ASN.1 header. See
    `derTruncate()` in `run.php`.
 
 ## Provenance
 
 Clean-room implementation written from ISO 32000-1 §7.5.6 (Incremental Updates) and §12.8
-(Digital Signatures). No line derived from `ddn/sapp` (LGPL) — see docs/spec/invariants.md.
+(Digital Signatures). No line derived from `ddn/sapp` (LGPL). See docs/spec/invariants.md.

--- a/poc/incremental-signature/run.php
+++ b/poc/incremental-signature/run.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * PoC 0b — driver: signs the same PDF three times through incremental
+ * PoC 0b driver: signs the same PDF three times through incremental
  * revisions and checks that all three signatures survive.
  */
 
@@ -71,7 +71,7 @@ for ($i = 1; $i <= 3; $i++) {
         $before,
         strlen($pdf),
         strlen($pdf) - $before,
-        substr($pdf, 0, $origLen) === (string) file_get_contents($src) ? 'YES' : 'NO'
+        substr($pdf, 0, $origLen) === (string) file_get_contents($src) ? 'YES' : 'NO',
     );
 }
 
@@ -103,7 +103,7 @@ foreach ($br as $n => $m) {
     $signed = substr($pdf, 0, $a) . substr($pdf, $b, $c);
 
     // Embedded CMS, between '<' and '>'. The placeholder is zero-padded on the
-    // right, so the real end comes from the ASN.1 header length — not from
+    // right, so the real end comes from the ASN.1 header length, not from
     // rtrim(), which would cut legitimate 0x00 bytes of the DER itself.
     $hex = substr($pdf, $a + 1, $b - $a - 2);
     $der = derTruncate((string) hex2bin($hex));
@@ -120,10 +120,10 @@ foreach ($br as $n => $m) {
             escapeshellarg($sigFile),
             escapeshellarg($dataFile),
             escapeshellarg($certFile),
-            escapeshellarg($certFile)
+            escapeshellarg($certFile),
         ),
         $outLines,
-        $code
+        $code,
     );
 
     $code === 0 && $ok++;
@@ -136,7 +136,7 @@ foreach ($br as $n => $m) {
         $c,
         $a + $c,
         strlen($pdf),
-        $code === 0 ? 'VALID' : 'FAILED'
+        $code === 0 ? 'VALID' : 'FAILED',
     );
 
     if ($code !== 0) {
@@ -152,5 +152,5 @@ foreach ($br as $n => $m) {
 
 echo "\n";
 echo $ok === count($br) && $ok === 3
-    ? "RESULT: {$ok}/3 signatures valid — multiple signatures CONFIRMED\n"
+    ? "RESULT: {$ok}/3 signatures valid: multiple signatures CONFIRMED\n"
     : 'RESULT: only ' . $ok . '/' . count($br) . " valid\n";

--- a/poc/sign-samples.php
+++ b/poc/sign-samples.php
@@ -5,7 +5,7 @@
  * or ITI Validar.
  *
  * The certificate is a throwaway self-signed one, so every reader will report
- * the signer as untrusted — that is the certificate's provenance, not the
+ * the signer as untrusted: that is the certificate's provenance, not the
  * signature's integrity. What can be validated here is everything else: the
  * document hash, the sub-filter, the timestamp token and the coverage of each
  * signature in the multi-signature sample.

--- a/poc/tc-lib-pdf-ltv-tsa/README.md
+++ b/poc/tc-lib-pdf-ltv-tsa/README.md
@@ -1,4 +1,4 @@
-# PoC 0 — tc-lib-pdf: LTV and RFC 3161 timestamping
+# PoC 0, tc-lib-pdf: LTV and RFC 3161 timestamping
 
 Spike for PR 0 (see docs/history/v2-modernization.md). **Not production code.** It executes the
 claims that §3g had only read from the source, and it blocks PRs 7 and 8.
@@ -20,37 +20,37 @@ docker compose -f .docker/compose.yaml run --rm -v /path/to/fonts:/fonts php \
 tc-lib-pdf 8.67.2 | PHP 8.4.24
 
 === 1. baseline signature ===
-  [PASS] produces a PDF — 18872 bytes
+  [PASS] produces a PDF: 18872 bytes
   [PASS] contains a /Sig object
   [PASS] contains /ByteRange
-  [PASS] CMS is not an empty placeholder — 1476 bytes of DER
+  [PASS] CMS is not an empty placeholder: 1476 bytes of DER
   [PASS] accepts PEM strings for privkey/signcert (no file://)
 
 === 2. LTV (DSS / VRI) ===
-  [PASS] LTV run completes — 20605 bytes
+  [PASS] LTV run completes: 20605 bytes
   [PASS] /DSS present in the catalog
   [PASS] /VRI map present
   [PASS] /Certs entry present
-  [PASS] LTV output differs from baseline — 20605 vs 18872 bytes
+  [PASS] LTV output differs from baseline: 20605 vs 18872 bytes
 
 === 3. LTV option validation ===
-  [PASS] rejects a non-bool LTV option — Invalid signature LTV option: enabled
+  [PASS] rejects a non-bool LTV option: Invalid signature LTV option: enabled
 
 === 4. reserved empty signature fields ===
-  [PASS] empty approval widgets are emitted — 3 /FT /Sig fields
+  [PASS] empty approval widgets are emitted: 3 /FT /Sig fields
   [PASS] SigFlags set on AcroForm
 
 === 5. RFC 3161 timestamp ===
   TSA: https://freetsa.org/tsr
-  [PASS] timestamped run completes — 38872 bytes
-  [PASS] CMS grew, i.e. a token was embedded — 6135 vs 1476 bytes of DER
+  [PASS] timestamped run completes: 38872 bytes
+  [PASS] CMS grew, i.e. a token was embedded: 6135 vs 1476 bytes of DER
 
 RESULT: 15 passed, 0 failed, 0 skipped
 ```
 
 ## The version gap
 
-The repository's lock file pinned **tc-lib-pdf 8.0.85**; the current release is **8.67.2** —
+The repository's lock file pinned **tc-lib-pdf 8.0.85**; the current release is **8.67.2**,
 67 minor versions of drift. Everything below only holds on the current release.
 
 The upgrade also pulls in **`tecnickcom/tc-lib-pdf-sign` 1.1.1** transitively, a package that
@@ -71,14 +71,14 @@ migration.
 ## Incremental update already exists upstream
 
 `Output.php` in 8.67.2 has `appendIncrementalRevision()`, `buildIncrementalXref()`,
-`buildIncrementalTrailer()` and `previousStartxref()` — all `protected`. They back the
+`buildIncrementalTrailer()` and `previousStartxref()`, all `protected`. They back the
 post-signing `/DSS` (B-LT) and `/DocTimeStamp` (B-LTA) revisions.
 
 This does **not** invalidate PoC 0b: there is still no public API to sign an *externally
 supplied, already-signed* PDF, which is this package's core use case. But it does mean PR 7b
 should first try inheriting that machinery instead of shipping the writer from PoC 0b.
 
-## Fonts — a blocker worth recording
+## Fonts, a blocker worth recording
 
 **tc-lib-pdf cannot emit any PDF without a generated font definition**, not even a
 signature-only document with no text. A plain `composer install` ships none: the font data is
@@ -91,7 +91,7 @@ Com\Tecnick\Pdf\Font\Exception: unable to read file: helvetica.json
 TCPDF 6 bundles 165 fonts, but in PHP format; tc-lib-pdf-font expects JSON. Not
 interchangeable.
 
-The fix used here, and the proposed path for PR 7 — convert the core-14 AFM metrics that
+The fix used here, and the proposed path for PR 7, is to convert the core-14 AFM metrics that
 `tecnickcom/tc-font-mirror` ships:
 
 ```bash
@@ -108,7 +108,7 @@ have to know any of this.
 
 - **No external reader validation.** Checks are structural (PDF object inspection) plus one
   live TSA round-trip. Adobe Reader / ITI Validar conformance is still PR 7 work.
-- **OCSP and CRL were disabled** — the self-signed test certificate has neither an OCSP
+- **OCSP and CRL were disabled**: the self-signed test certificate has neither an OCSP
   responder nor a CRL distribution point. Only certificate embedding in the DSS is exercised.
 - **B-LTA was not exercised** end to end, only the B-LT DSS material.
-- **Signing an existing external PDF** — not covered here; that is PoC 0b's territory.
+- **Signing an existing external PDF**: not covered here; that is PoC 0b's territory.

--- a/poc/tc-lib-pdf-ltv-tsa/run.php
+++ b/poc/tc-lib-pdf-ltv-tsa/run.php
@@ -3,14 +3,14 @@
 declare(strict_types=1);
 
 /**
- * PoC 0 — does tc-lib-pdf actually deliver LTV and RFC 3161 timestamping,
+ * PoC 0: does tc-lib-pdf actually deliver LTV and RFC 3161 timestamping,
  * or does it only document them?
  *
  * Blocks PRs 7 and 8 (see docs/history/v2-modernization.md). Every claim in that section
  * was read from the source; this script executes them.
  *
  * Fonts: tc-lib-pdf ships no font definition files, and it cannot emit any PDF
- * without one — not even a signature-only document. Generate helvetica.json
+ * without one, not even a signature-only document. Generate helvetica.json
  * once and mount the directory (see this PoC's README):
  *
  *   php vendor/tecnickcom/tc-lib-pdf-font/util/convert.php \
@@ -39,14 +39,14 @@ function check(string $label, bool $ok, string $detail = ''): void
 {
     global $pass, $fail;
     $ok ? $pass++ : $fail++;
-    printf("  [%s] %s%s\n", $ok ? 'PASS' : 'FAIL', $label, $detail !== '' ? " — {$detail}" : '');
+    printf("  [%s] %s%s\n", $ok ? 'PASS' : 'FAIL', $label, $detail !== '' ? ": {$detail}" : '');
 }
 
 function skip(string $label, string $why): void
 {
     global $skip;
     $skip++;
-    printf("  [SKIP] %s — %s\n", $label, $why);
+    printf("  [SKIP] %s: %s\n", $label, $why);
 }
 
 // ---------------------------------------------------------------------------
@@ -91,7 +91,7 @@ function buildSigned(
         'cert_type' => 2,
         'info'      => ['Name' => 'PoC', 'Reason' => 'LTV/TSA probe'],
         'password'  => '',
-        // PEM strings, not file:// — this also exercises the "key in memory"
+        // PEM strings, not file://, which also exercises the "key in memory"
         // claim from docs/history/v2-modernization.md.
         'privkey'   => $keyPem,
         'signcert'  => $certPem,
@@ -180,7 +180,7 @@ try {
 }
 
 // ---------------------------------------------------------------------------
-// 3. LTV option validation — proves the option is really parsed
+// 3. LTV option validation, proves the option is really parsed
 // ---------------------------------------------------------------------------
 echo "\n=== 3. LTV option validation ===\n";
 
@@ -209,7 +209,7 @@ try {
 }
 
 // ---------------------------------------------------------------------------
-// 5. RFC 3161 timestamp — requires network access
+// 5. RFC 3161 timestamp, requires network access
 // ---------------------------------------------------------------------------
 echo "\n=== 5. RFC 3161 timestamp ===\n";
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -2,7 +2,7 @@
 
 One signed PDF per signature profile, plus a document carrying six signatures.
 They exist so a change to the signing engine can be checked against real
-readers — Adobe Reader, ITI Validar, poppler's `pdfsig` — and not only against
+readers (Adobe Reader, ITI Validar, poppler's `pdfsig`) and not only against
 this package's own validator, which shares its assumptions with the code it
 validates.
 
@@ -23,7 +23,7 @@ generates. Its password is:
 example's password with special chars: $ & * ? " '
 ```
 
-`certificate.pem` is **the same certificate**, not a second one — same serial,
+`certificate.pem` is **the same certificate**, not a second one: same serial,
 same subject, same password. It is here so the PEM entry point can be exercised
 against the identity the rest of this directory already uses:
 
@@ -39,7 +39,7 @@ shipped unencrypted, and this sample deliberately does not model that.
 
 **Every reader will report the signer as untrusted.** That is the certificate's
 provenance, not the signature's integrity: it is self-signed and chains to
-nothing. Everything else validates normally — document hash, sub-filter,
+nothing. Everything else validates normally: document hash, sub-filter,
 timestamp token, and the coverage of each signature.
 
 To make Adobe Reader report the signer as trusted, import `certificate.pfx` and
@@ -51,16 +51,16 @@ ICP-Brasil certificate.
 
 | File | What it carries |
 |---|---|
-| `legacy.pdf` | `/SubFilter adbe.pkcs7.detached` — ISO 32000-1, widest reader support |
-| `pades-b-b.pdf` | PAdES B-B — `ETSI.CAdES.detached` with the ESS `signing-certificate-v2` attribute |
+| `legacy.pdf` | `/SubFilter adbe.pkcs7.detached`, ISO 32000-1, widest reader support |
+| `pades-b-b.pdf` | PAdES B-B, `ETSI.CAdES.detached` with the ESS `signing-certificate-v2` attribute |
 | `pades-b-t.pdf` | B-B plus an RFC 3161 token from freetsa.org |
 | `pades-b-lt.pdf` | B-T plus a Document Security Store |
-| `pades-b-lta.pdf` | B-LT plus an archive timestamp — a second `/ByteRange`, of type `ETSI.RFC3161`, covering the whole file |
+| `pades-b-lta.pdf` | B-LT plus an archive timestamp, a second `/ByteRange`, of type `ETSI.RFC3161`, covering the whole file |
 | `six-signatures.pdf` | Six signatures on one document |
 
 There is no `pem-signed.pdf`, on purpose. The encoding only changes how the key
 is loaded, so a document signed through `certificatePem()` is indistinguishable
-from `pades-b-b.pdf` — a separate sample would imply a distinction that does not
+from `pades-b-b.pdf`, since a separate sample would imply a distinction that does not
 exist. `poc/sign-samples.php` signs one anyway and validates it, which is where
 the two entry points are shown to converge on real output.
 
@@ -71,7 +71,7 @@ could not produce. In v1 each new signature rebuilt the document through FPDI
 and discarded the previous one; here each signature is an appended revision, so
 all six coexist.
 
-Verified with poppler `pdfsig` 25.12 — all six report *Signature is Valid*, with
+Verified with poppler `pdfsig` 25.12: all six report *Signature is Valid*, with
 progressive coverage:
 
 ```


### PR DESCRIPTION
Third and final pass of the convention added in #214, after #215 (`src/`, `tests/`) and #216 (`docs/`).

**121 lines across 17 files**, insertions matching deletions.

## The scope was wider than "root files"

The figure of 73 quoted in #216 was wrong. It came from a grep that named directories explicitly, and so missed:

| File | Count |
|---|---|
| `poc/` | 39 |
| `samples/README.md` | 8 |
| `CONTRIBUTING.md` | 5 |
| `composer-dependency-analyser.php` | 2 |
| `config/a1-pdf-sign.php` | 1 |
| `phpstan.neon` | 1 |
| `.gitignore` | 1 |

The real figure was 121. The sweep at the end of this branch walks the whole repository instead of a list, so the number is now checked rather than assumed.

## `poc/` needed more care than its status suggests

The READMEs there quote console output captured from the scripts next to them:

```
  [PASS] produces a PDF — 18872 bytes
```

That line is not prose. It is built by `printf` in `run.php`, with `" — {$detail}"` as the separator. Rewriting the transcript without the `printf` would leave a record that no longer matches what the script prints, so both moved together and the transcript still reproduces.

## Four remain, deliberately

All in the counter-example column of the convention table in `CLAUDE.md`:

| Instead of | Write |
|---|---|
| `two reasons — cost and reproducibility` | `two reasons: cost and reproducibility` |

They are what the rule forbids, shown as the thing being forbidden. Removing them would empty the table of its point.

## Verification

`composer check` on PHP 8.5 through `.docker`: green, 135 tests, including `SpecTest` for documentation links.

With this merged the repository holds no em dash outside that table.