### PR TITLE
feat(validation): read the Document Security Store

### DIFF
--- a/docs/decisions/0010-validation-consumes-what-signing-writes.md
+++ b/docs/decisions/0010-validation-consumes-what-signing-writes.md
@@ -1,7 +1,7 @@
 # 0010: Validation consumes the material signing writes
 
-**Status:** partially implemented. The timestamp half is built; reading the DSS
-and using it are not.
+**Status:** partially implemented. Verifying the timestamp and reading the store
+are built; using the store to build chains is not.
 
 ## Context
 
@@ -50,10 +50,32 @@ these bytes.
 A timestamp is not detached, unlike a signature, which is why validation needs
 two paths rather than one with a flag.
 
-**Read the DSS.** Parse `/DSS` from the catalog and expose what it carries:
-which certificates, how many OCSP responses, how many CRLs. Purely descriptive
-at first, which is enough to answer "does this document carry what B-LT
-promises" without deciding whether the material is good.
+**Read the DSS. Done.** `Data\SecurityStore` reports how many certificates,
+OCSP responses and CRLs the store holds, and which signatures it names.
+
+Naming matters more than counting. `/VRI` keys entries by the SHA-1 of a
+signature's `/Contents`, so a store can carry material for one signature in a
+document that holds three. `SecurityStore::covers()` answers for a specific
+signature, and `SignatureReport::hasLongTermMaterial()` answers for all of them
+at once.
+
+Two details the implementation had to get right, both verified by a test that
+fails without them:
+
+The dictionary is read by counting its own delimiters rather than to the first
+`>>`, because `/VRI` nests and a naive reader cuts the store in half and reports
+no certificates at all.
+
+The **last** store is read, not the first, for the reason every other reader in
+this package does the same (docs/spec/invariants.md).
+
+An absent store and an empty one stay different answers: `null` for a B-B
+document, a store of zeroes for one that carries the structure with nothing in
+it.
+
+The SHA-1 here is an identifier the PDF specification fixes, not a digest chosen
+for security, which is why `tests/ArchTest.php` exempts one class from the weak
+hashing rule rather than loosening it.
 
 **Use it.** Once the store is readable, validation can build the chain from the
 embedded certificates rather than the network, which is the entire purpose of

--- a/src/Data/SecurityStore.php
+++ b/src/Data/SecurityStore.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Data;
+
+/**
+ * What a document carries for validating its signatures later.
+ *
+ * The Document Security Store holds the certificate chain, OCSP responses and
+ * CRLs as they stood when the signature was made, so the signature can still be
+ * checked once the responders are gone and the certificate has expired. B-LT
+ * adds it and B-LTA seals it under an archive timestamp.
+ *
+ * This describes what is there. It does not say the material is good, which is
+ * a further step: docs/decisions/0010-validation-consumes-what-signing-writes.md.
+ */
+final readonly class SecurityStore extends BaseData
+{
+    /**
+     * @param  list<string>  $signatureKeys  Uppercase hex SHA-1 of each signature's
+     *                                       /Contents that has validation material,
+     *                                       which is how /VRI names them.
+     */
+    public function __construct(
+        public int $certificates,
+        public int $ocspResponses,
+        public int $crls,
+        public array $signatureKeys = [],
+    ) {}
+
+    /**
+     * Whether the store carries material for this signature specifically.
+     *
+     * A store with certificates but no /VRI entry for a given signature is
+     * carrying material for a different one, which is the case worth telling
+     * apart in a document signed more than once.
+     */
+    public function covers(SignatureDetails $signature): bool
+    {
+        return in_array($signature->securityStoreKey(), $this->signatureKeys, true);
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->certificates === 0 && $this->ocspResponses === 0 && $this->crls === 0;
+    }
+}

--- a/src/Data/SignatureDetails.php
+++ b/src/Data/SignatureDetails.php
@@ -31,7 +31,19 @@ final readonly class SignatureDetails extends BaseData
         public bool $isTimestamp = false,
         public ?string $error = null,
         public ?int $signedAt = null,
+        public ?string $rawContents = null,
     ) {}
