### PR TITLE
feat(validation): verify archive timestamps instead of assuming them

### DIFF
--- a/docs/decisions/0010-validation-consumes-what-signing-writes.md
+++ b/docs/decisions/0010-validation-consumes-what-signing-writes.md
@@ -1,6 +1,7 @@
 # 0010: Validation consumes the material signing writes
 
-**Status:** proposed.
+**Status:** partially implemented. The timestamp half is built; reading the DSS
+and using it are not.
 
 ## Context
 
@@ -31,12 +32,23 @@ the missing half of surface that already exists.
 
 Three pieces, each independently useful and worth landing separately.
 
-**Verify the timestamp token.** An RFC 3161 token signs a TSTInfo carrying the
-imprint of the covered bytes. Verifying it means checking the CMS as it already
-does for signatures, and then checking that the imprint matches the digest of
-the range the token covers. Today the second half is what is missing, and it is
-what makes a timestamp meaningful rather than decorative. `SignatureDetails`
-gains the token's time.
+**Verify the timestamp token. Done.** An RFC 3161 token signs a TSTInfo carrying
+the imprint of the covered bytes, so two things have to hold: the token's own
+CMS verifies, and that TSTInfo's imprint is the digest of the range the token
+covers.
+
+**Checking only the first would be worse than checking neither**, because a
+token lifted from a different document passes it: its CMS is perfectly valid,
+it simply stamps other bytes. The test that matters is therefore the negative
+one, and it is written: the same token, offered the wrong bytes, is refused.
+
+The imprint is found rather than parsed. Walking the ASN.1 to the messageImprint
+field would be more literal, but the value searched for is a digest computed
+here, so a match cannot be coincidental. Finding it means the authority stamped
+these bytes.
+
+A timestamp is not detached, unlike a signature, which is why validation needs
+two paths rather than one with a flag.
 
 **Read the DSS.** Parse `/DSS` from the catalog and expose what it carries:
 which certificates, how many OCSP responses, how many CRLs. Purely descriptive

--- a/src/Data/SignatureDetails.php
+++ b/src/Data/SignatureDetails.php
@@ -58,8 +58,11 @@ final readonly class SignatureDetails extends BaseData
 
     /**
      * An archive timestamp is not a signature over the document, so it is
-     * reported but does not decide whether the document is valid. Its own
-     * cryptographic verification is not implemented yet.
+     * reported but does not decide whether the document is valid.
+     *
+     * It is verified on its own terms: its CMS has to check out and its
+     * messageImprint has to be the digest of the range it covers. What it does
+     * not carry is a signer, which is why it stays out of isValid().
      */
     public function countsTowardValidity(): bool
     {

--- a/src/Validation/PdfSignatureValidator.php
+++ b/src/Validation/PdfSignatureValidator.php
@@ -58,10 +58,18 @@ final readonly class PdfSignatureValidator implements SignatureValidator
             [$open, $close, $trailing] = $signature['byteRange'];
 
             $signatures[] = new SignatureDetails(
-                verified: $signature['isTimestamp'] ? false : $this->verifier->verify(
-                    $signature['cms'],
-                    $this->extractor->coveredBytes($pdfContents, $open, $close, $trailing),
-                ),
+                // A timestamp is verified against its own imprint rather than
+                // as a detached signature, which is why the two paths differ
+                // (docs/decisions/0010-validation-consumes-what-signing-writes.md).
+                verified: $signature['isTimestamp']
+                    ? $this->verifier->verifyTimestamp(
+                        $signature['cms'],
+                        $this->extractor->coveredBytes($pdfContents, $open, $close, $trailing),
+                    )
+                    : $this->verifier->verify(
+                        $signature['cms'],
+                        $this->extractor->coveredBytes($pdfContents, $open, $close, $trailing),
+                    ),
                 signers: $this->reader->signers($signature['cms']),
                 coverageEnd: $signature['coverageEnd'],
                 // Only the last signature reaches the end of the file; the

--- a/src/Validation/SignatureVerifier.php
+++ b/src/Validation/SignatureVerifier.php
@@ -52,4 +52,71 @@ final readonly class SignatureVerifier
             return false;
         }
     }
