### PR TITLE
feat(signing): read cross-reference streams, and refuse to write them

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     "ext-json": "*",
     "ext-mbstring": "*",
     "ext-openssl": "*",
+    "ext-zlib": "*",
     "illuminate/console": "^13",
     "illuminate/encryption": "^13",
     "illuminate/http": "^13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c079cb6327ad54c16b7d11bce705c5c3",
+    "content-hash": "ab624df52199e40744e1d731127ddd2c",
     "packages": [
         {
             "name": "brick/math",
@@ -11577,7 +11577,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {},
-    "prefer-stable": true,
+    "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.4 <8.6",
@@ -11585,7 +11585,8 @@
         "ext-gd": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "ext-openssl": "*"
+        "ext-openssl": "*",
+        "ext-zlib": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/docs/decisions/0009-cross-reference-streams.md
+++ b/docs/decisions/0009-cross-reference-streams.md
@@ -1,7 +1,8 @@
 # 0009: Cross-reference streams
 
-**Status:** proposed. The measurement below is done and the rejection is
-already correct; reading support is not built.
+**Status:** partially implemented. Reading is built. Writing is not, and the
+measurement below says why that distinction had to be enforced rather than
+assumed.
 
 ## Context
 
@@ -68,9 +69,40 @@ rewriting.
   predates PDF 1.5 tolerance, because the failure mode is "opens here, refuses
   there" rather than an exception.
 
-## Until it is built
+## What the writing measurement said
 
-`tests/Resources/xref-stream.pdf` is committed and a test asserts the current
-rejection by message, not only by class. That keeps the boundary honest: if
-someone implements reading, the test fails and has to be rewritten
-deliberately rather than silently passing.
+Reading landed first, and signing was then tried on the fixture to answer the
+question above rather than guess at it. It appeared to work:
+
+```
+ASSINOU: 17376 bytes
+```
+
+poppler disagreed:
+
+```
+File '.output/xref-signed.pdf' does not contain any signatures
+```
+
+**So appending a classic table to a document whose latest section is a stream
+produces a file that no reader sees as signed, and produces it silently.** That
+is worse than the refusal it replaced, and it is the failure mode
+[0014](0014-refuse-encrypted-documents.md) exists to prevent: a guard is not a
+substitute for the feature, but silence is worse than either.
+
+Signing therefore refuses while reading succeeds. `DocumentInfo` carries
+`usesXrefStream` so the signer can tell, and the message says the document can
+be read but not yet appended to, which is the true state.
+
+The remaining work is the writing choice this record already framed, now with
+evidence that option 2, the classic table with `/Prev` into a stream, is not
+viable on its own.
+
+## The boundary tests
+
+`tests/Resources/xref-stream.pdf` is committed, hand-built and 434 bytes.
+
+The test that asserted the old refusal did exactly what it was written to do:
+it failed the moment reading landed, and had to be rewritten deliberately. A
+second test now pins the signing refusal the same way, by message, so whoever
+builds the writing half has to come here and change it on purpose.

--- a/src/Signing/Incremental/DocumentInfo.php
+++ b/src/Signing/Incremental/DocumentInfo.php
@@ -19,6 +19,7 @@ final readonly class DocumentInfo
         public int $root,
         public ?string $infoRef,
         public int $startxref,
+        public bool $usesXrefStream = false,
     ) {}
 
     /**

--- a/src/Signing/Incremental/DocumentReader.php
+++ b/src/Signing/Incremental/DocumentReader.php
@@ -8,13 +8,16 @@ use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidPdfFileException;
  * Reads the cross-reference chain of an existing PDF.
  *
  * Clean-room implementation from ISO 32000-1 §7.5.4 and §7.5.6. Scope is the
- * classic cross-reference table; cross-reference streams (PDF 1.5+) are
- * detected and rejected rather than mis-parsed.
+ * Both cross-reference forms are read: the classic table of §7.5.4 and the
+ * cross-reference stream of §7.5.8, which PDF 1.5 introduced and most modern
+ * generators emit.
  *
  * @internal
  */
 final class DocumentReader
 {
+    public function __construct(private readonly XrefStreamReader $streams = new XrefStreamReader()) {}
+
     /**
      * Walks the /Prev chain and returns the effective view of the document.
      *
@@ -43,12 +46,14 @@ final class DocumentReader
         $size = 0;
         $root = 0;
         $infoRef = null;
+        $usesStream = false;
 
         // The chain runs newest to oldest, so walk it reversed and let the most
         // recent entries win.
         foreach (array_reverse($chain) as $section) {
             $xref = array_replace($xref, $section['xref']);
             $size = max($size, $section['size']);
+            $usesStream = $usesStream || $section['stream'];
 
             if ($section['root'] > 0) {
                 $root = $section['root'];
@@ -63,7 +68,7 @@ final class DocumentReader
             throw new InvalidPdfFileException('no /Root entry found in any trailer');
         }
 
-        return new DocumentInfo($xref, $size, $root, $infoRef, $latest);
+        return new DocumentInfo($xref, $size, $root, $infoRef, $latest, $usesStream);
     }
 
     /**
@@ -110,15 +115,22 @@ final class DocumentReader
     }
 
     /**
-     * @return array{xref: array<int, int>, size: int, root: int, infoRef: ?string, prev: int}
+     * @return array{xref: array<int, int>, size: int, root: int, infoRef: ?string, prev: int, stream: bool}
      *
      * @throws InvalidPdfFileException
      */
     private function readSection(string $pdf, int $offset): array
     {
         if (! str_starts_with(ltrim(substr($pdf, $offset, 32)), 'xref')) {
+            // PDF 1.5 packs the same table into a stream object. Reading only
+            // the classic form bounded the package to documents older tools
+            // produce (docs/decisions/0009-cross-reference-streams.md).
+            if ($this->streams->handles($pdf, $offset)) {
+                return $this->streams->read($pdf, $offset);
+            }
+
             throw new InvalidPdfFileException(
-                "cross-reference stream at offset {$offset} is not supported; only classic tables are read",
+                "the cross-reference section at offset {$offset} is neither a table nor a stream",
             );
         }
 
@@ -179,6 +191,7 @@ final class DocumentReader
             'root' => isset($root[1]) ? (int) $root[1] : 0,
             'infoRef' => $info[1] ?? null,
             'prev' => isset($prev[1]) ? (int) $prev[1] : 0,
+            'stream' => false,
         ];
     }
 }

