### PR TITLE
docs: prepare the 2.2 release

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,109 @@
 # Upgrading
 
+## From 2.1 to 2.2
+
+2.2 is additive for applications. Nothing was removed, no behaviour changed for
+code that already worked, and the PHP and Laravel requirements do not move. An
+application that signs and validates upgrades without editing anything.
+
+Two changes reach code that **extends** the package rather than calls it, and
+one reaches anyone who compares a report's array form byte for byte.
+
+### The contracts gained methods and parameters
+
+| | 2.1 | 2.2 |
+|---|---|---|
+| `Contracts\A1PdfSign` | n/a | gains `signatureFields()` |
+| `Contracts\PdfSigner::sign()` | 7 parameters | gains `?string $intoField` and `?CertificationLevel $certification`, both trailing and optional |
+
+Injecting or calling them is unaffected: the new parameters are optional and
+positional callers are untouched. Implementing them is not, so a test double or
+a custom signer bound in the container has to be updated:
+
+```php
+public function signatureFields(string $pdfPath): array;   // list<SignatureField>
+
+public function sign(
+    string $pdfContents,
+    Certificate $certificate,
+    SignatureInfo $info,
+    string $fieldName = 'Signature',
+    ?SealImage $seal = null,
+    ?SealPlacement $placement = null,
+    ?SignatureProfile $profile = null,
+    ?string $intoField = null,              // new
+    ?CertificationLevel $certification = null,   // new
+): SignedPdf;
+```
+
+### `SignatureReport` gained a property
+
+`Data\SignatureReport` is a public return type, so a new property changes what
+`toArray()` returns:
+
+```php
+// 2.1
+['signatures' => [...], 'securityStore' => ...]
+
+// 2.2
+['signatures' => [...], 'securityStore' => ..., 'certification' => null]
+```
+
+Reading properties and calling methods is unaffected. Only code asserting on the
+whole array, a snapshot test or a strict equality check, has to be updated.
+
+### A document may now refuse to be signed
+
+`sign()` can raise two exceptions it never raised before, both of them
+deliberate refusals rather than failures:
+
+| | |
+|---|---|
+| `SignatureFieldException` | only when `intoField()` was used |
+| `CertificationException` | when the document is certified at `no-changes`, which forbids the further revision a signature would append |
+
+The second can reach code that does not use certification at all, if it signs a
+document someone else certified. That is the certification working: at
+`no-changes` a further signature would silently invalidate the one already
+there, so it is refused instead.
+
+### New: signing into a template's own fields
+
+```php
+foreach (A1PdfSign::signatureFields($template) as $field) {
+    $field->name;        // 'SignatureManager'
+    $field->isSigned;    // false
+    $field->rectangle;   // [30.0, 200.0, 200.0, 250.0]
+}
+
+A1PdfSign::newSignature()
+    ->certificate($pfx, $password)
+    ->pdf($template)
+    ->intoField('SignatureManager')
+    ->seal()              // drawn into the field's own rectangle
+    ->sign();
+```
+
+Previously the package appended a new field beside the empty one, so a template
+ended up with a signature in the wrong place and its own field still unfilled.
+
+### New: certification signatures
+
+```php
+A1PdfSign::newSignature()
+    ->certificate($pfx, $password)
+    ->pdf($path)
+    ->certify('form-filling')   // no-changes | form-filling | annotations
+    ->sign();
+```
+
+### New: documents with cross-reference streams
+
+No API change. Documents produced by Word, by "print to PDF" in Chrome and by
+most modern generators use the cross-reference stream of ISO 32000-1 §7.5.8
+rather than the classic table, and 2.1 refused them. 2.2 signs them, appending a
+revision in whichever form the document already uses.
+
 ## From 2.0 to 2.1
 
 2.1 adds PEM as a second accepted certificate encoding. PKCS#12 behaviour is

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -18,20 +18,21 @@ document drifts away from the code it describes.
 | [0006](0006-incremental-revision.md) | Sign by appending a revision, written in-package |
 | [0007](0007-pem-second-entry-one-pipeline.md) | PEM as a second entry point onto one pipeline |
 | [0008](0008-exceptions-name-the-real-fault.md) | Exceptions name the fault that actually occurred |
-| [0011](0011-signing-time-and-certificate-validity.md) | The report carries signing time and certificate validity |
-| [0014](0014-refuse-encrypted-documents.md) | Encrypted documents are refused, not signed badly |
-
-## Proposed
-
-Decided in shape, not yet built. Each records what was measured, so the next
-person starts from the measurement rather than from the guess.
-
-| # | Decision |
-|---|---|
 | [0009](0009-cross-reference-streams.md) | Cross-reference streams |
 | [0010](0010-validation-consumes-what-signing-writes.md) | Validation consumes the material signing writes |