+
+    /**
+     * Decides whether a DocTimeStamp token really stamps the bytes it sits in.
+     *
+     * A timestamp token is not a detached CMS. Its eContent is a TSTInfo, and
+     * the TSTInfo carries a messageImprint: the digest of what was stamped. So
+     * two things have to hold, and checking only the first is worse than
+     * checking neither, because a token lifted from another document passes it.
+     *
+     *   1. the token's own CMS verifies, which is what writing the TSTInfo out
+     *      proves, and
+     *   2. that TSTInfo's imprint is the digest of the range this token covers.
+     *
+     * The second is answered by looking for the digest inside the TSTInfo
+     * rather than by walking the ASN.1 to the messageImprint field. The value
+     * searched for is 32 or more bytes of a cryptographic digest computed here,
+     * so a match cannot be coincidental: finding it means the TSA stamped these
+     * bytes. Not finding it means it did not.
+     *
+     * See docs/decisions/0010-validation-consumes-what-signing-writes.md.
+     */
+    public function verifyTimestamp(string $token, string $coveredBytes): bool
+    {
+        try {
+            $tstInfo = $this->tstInfo($this->paths->tempPath(), $token);
+        } catch (Throwable) {
+            // A token whose own CMS does not verify writes nothing out.
+            return false;
+        }
+
+        return $tstInfo !== '' && $this->imprints($tstInfo, $coveredBytes);
+    }
+
+    /**
+     * The TSTInfo the token signs, as written out by OpenSSL.
+     */
+    private function tstInfo(string $directory, string $token): string
+    {
+        return TemporaryFile::with($directory, '.tst', $token, function (TemporaryFile $file) use ($directory): string {
+            return TemporaryFile::with($directory, '.der', '', function (TemporaryFile $out) use ($file): string {
+                $this->processes->run(sprintf(
+                    'openssl smime -verify -binary -inform DER -in %s -noverify -purpose any -out %s 2>&1',
+                    escapeshellarg($file->path),
+                    escapeshellarg($out->path),
+                ));
+
+                return (string) file_get_contents($out->path);
+            });
+        });
+    }
+
+    /**
+     * Whether the TSTInfo carries the digest of these bytes.
+     *
+     * Every algorithm a TSA might have used is tried, because the token names
+     * its own choice and this does not depend on guessing it right.
+     */
+    private function imprints(string $tstInfo, string $coveredBytes): bool
+    {
+        foreach (['sha256', 'sha384', 'sha512', 'sha1'] as $algorithm) {
+            if (str_contains($tstInfo, hash($algorithm, $coveredBytes, true))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/tests/TimestampTest.php
+++ b/tests/TimestampTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
+use LSNepomuceno\LaravelA1PdfSign\Support\Files;
+use LSNepomuceno\LaravelA1PdfSign\Validation\SignatureVerifier;
+
+it('verifies the archive timestamp of a B-LTA document', function () {
+    // samples/pades-b-lta.pdf is committed and carries a real freetsa.org
+    // token, so this needs no network. Before this, the report said
+    // verified=false for it by construction.
+    $report = A1PdfSign::validate(__DIR__ . '/../samples/pades-b-lta.pdf');
+
+    $timestamps = $report->timestamps();
+
+    expect($timestamps)->not->toBeEmpty();
+
+    foreach ($timestamps as $timestamp) {
+        expect($timestamp->isTimestamp)->toBeTrue()
+            ->and($timestamp->verified)->toBeTrue();
+    }
+});
+
+it('refuses a timestamp token that stamps other bytes', function () {
+    // The imprint check is the half that matters: without it a token lifted
+    // from another document verifies, because its own CMS is perfectly valid.
+    $pdf = Files::read(__DIR__ . '/../samples/pades-b-lta.pdf');
+
+    $report = A1PdfSign::validate(__DIR__ . '/../samples/pades-b-lta.pdf');
+    $token = null;
+
+    foreach (app(LSNepomuceno\LaravelA1PdfSign\Validation\PdfSignatureExtractor::class)->extract($pdf) as $entry) {
+        if ($entry['isTimestamp']) {
+            $token = $entry['cms'];
+        }
+    }
+
+    expect($token)->not->toBeNull()
+        ->and(app(SignatureVerifier::class)->verifyTimestamp((string) $token, 'these are not the bytes it stamped'))
+        ->toBeFalse();
+
+    expect($report->count())->toBeGreaterThan(0);
+});


### PR DESCRIPTION
First of the three pieces in [0010](docs/decisions/0010-validation-consumes-what-signing-writes.md).

## The asymmetry this starts closing

The package writes long-term validation material and reads none of it back. A B-LTA document **it produced itself** reported its own archive timestamp as unverified, by construction:

```php
verified: $signature['isTimestamp'] ? false : $this->verifier->verify(...)
```

## Why a timestamp needs its own path

A timestamp token is **not** a detached CMS. Its eContent is a TSTInfo carrying the imprint of what was stamped, so two things have to hold:

1. the token's own CMS verifies, and
2. that TSTInfo's imprint is the digest of the range the token covers.

**Checking only the first would be worse than checking neither.** A token lifted from a different document passes it: its CMS is perfectly valid, it simply stamps other bytes. So the test carrying the weight here is the negative one, and it is written:

```php
expect(app(SignatureVerifier::class)->verifyTimestamp($token, 'these are not the bytes it stamped'))
    ->toBeFalse();
```

## The imprint is found, not parsed

Walking the ASN.1 to the `messageImprint` field would be more literal. It is not more correct here: the value searched for is a digest computed in this process, so a match cannot be coincidental. Finding it means the authority stamped these bytes; not finding it means it did not. Every algorithm a TSA might have used is tried rather than guessed from the token.

This follows the reader's existing discipline of not trusting text output, and avoids adding an ASN.1 walk whose bugs would produce a false "valid" in the one place a false valid is unacceptable.

## Verification

Tested against `samples/pades-b-lta.pdf`, which is committed and carries a **real freetsa.org token**. So the test needs no network, and cannot go quiet the day the authority is unreachable, unlike the `network` group.

`composer check` on PHP 8.5: green, **146 tests**, up from 144.

## Not here

The other two pieces of 0010, reading the Document Security Store and building chains from the embedded material. The record now says which is built and which is not, rather than describing all three in the future tense.