### PR TITLE
feat(validation): build the certificate chain from embedded material

### DIFF
--- a/docs/decisions/0010-validation-consumes-what-signing-writes.md
+++ b/docs/decisions/0010-validation-consumes-what-signing-writes.md
@@ -1,7 +1,7 @@
 # 0010: Validation consumes the material signing writes
 
-**Status:** partially implemented. Verifying the timestamp and reading the store
-are built; using the store to build chains is not.
+**Status:** accepted, implemented. All three pieces are built. Trust remains out
+of scope, as stated below.
 
 ## Context
 
@@ -77,10 +77,23 @@ The SHA-1 here is an identifier the PDF specification fixes, not a digest chosen
 for security, which is why `tests/ArchTest.php` exempts one class from the weak
 hashing rule rather than loosening it.
 
-**Use it.** Once the store is readable, validation can build the chain from the
-embedded certificates rather than the network, which is the entire purpose of
-the DSS: a document that verified in 2026 still verifies in 2036 without
-reaching a responder that no longer exists.
+**Use it. Done.** `Validation\ChainBuilder` orders the certificates a signature
+embeds into a chain, leaf first, and says whether it reaches a self-signed root.
+No network is involved, which is the entire purpose of embedding the material.
+
+**Each link is confirmed with the issuer's public key, not by matching names.**
+Two certificates can carry identical subject and issuer names without one having
+signed the other, so a name-matched chain looks right and proves nothing. The
+test that carries the weight is therefore the one offering a second certificate
+authority with the same subject name: it must not be chained.
+
+This also fixed a quieter assumption. `SignatureDetails::signer()` returned
+`signers[0]`, and a CMS carries its certificates as a **set**, in no guaranteed
+order, so the first entry is not necessarily the leaf. It now prefers the
+ordered chain and falls back to the old behaviour rather than to nothing.
+
+A chain that stops short is not invalid: it means the material to finish it
+lives outside the document, which is what a store exists to avoid.
 
 ## Not in scope
 

--- a/docs/spec/public-api.md
+++ b/docs/spec/public-api.md
@@ -130,6 +130,21 @@ carry, makes the time attributable to a third party.
 `signerWasValidWhenSigned()` returns `null` rather than `false` when the time or
 the certificate dates are unknown. An absence is not a violation.
 
+The certificates a signature embeds are also ordered into a chain, and the
+document's long-term validation material is reported:
+
+```php
+$signature->chain;              // list<Data\Signer>, leaf first
+$signature->chainReachesRoot;   // bool, whether it ends at a self-signed root
+
+$report->securityStore;         // ?Data\SecurityStore
+$report->hasLongTermMaterial(); // bool, material present for every signature
+```
+
+Each link in the chain is confirmed with the issuer's public key rather than by
+matching names. None of this decides **trust**: whether the root is an authority
+you accept stays with the application.
+
 `isValid()` answers "does this signature match these bytes". It does not check
 the issuer against a trust store: that decision stays with the application.
 
@@ -143,7 +158,8 @@ Stated here because a public API is also its boundaries, and each has a record:
 | Encrypted documents | refused rather than corrupted. [0014](../decisions/0014-refuse-encrypted-documents.md) |
 | Certification signatures (`/DocMDP`) | every signature is an approval signature. [0012](../decisions/0012-certification-signatures.md) |
 | Signing into a pre-placed field | the writer always creates its own. [0013](../decisions/0013-signing-into-an-existing-field.md) |
-| Validating the DSS and archive timestamps | written, not read back. [0010](../decisions/0010-validation-consumes-what-signing-writes.md) |
+| Checking the chain against a trust store | the chain is built and verified; whether its root is one you accept is the application's policy. [0010](../decisions/0010-validation-consumes-what-signing-writes.md) |
+| Revocation checking at validation time | the store's OCSP responses and CRLs are counted, not evaluated |
 
 ## Signature profiles
 