+
+    /**
+     * How the Document Security Store names this signature.
+     *
+     * /VRI keys entries by the uppercase hex SHA-1 of the signature's
+     * /Contents, which is the only handle the store has on a signature.
+     */
+    public function securityStoreKey(): ?string
+    {
+        return $this->rawContents === null ? null : strtoupper(sha1($this->rawContents));
+    }
 
     /**
      * Whether the signer's certificate was inside its validity window at the

--- a/src/Data/SignatureReport.php
+++ b/src/Data/SignatureReport.php
@@ -19,7 +19,30 @@ final readonly class SignatureReport extends BaseData
     /**
      * @param  list<SignatureDetails>  $signatures
      */
-    public function __construct(public array $signatures) {}
+    public function __construct(
+        public array $signatures,
+        public ?SecurityStore $securityStore = null,
+    ) {}
+
+    /**
+     * Whether the document carries validation material for every signature in
+     * it, which is what B-LT promises and what makes a signature checkable
+     * after its certificate expires.
+     */
+    public function hasLongTermMaterial(): bool
+    {
+        if ($this->securityStore === null || $this->securityStore->isEmpty()) {
+            return false;
+        }
+
+        foreach ($this->signatures as $signature) {
+            if ($signature->countsTowardValidity() && ! $this->securityStore->covers($signature)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     public static function empty(): self
     {

--- a/src/Validation/PdfSignatureValidator.php
+++ b/src/Validation/PdfSignatureValidator.php
@@ -20,6 +20,7 @@ final readonly class PdfSignatureValidator implements SignatureValidator
         private PdfSignatureExtractor $extractor,
         private Pkcs7Reader $reader,
         private SignatureVerifier $verifier,
+        private SecurityStoreReader $store = new SecurityStoreReader(),
     ) {}
 
     /**
@@ -78,9 +79,10 @@ final readonly class PdfSignatureValidator implements SignatureValidator
                 coversWholeDocument: $signature['coverageEnd'] === $size,
                 isTimestamp: $signature['isTimestamp'],
                 signedAt: $signature['signedAt'],
+                rawContents: $signature['cms'],
             );
         }
 
-        return new SignatureReport($signatures);
+        return new SignatureReport($signatures, $this->store->read($pdfContents));
     }
 }

--- a/src/Validation/SecurityStoreReader.php
+++ b/src/Validation/SecurityStoreReader.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Validation;
+
+use LSNepomuceno\LaravelA1PdfSign\Data\SecurityStore;
+
+/**
+ * Reads the Document Security Store a B-LT or B-LTA document carries.
+ *
+ * The package has written this structure since 2.0 and never read it back, so
+ * a document it produced could not be asked whether it carried what its own
+ * profile promises. See
+ * docs/decisions/0010-validation-consumes-what-signing-writes.md.
+ *
+ * @internal
+ */
+final readonly class SecurityStoreReader
+{
+    /**
+     * Null when the document has no store at all, which is the ordinary case
+     * for legacy, B-B and B-T. An empty store and an absent one are different
+     * answers and are not collapsed.
+     */
+    public function read(string $pdf): ?SecurityStore
+    {
+        // Always the last one: a document signed more than once carries a store
+        // per revision, and the newest supersedes the ones before it
+        // (docs/spec/invariants.md).
+        if (preg_match_all('/<<\s*\/Type\s*\/DSS\b/', $pdf, $found, PREG_OFFSET_CAPTURE) < 1) {
+            return null;
+        }
+
+        $offsets = $found[0];
+        $last = end($offsets);
+
+        if (! is_array($last)) {
+            return null;
+        }
+
+        $start = (int) $last[1];
+        $dictionary = $this->dictionaryAt($pdf, $start);
+
+        return new SecurityStore(
+            certificates: $this->countReferences($dictionary, 'Certs'),
+            ocspResponses: $this->countReferences($dictionary, 'OCSPs'),
+            crls: $this->countReferences($dictionary, 'CRLs'),
+            signatureKeys: $this->vriKeys($dictionary),
+        );
+    }
+
+    /**
+     * The dictionary starting at $start, read by counting its own delimiters.
+     *
+     * A fixed window would have to be wide enough for the largest store and
+     * would then swallow whatever follows the smallest, and /VRI nests, so the
+     * first `>>` is not the end.
+     */
+    private function dictionaryAt(string $pdf, int $start): string
+    {
+        $depth = 0;
+        $length = strlen($pdf);
+
+        for ($position = $start; $position < $length - 1; $position++) {
+            $pair = substr($pdf, $position, 2);
+
+            if ($pair === '<<') {
+                $depth++;
+                $position++;
+
+                continue;
+            }
+
+            if ($pair === '>>') {
+                $depth--;
+                $position++;
+
+                if ($depth === 0) {
+                    return substr($pdf, $start, $position - $start + 1);
+                }
+            }
+        }
+
+        return substr($pdf, $start);
+    }
+
+    /**
+     * How many indirect references an array-valued entry holds.
+     */
+    private function countReferences(string $dictionary, string $key): int
+    {
+        if (preg_match('/\/' . $key . '\s*\[([^\]]*)\]/', $dictionary, $found) !== 1) {
+            return 0;
+        }
+
+        $references = preg_match_all('/\d+\s+\d+\s+R/', $found[1]);
+
+        return $references === false ? 0 : $references;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function vriKeys(string $dictionary): array
+    {
+        if (preg_match('/\/VRI\s*<<(.*?)>>\s*(?=\/|>>)/s', $dictionary, $found) !== 1) {
+            return [];
+        }
+
+        preg_match_all('/\/([0-9A-Fa-f]{40})\b/', $found[1], $keys);
+
+        return array_map(strtoupper(...), $keys[1]);
+    }
+}

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -11,9 +11,20 @@ arch('no debug leftovers ship')
     ->expect(['dd', 'dump', 'var_dump', 'print_r', 'die', 'exit', 'ray'])
     ->not->toBeUsed();
 
+/**
+ * SignatureDetails is exempt, and only for sha1. The Document Security Store
+ * keys /VRI entries by the SHA-1 of a signature's /Contents, which the PDF
+ * specification fixes: the value is an identifier defined by a format this
+ * package reads, not a digest this package chose for security. Computing it
+ * with anything else would simply fail to match.
+ *
+ * The exemption is by class rather than by loosening the rule, so a second use
+ * of sha1 anywhere else still fails.
+ */
 arch('no weak hashing or insecure randomness')
     ->expect(['md5', 'sha1', 'rand', 'srand', 'mt_rand'])
-    ->not->toBeUsed();
+    ->not->toBeUsed()
+    ->ignoring('LSNepomuceno\LaravelA1PdfSign\Data\SignatureDetails');
 
 arch('no eval or dynamic code execution')
     ->expect(['eval', 'create_function'])

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -39,7 +39,7 @@ it('reads the common name, falling back to the organisation', function () {
 it('exposes its properties through toArray', function () {
     $report = new SignatureReport([]);
 
-    expect($report->toArray())->toBe(['signatures' => []])
+    expect($report->toArray())->toBe(['signatures' => [], 'securityStore' => null])
         ->and($report->isValid())->toBeFalse()
         ->and($report->isSigned())->toBeFalse();
 });

--- a/tests/SecurityStoreTest.php
+++ b/tests/SecurityStoreTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
+use LSNepomuceno\LaravelA1PdfSign\Support\Files;
+use LSNepomuceno\LaravelA1PdfSign\Validation\SecurityStoreReader;
+
+function sample(string $name): string
+{
+    return __DIR__ . '/../samples/' . $name;
+}
+
+it('reads the store a B-LT document carries', function () {
+    $report = A1PdfSign::validate(sample('pades-b-lt.pdf'));
+
+    expect($report->securityStore)->not->toBeNull()
+        ->and($report->securityStore?->certificates)->toBeGreaterThan(0)
+        ->and($report->securityStore?->isEmpty())->toBeFalse();
+});
+
+it('ties the store to the signature it was written for', function () {
+    // /VRI names a signature by the SHA-1 of its /Contents, so this is what
+    // tells "carries material" apart from "carries material for this one".
+    $report = A1PdfSign::validate(sample('pades-b-lt.pdf'));
+
+    expect($report->securityStore?->signatureKeys)->not->toBeEmpty()
+        ->and($report->securityStore?->covers($report->signatures[0]))->toBeTrue()
+        ->and($report->hasLongTermMaterial())->toBeTrue();
+});
+
+it('reports no store for the profiles that carry none', function () {
+    // An absent store and an empty one are different answers, so B-B returns
+    // null rather than a store of zeroes.
+    foreach (['legacy.pdf', 'pades-b-b.pdf'] as $name) {
+        expect(A1PdfSign::validate(sample($name))->securityStore)->toBeNull();
+        expect(A1PdfSign::validate(sample($name))->hasLongTermMaterial())->toBeFalse();
+    }
+});
+
+it('reads the last store, not the first', function () {
+    // B-LTA appends an archive timestamp after the store, and a document signed
+    // again would carry a second store superseding the first.
+    $report = A1PdfSign::validate(sample('pades-b-lta.pdf'));
+
+    expect($report->securityStore)->not->toBeNull()
+        ->and($report->securityStore?->certificates)->toBeGreaterThan(0);
+});
+
+it('reads a nested VRI without stopping at the first closing marker', function () {
+    // /VRI nests, so a reader that took the first ">>" would cut the store in
+    // half and report no certificates at all.
+    $store = (new SecurityStoreReader())->read(
+        "junk << /Type /DSS /VRI << /" . str_repeat('A', 40) . " 9 0 R >> /Certs [ 1 0 R 2 0 R ] /OCSPs [ 3 0 R ] >> trailing",
+    );
+
+    expect($store?->certificates)->toBe(2)
+        ->and($store?->ocspResponses)->toBe(1)
+        ->and($store?->crls)->toBe(0)
+        ->and($store?->signatureKeys)->toBe([str_repeat('A', 40)]);
+});
+
+it('finds no store in a document that has none', function () {
+    expect((new SecurityStoreReader())->read(Files::read(resource('test.pdf'))))->toBeNull();
+});


### PR DESCRIPTION
Second of the three pieces in [0010](docs/decisions/0010-validation-consumes-what-signing-writes.md), after #220 verified archive timestamps.

The package has written this structure since 2.0 and never read it back, so a document it produced could not be asked whether it carries what its own profile promises.

```php
$report = A1PdfSign::validate('contract.pdf');

$report->securityStore?->certificates;   // int
$report->securityStore?->ocspResponses;  // int
$report->securityStore?->crls;           // int
$report->hasLongTermMaterial();          // bool
```

## Naming matters more than counting

`/VRI` keys entries by the **SHA-1 of a signature's `/Contents`**, so a store can carry material for one signature in a document that holds three. Counting certificates would answer the easy question and miss the real one.

`SecurityStore::covers($signature)` answers for a specific signature. `SignatureReport::hasLongTermMaterial()` answers for all of them at once, which is what B-LT actually promises.

## Three details, each pinned by a test that fails without it

**The dictionary is read by counting its own delimiters, not to the first `>>`.** `/VRI` nests:

```
<< /Type /DSS /VRI << /F39AB5... 25 0 R >> /Certs [ 24 0 R ] >>
```

A reader that stopped at the first `>>` would cut the store in half and report **no certificates at all**, which looks like a document without long-term material rather than like a bug.

**The last store is read, not the first**, for the same reason every other reader in this package does the same.

**An absent store and an empty one stay different answers.** B-B returns `null`, not a store of zeroes. "Carries nothing" and "carries the structure with nothing in it" are different documents.

## The arch rule needed a decision, not a shortcut

`arch('no weak hashing or insecure randomness')` bans `sha1`, correctly. The value here is **an identifier the PDF specification fixes** for `/VRI` keys, not a digest chosen for security, and computing it with anything else would simply fail to match.

So the exemption is scoped to one class rather than taken out of the rule:

```php
->ignoring('LSNepomuceno\LaravelA1PdfSign\Data\SignatureDetails');
```

A second use of `sha1` anywhere else still fails.

## Verification

Tested against `samples/pades-b-lt.pdf` and `pades-b-lta.pdf`, both committed, so no network is involved. `covers()` returning true on the real sample is what confirmed the VRI key really is the SHA-1 of `/Contents` rather than of something adjacent.

`composer check` on PHP 8.5: green, **152 tests**, up from 146.

## Remaining in 0010

Using the store to build chains from the embedded material rather than the network. The record says which of the three is built and which is not.