--- a/src/Signing/Incremental/XrefStreamReader.php
+++ b/src/Signing/Incremental/XrefStreamReader.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Signing\Incremental;
+
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidPdfFileException;
+
+/**
+ * Reads a cross-reference stream, ISO 32000-1 §7.5.8.
+ *
+ * PDF 1.5 replaced the classic table with a stream object whose data is a
+ * packed table of fixed-width fields, so the same information arrives
+ * compressed and as an ordinary object. Word, "print to PDF" in Chrome, LaTeX
+ * with compression and most modern generators emit this form, which is why
+ * reading only classic tables bounded who could use the package.
+ *
+ * See docs/decisions/0009-cross-reference-streams.md.
+ *
+ * @internal
+ */
+final readonly class XrefStreamReader
+{
+    /**
+     * Whether the section at this offset is a stream rather than a table.
+     */
+    public function handles(string $pdf, int $offset): bool
+    {
+        return preg_match('/^\s*\d+\s+\d+\s+obj\b/', substr($pdf, $offset, 64)) === 1;
+    }
+
+    /**
+     * @return array{xref: array<int, int>, size: int, root: int, infoRef: ?string, prev: int, stream: bool}
+     *
+     * @throws InvalidPdfFileException
+     */
+    public function read(string $pdf, int $offset): array
+    {
+        $dictionary = $this->dictionary($pdf, $offset);
+
+        if (! str_contains($dictionary, '/XRef')) {
+            throw new InvalidPdfFileException(
+                "the object at offset {$offset} is not a cross-reference stream",
+            );
+        }
+
+        $widths = $this->widths($dictionary, $offset);
+        $size = $this->integer($dictionary, 'Size');
+
+        return [
+            'xref' => $this->entries($this->data($pdf, $offset, $dictionary), $widths, $this->index($dictionary, $size)),
+            'size' => $size,
+            'root' => $this->reference($dictionary, 'Root'),
+            'infoRef' => $this->rawReference($dictionary, 'Info'),
+            'prev' => $this->integer($dictionary, 'Prev'),
+            'stream' => true,
+        ];
+    }
+
+    /**
+     * @throws InvalidPdfFileException
+     */
+    private function dictionary(string $pdf, int $offset): string
+    {
+        $start = strpos($pdf, '<<', $offset);
+        $end = strpos($pdf, 'stream', $offset);
+
+        if ($start === false || $end === false || $start > $end) {
+            throw new InvalidPdfFileException("no stream dictionary at offset {$offset}");
+        }
+
+        return substr($pdf, $start, $end - $start);
+    }
+
+    /**
+     * The stream's bytes, decoded through whichever filter it declares.
+     *
+     * @throws InvalidPdfFileException
+     */
+    private function data(string $pdf, int $offset, string $dictionary): string
+    {
+        $keyword = strpos($pdf, 'stream', $offset);
+
+        if ($keyword === false) {
+            throw new InvalidPdfFileException("no stream keyword at offset {$offset}");
+        }
+
+        // "stream" is followed by CRLF or LF, and by nothing else.
+        $start = $keyword + 6;
+        $start += str_starts_with(substr($pdf, $start, 2), "\r\n") ? 2 : 1;
+
+        $length = $this->integer($dictionary, 'Length');
+
+        if ($length < 1) {
+            $end = strpos($pdf, 'endstream', $start);
+            $length = ($end === false ? strlen($pdf) : $end) - $start;
+        }
+
+        $raw = substr($pdf, $start, $length);
+
+        if (! str_contains($dictionary, '/Filter')) {
+            return $raw;
+        }
+
+        if (preg_match('/\/Filter\s*\/(FlateDecode|ASCIIHexDecode)/', $dictionary, $filter) !== 1) {
+            throw new InvalidPdfFileException(
+                'the cross-reference stream uses a filter this package does not decode: ' . $dictionary,
+            );
+        }
+
+        $decoded = $filter[1] === 'FlateDecode' ? @gzuncompress($raw) : @hex2bin(trim($raw, "> \n\r\t"));
+
+        if ($decoded === false) {
+            throw new InvalidPdfFileException("the cross-reference stream at offset {$offset} could not be decoded");
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * The field widths from /W, which say how many bytes each of the three
+     * columns takes. A width of zero means the field is absent and takes its
+     * default, which for the type column is 1.
+     *
+     * @return array{0: int, 1: int, 2: int}
+     *
+     * @throws InvalidPdfFileException
+     */
+    private function widths(string $dictionary, int $offset): array
+    {
+        if (preg_match('/\/W\s*\[\s*(\d+)\s+(\d+)\s+(\d+)/', $dictionary, $found) !== 1) {
+            throw new InvalidPdfFileException("the cross-reference stream at offset {$offset} declares no /W");
+        }
+
+        return [(int) $found[1], (int) $found[2], (int) $found[3]];
+    }
+
+    /**
+     * The object ranges the stream describes, defaulting to all of them.
+     *
+     * @return list<array{0: int, 1: int}>
+     */
+    private function index(string $dictionary, int $size): array
+    {
+        if (preg_match('/\/Index\s*\[([^\]]*)\]/', $dictionary, $found) !== 1) {
+            return [[0, $size]];
+        }
+
+        preg_match_all('/\d+/', $found[1], $numbers);
+
+        $ranges = [];
+
+        for ($i = 0; $i + 1 < count($numbers[0]); $i += 2) {
+            $ranges[] = [(int) $numbers[0][$i], (int) $numbers[0][$i + 1]];
+        }
+
+        return $ranges;
+    }
+
+    /**
+     * @param  array{0: int, 1: int, 2: int}  $widths
+     * @param  list<array{0: int, 1: int}>  $index
+     * @return array<int, int>
+     */
+    private function entries(string $data, array $widths, array $index): array
+    {
+        $row = array_sum($widths);
+        $xref = [];
+        $position = 0;
+
+        foreach ($index as [$first, $count]) {
+            for ($i = 0; $i < $count; $i++) {
+                if ($position + $row > strlen($data)) {
+                    return $xref;
+                }
+
+                $type = $widths[0] === 0 ? 1 : $this->field($data, $position, $widths[0]);
+                $offset = $this->field($data, $position + $widths[0], $widths[1]);
+                $position += $row;
+
+                // Type 1 is an ordinary object at a byte offset. Type 0 is free
+                // and type 2 lives inside an object stream, neither of which
+                // this signer needs: it appends objects rather than rewriting
+                // the ones already there.
+                if ($type === 1) {
+                    $xref[$first + $i] = $offset;
+                }
+            }
+        }
+
+        return $xref;
+    }
+
+    /**
+     * One big-endian field of $width bytes.
+     */
+    private function field(string $data, int $position, int $width): int
+    {
+        $value = 0;
+
+        for ($i = 0; $i < $width; $i++) {
+            $value = ($value << 8) | ord($data[$position + $i] ?? "\x00");
+        }
+
+        return $value;
+    }
+
+    private function integer(string $dictionary, string $key): int
+    {
+        return preg_match('/\/' . $key . '\s+(\d+)/', $dictionary, $found) === 1 ? (int) $found[1] : 0;
+    }
+
+    private function reference(string $dictionary, string $key): int
+    {
+        return preg_match('/\/' . $key . '\s+(\d+)\s+\d+\s+R/', $dictionary, $found) === 1 ? (int) $found[1] : 0;
+    }
+
+    private function rawReference(string $dictionary, string $key): ?string
+    {
+        return preg_match('/\/' . $key . '\s+(\d+\s+\d+\s+R)/', $dictionary, $found) === 1 ? $found[1] : null;
+    }
+}

--- a/src/Signing/IncrementalSigner.php
+++ b/src/Signing/IncrementalSigner.php
@@ -61,6 +61,18 @@ final readonly class IncrementalSigner implements PdfSigner
 
         $document = $this->reader->read($pdfContents);
 
+        // Reading a cross-reference stream works; appending a revision that a
+        // reader accepts does not, and the difference is silent. Measured on
+        // 2026-08-09: signing produced 17376 bytes that poppler reports as
+        // carrying no signature at all. Refusing is worse for reach and far
+        // better than handing back a file that looks signed and is not.
+        // See docs/decisions/0009-cross-reference-streams.md.
+        if ($document->usesXrefStream) {
+            throw new InvalidPdfFileException(
+                'this document uses a cross-reference stream (PDF 1.5+), which can be read but not yet appended to; signing it would produce a file readers do not see as signed',
+            );
+        }
+
         $withRevision = $this->writer->append(
             $pdfContents,
             $document,

--- a/tests/SigningIncrementalTest.php
+++ b/tests/SigningIncrementalTest.php
@@ -123,13 +123,15 @@ it('lets the caller choose the transport after signing', function () {
     unlink($path);
 });
 
-it('refuses a cross-reference stream, and says so', function () {
-    // PDF 1.5 is from 2003 and this format is what most modern generators
-    // emit, so the boundary is worth pinning by message rather than by class.
-    // When reading support lands (docs/decisions/0009-cross-reference-streams.md)
-    // this test fails and has to be rewritten deliberately.
-    expect(fn() => app(DocumentReader::class)->read(Files::read(resource('xref-stream.pdf'))))
-        ->toThrow(InvalidPdfFileException::class, 'cross-reference stream');
+it('reads a cross-reference stream', function () {
+    // This asserted a refusal until reading landed, which is what the boundary
+    // test was for (docs/decisions/0009-cross-reference-streams.md). PDF 1.5 is
+    // from 2003 and this is the form most modern generators emit.
+    $document = app(DocumentReader::class)->read(Files::read(resource('xref-stream.pdf')));
+
+    expect($document->root)->toBe(1)
+        ->and($document->size)->toBe(6)
+        ->and($document->xref)->toHaveKeys([1, 2, 3, 4, 5]);
 });
 
 it('refuses an encrypted document rather than corrupting it', function () {
@@ -158,4 +160,18 @@ it('names the structural fault instead of blaming the file extension', function 
 it('keeps the extension message for the one case that meant it', function () {
     expect(InvalidPdfFileException::extension('/tmp/contract.docx')->getMessage())
         ->toBe('Invalid file extension, accept only ".pdf" extension files. Current file: /tmp/contract.docx.');
+});
+
+it('refuses to sign a cross-reference stream until it can append to one', function () {
+    // Reading works; appending a revision a reader accepts does not. Measured
+    // on 2026-08-09: signing produced 17376 bytes that poppler reports as
+    // carrying no signature at all, so this refuses rather than hands back a
+    // file that looks signed and is not.
+    [$pfxPath, $password] = debugCertificate();
+
+    expect(fn() => A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdf(resource('xref-stream.pdf'))
+        ->sign())
+        ->toThrow(InvalidPdfFileException::class, 'cross-reference stream');
 });


### PR DESCRIPTION
Half of [0009](docs/decisions/0009-cross-reference-streams.md), and the half that is safe to ship.

## Reading is built

`/Type /XRef` recognised, the stream decoded through its filter, entries walked by the widths in `/W`, `/Index` honoured. Type 2 entries inside object streams are skipped rather than resolved, which is sound here: the signer appends objects rather than rewriting the ones already there.

PDF 1.5 is from 2003 and this is what Word, print-to-PDF, LaTeX with compression and most modern generators emit, so reading only classic tables bounded who could use the package.

## Then signing was measured, not assumed

The record asked for the writing choice to be measured. It was. Signing the fixture appeared to work:

```
ASSINOU: 17376 bytes
```

poppler disagreed:

```
File '.output/xref-signed.pdf' does not contain any signatures
```

**Appending a classic table to a document whose latest section is a stream produces a file no reader sees as signed, and produces it silently.**

That is worse than the refusal it would have replaced. It is exactly the failure [0014](docs/decisions/0014-refuse-encrypted-documents.md) exists to prevent, and shipping the reading half alone would have turned a loud refusal into quiet corruption, which is the one trade never worth making in a signing library.

So **signing refuses while reading succeeds**, and the message says the document can be read but not yet appended to, which is the true state. `DocumentInfo` carries `usesXrefStream` to tell them apart.

## The boundary test earned its keep twice

It failed the moment reading landed, as it was written to, and had to be rewritten deliberately rather than passing silently. A second test now pins the signing refusal the same way, by message, so whoever builds the writing half has to come here and change it on purpose.

## One finding from the tooling

`ext-zlib` is now declared. `gzuncompress` made it a shadow dependency and the analyser caught it.

`composer check` on PHP 8.5: green, **172 tests**.

## What remains of 0009

The writing half, now with evidence that the classic table with `/Prev` into a stream is not viable on its own. The remaining option is appending a cross-reference stream, which the record describes.