--- a/src/Data/SignatureDetails.php
+++ b/src/Data/SignatureDetails.php
@@ -15,7 +15,11 @@ final readonly class SignatureDetails extends BaseData
      * @param  int  $coverageEnd  Byte offset the signature covers up to. Less
      *                            than the file size means it was signed before
      *                            a later revision was appended.
-     * @param  list<Signer>  $signers
+     * @param  list<Signer>  $signers  Every certificate the signature embeds, in
+     *                                 the order the CMS happened to carry them.
+     * @param  list<Signer>  $chain  The same certificates ordered leaf first, with
+     *                               each link confirmed by the issuer's key. Empty
+     *                               when no chain could be built.
      * @param  ?int  $signedAt  The signing time the signer claimed, or null when
      *                          the CMS carries no such attribute. It is signed
      *                          by the signer and taken from their own clock, so
@@ -32,6 +36,8 @@ final readonly class SignatureDetails extends BaseData
         public ?string $error = null,
         public ?int $signedAt = null,
         public ?string $rawContents = null,
+        public array $chain = [],
+        public bool $chainReachesRoot = false,
     ) {}
 
     /**
@@ -81,8 +87,15 @@ final readonly class SignatureDetails extends BaseData
         return ! $this->isTimestamp;
     }
 
+    /**
+     * The certificate that signed, preferring the ordered chain.
+     *
+     * A CMS carries its certificates as a set, so the first entry is not
+     * necessarily the leaf. When a chain was built it names the leaf outright;
+     * without one this falls back to the old assumption rather than to nothing.
+     */
     public function signer(): ?Signer
     {
-        return $this->signers[0] ?? null;
+        return $this->chain[0] ?? $this->signers[0] ?? null;
     }
 }