+| [0011](0011-signing-time-and-certificate-validity.md) | The report carries signing time and certificate validity |
 | [0012](0012-certification-signatures.md) | Certification signatures and DocMDP |
 | [0013](0013-signing-into-an-existing-field.md) | Signing into a field the document already carries |
+| [0014](0014-refuse-encrypted-documents.md) | Encrypted documents are refused, not signed badly |
+
+Nothing is currently proposed and unbuilt. The four that were, 0009, 0010, 0012
+and 0013, all shipped in 2.2, and each carries the measurement that decided its
+shape rather than only the shape.
+
+**0012 is the one to read before trusting it.** It is implemented and its
+verification is deliberately incomplete: `pdfsig` does not surface `/DocMDP`, so
+whether a reader *enforces* a certification is untested here. The record says so
+rather than rounding up.
 
 Rules that break the product when violated are not decisions and do not live
 here. They are in [the invariants](../spec/invariants.md).

--- a/docs/history/decision-log.md
+++ b/docs/history/decision-log.md
@@ -42,3 +42,23 @@ what this reorganisation exists to close.
 > twice: first by the real tooling requirements, then by the realisation that
 > the PHP *ceiling* of older Laravel versions, not the floor, is the limiting
 > factor. See [0005](../decisions/0005-php-and-laravel-floor.md).
+
+## Answered by 2.2
+
+The four records that were proposed and unbuilt when the specification was
+split. Each is now implemented, and each was decided by a measurement rather
+than by the plan.
+
+| # | Question | Outcome |
+|---|---|---|
+| 16 | Cross-reference streams: append a stream, or a classic table plus `/XRefStm`? | ✅ **Append a stream.** Measured, not assumed: appending a classic table to a document whose latest section is a stream produced a file poppler reported as carrying no signatures at all. Reading shipped one release before writing, with signing refusing in between, so the gap was a loud refusal rather than silent corruption ([0009](../decisions/0009-cross-reference-streams.md)) |
+| 17 | Does validation have to read back everything signing writes? | ✅ **Yes**, and the asymmetry was real: the package wrote B-LTA material it could not then report. Signing time came from `/M` rather than the PKCS#9 attribute, which measurement showed absent ([0010](../decisions/0010-validation-consumes-what-signing-writes.md)) |
+| 18 | Certification: is a byte-level test enough? | ❌ **No, and it still is not.** All three levels write and read back, and poppler confirms the signature verifies, but `pdfsig` does not surface `/DocMDP`, so reader *enforcement* is unverified and needs Adobe Reader or ITI Validar. Recorded as an open gap rather than closed by a passing test ([0012](../decisions/0012-certification-signatures.md)) |
+| 19 | Signing into a pre-placed field: fill it, or fall back to appending when it is missing? | ✅ **Fill, and refuse rather than fall back.** The fallback is exactly the failure the feature prevents, and it would happen quietly: a signature that is valid and in the wrong place, with the template's field still empty ([0013](../decisions/0013-signing-into-an-existing-field.md)) |
+
+One defect surfaced that belonged to none of them. `DocumentReader::findFirstPage()`
+scanned a fixed 400-byte window from each object's offset, which in a compact
+document reaches the objects that follow, so the catalog was reported as the
+first page. It was latent in any document whose objects sit close together, and
+only a 434-byte fixture built for [0009](../decisions/0009-cross-reference-streams.md)
+was small enough to expose it.


### PR DESCRIPTION
Release preparation for **2.2**. No code changes.

## `UPGRADE.md` gains the 2.1 to 2.2 entry

The release is additive for applications: nothing removed, no behaviour changed for code that already worked, and the PHP and Laravel requirements do not move.

Three things reach code that **extends** the package:

| | 2.1 | 2.2 |
|---|---|---|
| `Contracts\A1PdfSign` | n/a | gains `signatureFields()` |
| `Contracts\PdfSigner::sign()` | 7 parameters | gains `?string $intoField` and `?CertificationLevel $certification`, both trailing and optional |
| `Data\SignatureReport::toArray()` | 2 keys | gains `certification` |

**One reaches callers who use none of the new features.** `sign()` can now raise `CertificationException` on a document someone else certified at `no-changes`. That is the certification working rather than a regression: a further signature would otherwise silently invalidate the one already there.

## The decision index was wrong

It listed 0009, 0010, 0012 and 0013 under "Proposed: decided in shape, not yet built". All four shipped. Nothing is proposed and unbuilt any more.

0012 is flagged there as the one to read before trusting: it is implemented and its verification is **deliberately incomplete**, since `pdfsig` does not surface `/DocMDP` and reader enforcement is untested here.

## The decision log gains the four outcomes

Plus the `findFirstPage` defect that belonged to none of them: a fixed 400-byte scan window that reached into the following objects, latent in any document whose objects sit close together, and exposed only because a 434-byte fixture was small enough to trip it.
