### PR TITLE
docs(2.x): document the 2.2 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ lerna-debug.log*
 *.njsproj
 *.sln
 *.sw?
+.output

--- a/public/docs/2.x/release-notes.md
+++ b/public/docs/2.x/release-notes.md
@@ -1,3 +1,99 @@
+# 2.2.0
+
+## Templates, certification, and the documents 2.1 refused
+
+Three things a real workflow needs and 2.1 could not do: sign a PDF produced by Word or Chrome, fill the signature field a contract template already carries, and certify a document as its author.
+
+```PHP
+// The field the template already drew, filled by name
+A1PdfSign::newSignature()
+    ->certificate($pfx, $password)
+    ->pdf($contract)
+    ->intoField('SignatureManager')
+    ->seal()
+    ->sign();
+
+// The author's statement about what may happen from here on
+A1PdfSign::newSignature()
+    ->certificate($pfx, $password)
+    ->pdf($contract)
+    ->certify('form-filling')
+    ->sign();
+```
+
+Nothing was removed and the PHP and Laravel requirements do not move, so an application that signs and validates upgrades without editing anything.
+
+<hr>
+
+## Documents 2.1 could not sign at all
+
+**PDF 1.5 replaced the cross-reference table with a stream**, and that is what Word, "print to PDF" in Chrome, LaTeX with compression and most modern generators emit. 2.1 refused them, which bounded who could use the package, and the bound was not small.
+
+2.2 reads that form and appends a revision in whichever form the document already uses. The mixture is not a matter of taste: appending a classic table to a document whose latest section is a stream produced a file poppler reported as carrying **no signatures at all**. Reading shipped one release before writing, with signing refusing in between, so the gap was a loud refusal rather than silent corruption.
+
+<hr>
+
+## Added
+
+- **`intoField()`**, which fills a signature field the document already carries instead of appending one beside it. Until now the package left the template's own field empty while putting a valid signature somewhere else. The field's rectangle decides where the seal goes;
+- **`A1PdfSign::signatureFields()`**, returning each field's name, rectangle, page and whether it is already signed;
+- **`certify()`**, writing a `/DocMDP` certification at `no-changes`, `form-filling` or `annotations` (ISO 32000-1 §12.8.2.2), requested in [discussion #160](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/discussions/160);
+- **Cross-reference stream support**, reading and writing, with no API change;
+- **`signedAt` and `signerWasValidWhenSigned()`** on each signature. The second returns `null` rather than `false` when the signing time is absent, because a validity window that cannot be checked is unknown, not invalid;
+- **`chain` and `chainReachesRoot`**, the embedded certificates ordered leaf first, with each link confirmed by the issuer's public key rather than by matching names;
+- **`securityStore` and `hasLongTermMaterial()`**, so a `pades-b-lt` document can be asked whether its validation material actually covers every signature in it;
+- **`isCertified()`, `certification` and `acceptsFurtherSignatures()`** on the report;
+- **Archive timestamps are verified** rather than assumed, against the imprint they actually stamp;
+- **`samples/certified.pdf`, `samples/signed-into-fields.pdf` and `samples/xref-stream.pdf`**, one per new capability.
+
+<hr>
+
+## Refusals, which are the feature
+
+Each of these raises rather than falling back, because every fallback here produces a file that looks right and is not.
+
+| Refused | Why |
+|---|---|
+| `intoField()` naming a field that does not exist | appending one beside it is exactly the failure the feature prevents. The message names the fields that do exist |
+| `intoField()` naming a field already signed | filling it again would replace that signature rather than add one |
+| A seal placement passed with `intoField()` | the field has its own rectangle; resolving by precedence would silently move the seal off the box the template drew |
+| A second certification, or one after an approval signature | a certification states what may happen from here on, and a signature already applied is a thing that happened |
+| **Any signature on a document certified at `no-changes`** | a further signature is a further revision, which is exactly what that level forbids |
+| An encrypted document | the cross-reference table is not encrypted, so reading gets far enough to look successful while everything around it is unreadable |
+
+The `no-changes` one can reach code that uses no new feature at all, if it signs a document someone else certified. That is the certification working: without the refusal, the second signature would silently invalidate the first.
+
+<hr>
+
+## Fixed
+
+- **The first page of a compact document was misidentified as the catalog.** The page search scanned a fixed 400-byte window from each object's offset, which in a document whose objects sit close together reaches the objects that follow. The revision then wrote the form entry and the annotation onto the same object, the second silently dropping the first, producing a document with a signature dictionary and no form to reach it from. It was latent in any such document, and only a 434-byte test fixture was small enough to expose it;
+- **Exceptions name the fault that actually occurred.** Fifteen of sixteen call sites reported structural faults as "Invalid file extension".
+
+<hr>
+
+## Breaking for implementers
+
+Calling or injecting the contracts is unaffected: the new parameters are optional and trailing. **Implementing them is not.**
+
+| | 2.1 | 2.2 |
+| --- | --- | --- |
+| `Contracts\A1PdfSign` | n/a | gains `signatureFields()` |
+| `Contracts\PdfSigner::sign()` | 7 parameters | gains `?string $intoField` and `?CertificationLevel $certification` |
+| `Data\SignatureReport::toArray()` | 2 keys | gains `certification` |
+
+The last one reaches anyone asserting on the whole array, a snapshot test or a strict equality check. Reading properties and calling methods is unaffected. The [upgrade guide](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/blob/main/UPGRADE.md) maps each one.
+
+<hr>
+
+## One verification this release does not claim
+
+**Whether a reader enforces a certification is untested.** `pdfsig` does not surface `/DocMDP` at all, so poppler confirms only that the file is well formed and both signatures verify. Enforcement needs Adobe Reader or ITI Validar, which this project cannot run in CI.
+
+The bytes are right and were checked by hand: `/Perms` names the signature that carries the transform, and the transform carries the permission for the level asked for. `samples/certified.pdf` exists so you can check the rest yourself. [Decision 0012](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/blob/main/docs/decisions/0012-certification-signatures.md) records the gap rather than rounding it up.
+
+<hr>
+
 # 2.1.0
 
 ## PEM certificates

--- a/public/docs/2.x/sign-pdf-file.md
+++ b/public/docs/2.x/sign-pdf-file.md
@@ -195,3 +195,94 @@ Both seals are visible in the finished document, in different places. One signat
 This works because each signature is an appended revision carrying its own widget annotation, with its own image and form objects. Nothing is reused between them, so changing the second seal cannot disturb the first.
 
 [`samples/two-seals.pdf`](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/blob/main/samples/two-seals.pdf) is exactly this case, signed and ready to open in a reader.
+
+<hr>
+
+#### 7 - Signing into a field the document already carries. <small>(since 2.2)</small>
+
+A contract laid out by someone else arrives with its signature fields already placed. `intoField()` fills the one you name, instead of appending another beside it.
+
+```PHP
+<?php
+
+use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
+
+// What does this template carry?
+foreach (A1PdfSign::signatureFields('path/to/contract-template.pdf') as $field) {
+    $field->name;        // 'SignatureManager'
+    $field->isSigned;    // false
+    $field->pageNumber;  // 3
+    $field->rectangle;   // [30.0, 200.0, 200.0, 250.0]
+    $field->isVisible(); // true, the field has an area to draw into
+}
+
+$signed = A1PdfSign::newSignature()
+    ->certificate('path/to/certificate.pfx', 'password')
+    ->pdf('path/to/contract-template.pdf')
+    ->intoField('SignatureManager')
+    ->seal()
+    ->sign();
+```
+
+**The field's own rectangle decides where the seal goes**, because the template already drew the box. For that reason `intoField()` cannot be combined with a `SealPlacement`, and a field with a zero rectangle keeps the signature invisible even when `seal()` was called: the template's geometry is the template's decision.
+
+Three things raise `SignatureFieldException` rather than falling back to appending a field:
+
+| Refused | Why |
+|---|---|
+| A field that does not exist | the message names the fields that do, since a misspelling is the usual cause |
+| A field already signed | filling it again would replace that signature rather than add one |
+| A placement passed as well | resolving by precedence would silently move the seal off the box the template drew |
+
+> **Falling back would be worse than failing.** Before 2.2 the package appended a new field beside the empty one, so the document ended up with a signature that was valid and in the wrong place, plus an unfilled field that was the point of the template.
+
+[`samples/signed-into-fields.pdf`](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/blob/main/samples/signed-into-fields.pdf) is a template with two fields, both filled by name.
+
+<hr>
+
+#### 8 - Certifying a document. <small>(since 2.2)</small>
+
+Every signature above is an **approval** signature: it asserts what the bytes were. A **certification** is a different claim, the author's statement about what may happen to the document from here on (ISO 32000-1 §12.8.2.2).
+
+```PHP
+<?php
+
+use LSNepomuceno\LaravelA1PdfSign\Enums\CertificationLevel;
+use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
+
+$certified = A1PdfSign::newSignature()
+    ->certificate('path/to/certificate.pfx', 'password')
+    ->pdf('path/to/contract.pdf')
+    ->certify(CertificationLevel::FormFilling)   // or the string 'form-filling'
+    ->info(name: 'Document author')
+    ->seal()
+    ->sign();
+```
+
+| Level | Permits |
+|---|---|
+| `no-changes` | nothing. The document **cannot be signed again** |
+| `form-filling` | filling form fields and signing. **The default** |
+| `annotations` | form filling, signing and annotations |
+
+`certify()` defaults to `form-filling` because a document that still has to be signed is the common case, and defaulting to the level that refuses the next signer would fail closed in the wrong direction.
+
+Three rules are enforced, not merely documented, each raising `CertificationException`:
+
+- **A certification has to be the first signature.** It states what may happen from here on, and an approval signature already applied is a thing that happened;
+- **There can be only one** per document;
+- **`no-changes` refuses every later signature**, approval or otherwise.
+
+> **That last rule can reach code that never calls `certify()`.** Signing a document someone else certified at `no-changes` raises rather than succeeding. This is the certification working: a further signature is a further revision, and without the refusal it would silently invalidate the signature already there. If the document still has to be signed, certify at `form-filling` instead.
+
+[`samples/certified.pdf`](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/blob/main/samples/certified.pdf) is certified at `form-filling` and then signed by a second party.
+
+<hr>
+
+#### 9 - Documents produced by Word, Chrome and LaTeX. <small>(since 2.2)</small>
+
+No API change, and nothing to call. It is worth knowing about because 2.1 refused these documents outright.
+
+PDF 1.5 replaced the cross-reference table with a **cross-reference stream**, and that is the form Word, "print to PDF" in Chrome, LaTeX with compression and most modern generators emit. 2.2 reads it and appends the new revision in whichever form the document already uses.
+
+The two cannot be mixed: appending a classic table to a document whose latest section is a stream produces a file that readers do not see as signed at all. If you are signing documents from a source that previously failed, this is why.

--- a/public/docs/2.x/validating-signature.md
+++ b/public/docs/2.x/validating-signature.md
@@ -38,6 +38,12 @@ foreach ($report->signatures as $signature) {
     $signature->isTimestamp;          // bool, a DocTimeStamp, not a signature by a signer
     $signature->error;                // ?string, why it failed, when it did
 
+    // since 2.2
+    $signature->signedAt;                    // ?CarbonInterface, the time the signer claimed
+    $signature->signerWasValidWhenSigned();  // ?bool, null when the time is unknown
+    $signature->chain;                       // list<Signer>, leaf first
+    $signature->chainReachesRoot;            // bool, does it end at a self-signed root
+
     $signer = $signature->signer();
     $signer?->commonName;
     $signer?->organization;
@@ -76,7 +82,58 @@ $report->signers();    // signers only, the authority is not one of them
 
 <hr>
 
-#### 5 - What validation does not do.
+#### 5 - Signing time, and whether the certificate was valid then. <small>(since 2.2)</small>
+
+A signature carries the time the signer claimed, in the signature dictionary's `/M`. It is worth being precise about what that is:
+
+```PHP
+$signature = $report->latest();
+
+$signature?->signedAt;                    // ?CarbonInterface
+$signature?->signerWasValidWhenSigned();  // ?bool
+```
+
+**`signedAt` is the signer's claim, not proof.** Anyone who controls the signing machine controls its clock. An RFC 3161 timestamp is the attested version of the same fact, which is what the `pades-b-t` profile and above add.
+
+`signerWasValidWhenSigned()` returns **`null` rather than `false`** when the signing time is absent. A certificate whose validity window cannot be checked is unknown, not invalid, and collapsing the two would report a fact the document does not carry.
+
+<hr>
+
+#### 6 - Long-term validation material. <small>(since 2.2)</small>
+
+A `pades-b-lt` document carries a Document Security Store: the certificate chain, OCSP responses and CRLs as they stood when the signature was made, so the signature is still checkable once the responders are gone and the certificate has expired.
+
+```PHP
+$report->hasLongTermMaterial();      // does every signature have material covering it?
+
+$store = $report->securityStore;
+$store?->certificates;               // int
+$store?->ocspResponses;              // int
+$store?->crls;                       // int
+$store?->covers($signature);         // is there material for this signature specifically?
+```
+
+This reports **what is there, not that it is good**. Counting an OCSP response is not evaluating it: revocation is not checked at validation time, and a store with certificates but no entry for a given signature is carrying material for a different one.
+
+<hr>
+
+#### 7 - Certification. <small>(since 2.2)</small>
+
+Whether the document's author certified it, and what that permits:
+
+```PHP
+$report->isCertified();               // bool
+$report->certification;               // ?CertificationLevel
+$report->acceptsFurtherSignatures();  // false only at no-changes
+```
+
+`acceptsFurtherSignatures()` is worth checking before signing a document you did not produce. At `no-changes` the package will refuse, because a further signature would invalidate the certification rather than add to it.
+
+Half a certification is not reported as one: a `/Perms` entry naming a signature that carries no `/DocMDP` transform, or a `/FieldMDP` transform (which locks named fields and carries the same parameters), both report `null`.
+
+<hr>
+
+#### 8 - What validation does not do.
 
 `isValid()` answers whether each signature matches the document. **It does not check the issuer against a trust store**: whether you trust the certificate authority is a policy decision, and it stays with your application:
 
@@ -90,7 +147,7 @@ if ($signer?->issuerName() !== 'AC Certisign RFB G5') {
 
 <hr>
 
-#### 6 - Verifying independently.
+#### 9 - Verifying independently.
 
 Our validator shares its assumptions with the code that produced the signature, so it is worth checking against something that does not. Poppler's `pdfsig` has caught bugs in this package that the whole test suite passed straight through:
 


### PR DESCRIPTION
Documents what shipped in [2.2.0](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/releases/tag/2.2.0). Three pages.

## `sign-pdf-file.md`

- **§7 `intoField()`**, for templates whose signature fields are already placed, with the three refusals and why falling back would be worse than failing;
- **§8 `certify()`**, the three `/DocMDP` levels, and the rule that reaches callers who never call it: signing a document someone else certified at `no-changes` raises;
- **§9 cross-reference streams.** No API, but worth a section: 2.1 refused documents produced by Word and by "print to PDF" in Chrome, and someone who hit that will want to know it is fixed rather than discover it by retrying.

## `validating-signature.md`

Gains signing time, the certificate chain, the Document Security Store and certification, renumbered to fit them.

**The first three were never documented on the site**, so this closes that gap as well as the new one. Two points that are easy to get wrong are called out explicitly: `signedAt` is the signer's claim rather than proof, and `signerWasValidWhenSigned()` returns `null` rather than `false` when the time is unknown.

## `release-notes.md`

2.2.0 prepended, including **the verification the release does not claim**: `pdfsig` does not surface `/DocMDP`, so whether a reader enforces a certification is untested and needs Adobe Reader or ITI Validar.

## Also

`.output` added to `.gitignore`. It is a build artefact of the package repository that leaks into this working tree on a branch switch.

No navigation changes: the new material sits in existing pages, the way PEM did for 2.1.