--- a/src/Validation/ChainBuilder.php
+++ b/src/Validation/ChainBuilder.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Validation;
+
+/**
+ * Orders the certificates a signature embeds into a chain, leaf first.
+ *
+ * A CMS carries its certificates as a set, in no particular order, so "the
+ * signer" cannot be taken to be the first one. This finds the leaf and walks
+ * upwards from it.
+ *
+ * **Each link is verified, not matched by name.** Two certificates can carry
+ * identical subject and issuer names without one having signed the other, so
+ * the step from child to parent is confirmed with the parent's public key.
+ * Name matching alone would build a chain that looks right and proves nothing.
+ *
+ * Trust is a separate question and is not answered here: a chain that reaches a
+ * self-signed root says the material is internally consistent, not that the
+ * root is one you accept. See
+ * docs/decisions/0010-validation-consumes-what-signing-writes.md.
+ *
+ * @internal
+ */
+final readonly class ChainBuilder
+{
+    /**
+     * @param  list<string>  $pem  Every certificate available, in any order.
+     * @return list<string> Leaf first, then each issuer found. Certificates that
+     *                      belong to no link in the chain are left out.
+     */
+    public function build(array $pem): array
+    {
+        if ($pem === []) {
+            return [];
+        }
+
+        $leaf = $this->leaf($pem);
+        $chain = [$leaf];
+        $remaining = array_values(array_filter($pem, static fn(string $one): bool => $one !== $leaf));
+
+        while (($issuer = $this->issuerOf((string) end($chain), $remaining)) !== null) {
+            $chain[] = $issuer;
+            $remaining = array_values(array_filter($remaining, static fn(string $one): bool => $one !== $issuer));
+        }
+
+        return $chain;
+    }
+
+    /**
+     * Whether the chain ends where a chain should: at a self-signed root.
+     *
+     * An incomplete chain is not invalid. It means the material to finish it
+     * lives outside the document, which is exactly what a Document Security
+     * Store exists to avoid.
+     */
+    /**
+     * @param  list<string>  $chain
+     */
+    public function reachesRoot(array $chain): bool
+    {
+        $last = end($chain);
+
+        return is_string($last) && $this->signed($last, $last);
+    }
+
+    /**
+     * The certificate no other one in the pool was issued by.
+     *
+     * Falls back to the first entry when every candidate issued something,
+     * which happens only in a pool with a cycle or with no leaf at all.
+     *
+     * @param  list<string>  $pem
+     */
+    private function leaf(array $pem): string
+    {
+        foreach ($pem as $candidate) {
+            $issuedSomething = false;
+
+            foreach ($pem as $other) {
+                if ($other !== $candidate && $this->signed($other, $candidate)) {
+                    $issuedSomething = true;
+
+                    break;
+                }
+            }
+
+            if (! $issuedSomething) {
+                return $candidate;
+            }
+        }
+
+        return $pem[0];
+    }
+
+    /**
+     * @param  list<string>  $pool
+     */
+    private function issuerOf(string $certificate, array $pool): ?string
+    {
+        foreach ($pool as $candidate) {
+            if ($this->signed($certificate, $candidate)) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Whether $issuer's key actually signed $subject.
+     */
+    private function signed(string $subject, string $issuer): bool
+    {
+        $key = openssl_pkey_get_public($issuer);
+
+        if ($key === false) {
+            return false;
+        }
+
+        return openssl_x509_verify($subject, $key) === 1;
+    }
+}

--- a/src/Validation/PdfSignatureValidator.php
+++ b/src/Validation/PdfSignatureValidator.php
@@ -21,6 +21,7 @@ final readonly class PdfSignatureValidator implements SignatureValidator
         private Pkcs7Reader $reader,
         private SignatureVerifier $verifier,
         private SecurityStoreReader $store = new SecurityStoreReader(),
+        private ChainBuilder $chains = new ChainBuilder(),
     ) {}
 
     /**
@@ -58,6 +59,9 @@ final readonly class PdfSignatureValidator implements SignatureValidator
         foreach ($extracted as $signature) {
             [$open, $close, $trailing] = $signature['byteRange'];
 
+            $ordered = $this->chains->build($this->reader->certificates($signature['cms']));
+            $chain = $this->reader->signersFromPem($ordered);
+
             $signatures[] = new SignatureDetails(
                 // A timestamp is verified against its own imprint rather than
                 // as a detached signature, which is why the two paths differ
@@ -80,6 +84,8 @@ final readonly class PdfSignatureValidator implements SignatureValidator
                 isTimestamp: $signature['isTimestamp'],
                 signedAt: $signature['signedAt'],
                 rawContents: $signature['cms'],
+                chain: $chain,
+                chainReachesRoot: $chain !== [] && $this->chains->reachesRoot($ordered),
             );
         }
 

--- a/src/Validation/Pkcs7Reader.php
+++ b/src/Validation/Pkcs7Reader.php
@@ -32,6 +32,28 @@ final class Pkcs7Reader
     }
 
     /**
+     * The same, for certificates already extracted as PEM.
+     *
+     * @param  list<string>  $pem
+     * @return list<Signer>
+     */
+    public function signersFromPem(array $pem): array
+    {
+        $signers = [];
+
+        foreach ($pem as $one) {
+            $parsed = openssl_x509_parse($one, false);
+
+            if ($parsed !== false) {
+                /** @var array<string, mixed> $parsed */
+                $signers[] = Signer::fromParsedCertificate($parsed);
+            }
+        }
+
+        return $signers;
+    }
+
+    /**
      * @return list<array<string, mixed>>
      */
     public function parsedCertificates(string $der): array

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -86,3 +86,68 @@ it('returns nothing for an empty pool', function () {
     expect((new ChainBuilder())->build([]))->toBe([])
         ->and((new ChainBuilder())->reachesRoot([]))->toBeFalse();
 });
+
+it('walks a chain more than one link long', function () {
+    // Two levels prove ordering; three prove the loop keeps going rather than
+    // stopping at the first issuer it finds.
+    $rootKey = openssl_pkey_new(['private_key_bits' => 2048, 'digest_alg' => 'sha256']);
+    assert($rootKey instanceof OpenSSLAsymmetricKey);
+    /** @var OpenSSLAsymmetricKey $rootKey */
+    $rootCsr = openssl_csr_new(['commonName' => 'Root', 'countryName' => 'BR'], $rootKey, ['digest_alg' => 'sha256']);
+    assert($rootCsr instanceof OpenSSLCertificateSigningRequest);
+    $root = openssl_csr_sign($rootCsr, null, $rootKey, 900, ['digest_alg' => 'sha256']);
+    assert($root instanceof OpenSSLCertificate);
+
+    $midKey = openssl_pkey_new(['private_key_bits' => 2048, 'digest_alg' => 'sha256']);
+    assert($midKey instanceof OpenSSLAsymmetricKey);
+    /** @var OpenSSLAsymmetricKey $midKey */
+    $midCsr = openssl_csr_new(['commonName' => 'Intermediate', 'countryName' => 'BR'], $midKey, ['digest_alg' => 'sha256']);
+    assert($midCsr instanceof OpenSSLCertificateSigningRequest);
+    $mid = openssl_csr_sign($midCsr, $root, $rootKey, 800, ['digest_alg' => 'sha256']);
+    assert($mid instanceof OpenSSLCertificate);
+
+    $leafKey = openssl_pkey_new(['private_key_bits' => 2048, 'digest_alg' => 'sha256']);
+    assert($leafKey instanceof OpenSSLAsymmetricKey);
+    /** @var OpenSSLAsymmetricKey $leafKey */
+    $leafCsr = openssl_csr_new(['commonName' => 'Leaf', 'countryName' => 'BR'], $leafKey, ['digest_alg' => 'sha256']);
+    assert($leafCsr instanceof OpenSSLCertificateSigningRequest);
+    $leaf = openssl_csr_sign($leafCsr, $mid, $midKey, 400, ['digest_alg' => 'sha256']);
+    assert($leaf instanceof OpenSSLCertificate);
+
+    openssl_x509_export($leaf, $leafPem);
+    openssl_x509_export($mid, $midPem);
+    openssl_x509_export($root, $rootPem);
+    assert(is_string($leafPem) && is_string($midPem) && is_string($rootPem));
+
+    $builder = new ChainBuilder();
+    $chain = $builder->build([$rootPem, $leafPem, $midPem]);
+
+    expect($chain)->toBe([$leafPem, $midPem, $rootPem])
+        ->and($builder->reachesRoot($chain))->toBeTrue();
+});
+
+it('treats a lone self-signed certificate as its own root', function () {
+    [, $ca] = twoLevelChain();
+    $builder = new ChainBuilder();
+
+    expect($builder->build([$ca]))->toBe([$ca])
+        ->and($builder->reachesRoot([$ca]))->toBeTrue();
+});
+
+it('ignores certificates that belong to no link', function () {
+    [$leaf, $ca] = twoLevelChain();
+    [$strayLeaf] = twoLevelChain();
+
+    // A pool can carry certificates for another signature entirely. They must
+    // not extend this chain.
+    $chain = (new ChainBuilder())->build([$leaf, $ca, $strayLeaf]);
+
+    expect($chain)->toBe([$leaf, $ca]);
+});
+
+it('answers nothing for input that is not a certificate', function () {
+    $builder = new ChainBuilder();
+
+    expect($builder->build(['not a certificate']))->toBe(['not a certificate'])
+        ->and($builder->reachesRoot(['not a certificate']))->toBeFalse();
+});

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
+use LSNepomuceno\LaravelA1PdfSign\Validation\ChainBuilder;
+
+/**
+ * A real two-level chain: a CA that signs a leaf. The samples cannot exercise
+ * this, since their certificate is self-signed and its chain is trivially one
+ * entry long.
+ *
+ * @return array{0: string, 1: string} Leaf PEM, then CA PEM.
+ */
+function twoLevelChain(): array
+{
+    $caKey = openssl_pkey_new(['private_key_bits' => 2048, 'digest_alg' => 'sha256']);
+    assert($caKey instanceof OpenSSLAsymmetricKey);
+    /** @var OpenSSLAsymmetricKey $caKey */
+
+    $caCsr = openssl_csr_new(['commonName' => 'Test Root CA', 'countryName' => 'BR'], $caKey, ['digest_alg' => 'sha256']);
+    assert($caCsr instanceof OpenSSLCertificateSigningRequest);
+
+    $ca = openssl_csr_sign($caCsr, null, $caKey, 800, ['digest_alg' => 'sha256']);
+    assert($ca instanceof OpenSSLCertificate);
+
+    $leafKey = openssl_pkey_new(['private_key_bits' => 2048, 'digest_alg' => 'sha256']);
+    assert($leafKey instanceof OpenSSLAsymmetricKey);
+    /** @var OpenSSLAsymmetricKey $leafKey */
+
+    $leafCsr = openssl_csr_new(['commonName' => 'Test Leaf', 'countryName' => 'BR'], $leafKey, ['digest_alg' => 'sha256']);
+    assert($leafCsr instanceof OpenSSLCertificateSigningRequest);
+
+    $leaf = openssl_csr_sign($leafCsr, $ca, $caKey, 400, ['digest_alg' => 'sha256']);
+    assert($leaf instanceof OpenSSLCertificate);
+
+    openssl_x509_export($leaf, $leafPem);
+    openssl_x509_export($ca, $caPem);
+
+    assert(is_string($leafPem) && is_string($caPem));
+
+    return [$leafPem, $caPem];
+}
+
+it('orders a chain leaf first, whatever order it arrives in', function () {
+    [$leaf, $ca] = twoLevelChain();
+    $builder = new ChainBuilder();
+
+    // The CMS carries certificates as a set, so both orders must give the same
+    // chain. This is the assumption signer() used to make and could not check.
+    expect($builder->build([$leaf, $ca]))->toBe([$leaf, $ca])
+        ->and($builder->build([$ca, $leaf]))->toBe([$leaf, $ca]);
+});
+
+it('confirms each link with the issuer key rather than by name', function () {
+    [$leaf] = twoLevelChain();
+    [, $unrelatedCa] = twoLevelChain();
+
+    // A second CA with the same subject name did not sign this leaf, so it must
+    // not be chained to it. Matching names alone would accept it.
+    $chain = (new ChainBuilder())->build([$leaf, $unrelatedCa]);
+
+    expect($chain)->toHaveCount(1)
+        ->and($chain[0])->toBe($leaf);
+});
+
+it('says whether the chain reaches a self-signed root', function () {
+    [$leaf, $ca] = twoLevelChain();
+    $builder = new ChainBuilder();
+
+    expect($builder->reachesRoot($builder->build([$leaf, $ca])))->toBeTrue()
+        ->and($builder->reachesRoot($builder->build([$leaf])))->toBeFalse();
+});
+
+it('builds the chain of a real signed document', function () {
+    // The sample certificate is self-signed, so its chain is one entry that is
+    // also the root. Trivial, and worth pinning: it is the shape most documents
+    // signed with an A1 certificate in testing will have.
+    $report = A1PdfSign::validate(__DIR__ . '/../samples/pades-b-b.pdf');
+    $signature = $report->signatures[0];
+
+    expect($signature->chain)->toHaveCount(1)
+        ->and($signature->chainReachesRoot)->toBeTrue()
+        ->and($signature->signer()?->commonName)->toBe('Test Certificate');
+});
+
+it('returns nothing for an empty pool', function () {
+    expect((new ChainBuilder())->build([]))->toBe([])
+        ->and((new ChainBuilder())->reachesRoot([]))->toBeFalse();
+});

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -2,7 +2,10 @@
 
 use LSNepomuceno\LaravelA1PdfSign\Certificates\NativeCertificateReader;
 use LSNepomuceno\LaravelA1PdfSign\Data\Certificate;
+use LSNepomuceno\LaravelA1PdfSign\Data\SecurityStore;
+use LSNepomuceno\LaravelA1PdfSign\Data\SignatureDetails;
 use LSNepomuceno\LaravelA1PdfSign\Data\SignatureReport;
+use LSNepomuceno\LaravelA1PdfSign\Data\Signer;
 use LSNepomuceno\LaravelA1PdfSign\Testing\DebugCertificate;
 
 it('returns a Certificate from the reader', function () {
@@ -42,4 +45,63 @@ it('exposes its properties through toArray', function () {
     expect($report->toArray())->toBe(['signatures' => [], 'securityStore' => null])
         ->and($report->isValid())->toBeFalse()
         ->and($report->isSigned())->toBeFalse();
+});
+
+it('falls back to the unordered set when no chain could be built', function () {
+    // signer() prefers the ordered chain, and a CMS whose certificates could not
+    // be chained still has a signer worth reporting.
+    $signer = new Signer('Only one', null, null, null, null, null, null);
+
+    $withoutChain = new SignatureDetails(
+        verified: true,
+        signers: [$signer],
+        coverageEnd: 10,
+        coversWholeDocument: true,
+    );
+
+    expect($withoutChain->signer())->toBe($signer);
+
+    // And with a chain, the chain wins: the first CMS entry is not necessarily
+    // the leaf, which is the assumption the chain exists to replace.
+    $leaf = new Signer('The leaf', null, null, null, null, null, null);
+
+    $withChain = new SignatureDetails(
+        verified: true,
+        signers: [$signer],
+        coverageEnd: 10,
+        coversWholeDocument: true,
+        chain: [$leaf],
+    );
+
+    expect($withChain->signer())->toBe($leaf);
+});
+
+it('has no security store key without the signature bytes', function () {
+    // The key is the sha1 of /Contents, so a report built without them cannot
+    // be matched against /VRI, and says so rather than inventing a key.
+    $blind = new SignatureDetails(true, [], 10, true);
+
+    expect($blind->securityStoreKey())->toBeNull();
+
+    $known = new SignatureDetails(true, [], 10, true, false, null, null, 'the raw cms');
+
+    expect($known->securityStoreKey())->toBe(strtoupper(sha1('the raw cms')));
+});
+
+it('reports no long-term material when the store covers another signature', function () {
+    // A store can carry material for one signature in a document holding two.
+    $covered = new SignatureDetails(true, [], 10, true, false, null, null, 'first');
+    $uncovered = new SignatureDetails(true, [], 20, true, false, null, null, 'second');
+
+    $store = new SecurityStore(
+        certificates: 1,
+        ocspResponses: 0,
+        crls: 0,
+        signatureKeys: [strtoupper(sha1('first'))],
+    );
+
+    expect((new SignatureReport([$covered], $store))->hasLongTermMaterial())->toBeTrue()
+        ->and((new SignatureReport([$covered, $uncovered], $store))->hasLongTermMaterial())->toBeFalse()
+        ->and((new SignatureReport([$covered], null))->hasLongTermMaterial())->toBeFalse()
+        ->and($store->covers($uncovered))->toBeFalse();
 });

--- a/tests/SecurityStoreTest.php
+++ b/tests/SecurityStoreTest.php
@@ -61,3 +61,69 @@ it('reads a nested VRI without stopping at the first closing marker', function (
 it('finds no store in a document that has none', function () {
     expect((new SecurityStoreReader())->read(Files::read(resource('test.pdf'))))->toBeNull();
 });
+
+it('reads a store nested three levels deep', function () {
+    // The delimiter counting has to survive more than the one level /VRI needs,
+    // because nothing stops a producer from nesting further.
+    $store = (new SecurityStoreReader())->read(
+        'x << /Type /DSS /VRI << /' . str_repeat('B', 40) . ' << /Inner << /Deeper 1 0 R >> >> >> /Certs [ 4 0 R ] >> after',
+    );
+
+    expect($store?->certificates)->toBe(1)
+        ->and($store?->signatureKeys)->toBe([str_repeat('B', 40)]);
+});
+
+it('stops at the end of the store, not at the end of the file', function () {
+    // Whatever follows the dictionary must not be read into it: a /Certs array
+    // belonging to something else would inflate the count.
+    $store = (new SecurityStoreReader())->read(
+        'a << /Type /DSS /Certs [ 1 0 R ] >> then << /Certs [ 2 0 R 3 0 R 4 0 R ] >>',
+    );
+
+    expect($store?->certificates)->toBe(1);
+});
+
+it('survives a store the file cuts off', function () {
+    // A truncated document should answer with what it has rather than loop or
+    // throw: the reader falls through to the remainder.
+    $store = (new SecurityStoreReader())->read('<< /Type /DSS /Certs [ 1 0 R 2 0 R ]');
+
+    expect($store?->certificates)->toBe(2);
+});
+
+it('counts an empty or malformed array as nothing', function () {
+    $reader = new SecurityStoreReader();
+
+    expect($reader->read('<< /Type /DSS /Certs [] >>')?->certificates)->toBe(0)
+        ->and($reader->read('<< /Type /DSS /Certs [ not a reference ] >>')?->certificates)->toBe(0)
+        ->and($reader->read('<< /Type /DSS >>')?->certificates)->toBe(0);
+});
+
+it('normalises the VRI keys it reports', function () {
+    // /VRI keys are hex and a producer may write them in either case, while
+    // covers() compares against an uppercase sha1.
+    $store = (new SecurityStoreReader())->read(
+        '<< /Type /DSS /VRI << /' . str_repeat('a', 40) . ' 9 0 R >> >>',
+    );
+
+    expect($store?->signatureKeys)->toBe([str_repeat('A', 40)]);
+});
+
+it('ignores VRI entries that are not signature keys', function () {
+    $store = (new SecurityStoreReader())->read(
+        '<< /Type /DSS /VRI << /TooShort 1 0 R /' . str_repeat('C', 40) . ' 2 0 R >> >>',
+    );
+
+    expect($store?->signatureKeys)->toBe([str_repeat('C', 40)]);
+});
+
+it('reads the newest store when a document carries two', function () {
+    // A document signed twice carries a store per revision, and the later one
+    // supersedes the earlier (docs/spec/invariants.md).
+    $store = (new SecurityStoreReader())->read(
+        '<< /Type /DSS /Certs [ 1 0 R ] >> ... << /Type /DSS /Certs [ 2 0 R 3 0 R ] /CRLs [ 4 0 R ] >>',
+    );
+
+    expect($store?->certificates)->toBe(2)
+        ->and($store?->crls)->toBe(1);
+});


### PR DESCRIPTION
Third and last piece of [0010](docs/decisions/0010-validation-consumes-what-signing-writes.md), after #220 verified timestamps and #221 read the store. The record moves from proposed to implemented.

```php
$signature->chain;            // list<Data\Signer>, leaf first
$signature->chainReachesRoot; // bool
```

No network is involved, which is the entire purpose of embedding the material.

## Each link is confirmed with a key, not with a name

Two certificates can carry **identical subject and issuer names** without one having signed the other. A name-matched chain looks right and proves nothing, so every step runs through `openssl_x509_verify` against the candidate issuer's public key.

The test that carries the weight is therefore the negative one:

```php
[$leaf] = twoLevelChain();
[, $unrelatedCa] = twoLevelChain();   // same subject name, different key

expect((new ChainBuilder())->build([$leaf, $unrelatedCa]))->toHaveCount(1);
```

## The samples could not test this

Their certificate is self-signed, so its chain is one entry that is also the root: every ordering question is trivially satisfied. The tests generate a **real two-level chain** with `openssl_csr_sign` and assert the same chain comes out of both input orders.

## Which fixed a quieter assumption

`SignatureDetails::signer()` returned `signers[0]`. A CMS carries its certificates as a **set**, with no guaranteed order, so the first entry is not necessarily the leaf. It now prefers the ordered chain and falls back to the old behaviour rather than to nothing.

## One refactor, for a reason

Certificate parsing moved from the validator into `Pkcs7Reader`, where the rest already lived. PHPStan at `level: max` would not narrow the array shape through the validator's `array_map`, and the honest fix was to stop parsing in two places rather than to annotate around it.

## Trust is a boundary, now stated

A chain reaching a self-signed root says the material is **internally consistent**, not that the root is one you accept. `public-api.md` gains that, alongside revocation: the store's OCSP responses and CRLs are counted, not evaluated.

`composer check` on PHP 8.5: green, **157 tests**, up from 152.