### PR TITLE
ci: gate backward compatibility against the last release

### DIFF
--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -1,0 +1,70 @@
+---
+# Backward compatibility, checked against the last release rather than against
+# review.
+#
+# The package is a library: its public surface is other people's code. Every
+# release so far has changed a contract, and each time the break was found by
+# reading the diff, which is the method that eventually misses one. This is the
+# gate that does not get tired.
+#
+# It compares the last SemVer tag against HEAD, so the baseline moves on its own
+# as releases are cut and there is no list to maintain.
+#
+# **The tool is installed in a directory of its own, not into require-dev.**
+# Two reasons, and both are specific to this repository: it needs ext-intl and a
+# dependency tree of its own that would have to coexist with a pinned
+# phpunit/php-code-coverage and Pest 5, and composer-dependency-analyser would
+# report a binary nothing imports as an unused dependency.
+#
+# **Not the nyholm/roave-bc-check image.** It is pinned to an older parser and
+# fails outright on PHP 8.4's `new Foo()->bar()`, which this codebase uses
+# throughout. Measured on 2026-08-09: "Syntax error, unexpected
+# T_OBJECT_OPERATOR". The composer install carries a current nikic/php-parser
+# and reads the same file without complaint.
+name: BC
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bc-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  roave:
+    name: Backward compatibility
+    runs-on: ubuntu-latest
+
+    steps:
+      # The tool resolves its own baseline from the tags, so a shallow clone
+      # leaves it with nothing to compare against.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          # intl is the tool's requirement, not the package's. The package's own
+          # extensions are declared in composer.json.
+          extensions: intl, zip, openssl, mbstring, fileinfo, gd
+          coverage: none
+
+      - name: Install the checker
+        run: |
+          mkdir -p "${RUNNER_TEMP}/bc"
+          composer require --no-interaction --no-progress \
+            --working-dir="${RUNNER_TEMP}/bc" \
+            roave/backward-compatibility-check:^8.21
+
+      # Reports the break and fails the build. A break that is deliberate is
+      # answered by saying so in UPGRADE.md and in the release notes, and by
+      # choosing the version accordingly, not by silencing the check.
+      - name: Check for BC breaks
+        run: "${RUNNER_TEMP}/bc/vendor/bin/roave-backward-compatibility-check"

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -36,6 +36,31 @@ public function sign(
 ): SignedPdf;
 ```
 
+### `InvalidPdfFileException` takes a message
+
+The constructor took the offending filename and built the sentence itself. It
+now takes the message, and the one case the old wording described moved to a
+named constructor:
+
+```php
+new InvalidPdfFileException('/tmp/contract.docx');        // 2.1
+InvalidPdfFileException::extension('/tmp/contract.docx'); // 2.2, same string
+```
+
+The wording is preserved byte for byte, so a test asserting on it still passes.
+Fifteen of the sixteen places that raised this were reporting structural faults,
+and every one of them said "Invalid file extension"
+([0008](docs/decisions/0008-exceptions-name-the-real-fault.md)).
+
+Positional callers of `new InvalidPdfFileException(...)` outside the package are
+unaffected in behaviour, since the first argument is still a string that becomes
+the message. Only a named argument breaks:
+
+```php
+new InvalidPdfFileException(currentFile: $path);  // 2.1
+new InvalidPdfFileException(message: $text);      // 2.2
+```
+
 ### `SignatureReport` gained a property
 
 `Data\SignatureReport` is a public return type, so a new property changes what

--- a/src/Signing/IncrementalSigner.php
+++ b/src/Signing/IncrementalSigner.php
@@ -53,8 +53,14 @@ final readonly class IncrementalSigner implements PdfSigner
         private CadesBuilder $cades,
         private DssWriter $dss,
         private DocTimeStampWriter $archiveTimestamp,
-        private SignatureFieldReader $fields,
-        private CertificationReader $certifications,
+        // Defaulted, not required. 2.2 added both as required parameters and
+        // so raised the constructor's arity from six to eight, which breaks
+        // anyone who builds this by hand rather than through the container.
+        // The Roave check caught it on its first run; nothing in the suite
+        // could have, because the suite resolves everything from the container
+        // (docs/spec/quality-policy.md).
+        private SignatureFieldReader $fields = new SignatureFieldReader(new DocumentReader()),
+        private CertificationReader $certifications = new CertificationReader(new DocumentReader()),
     ) {}
 
     public function sign(


### PR DESCRIPTION
The BC check, deferred from the 2.2 work so its first run could be calibrated rather than merged blind. That calibration is the point of this PR.

The package is a library: its public surface is other people's code. Every release so far changed a contract, and each time the break was found by **reading the diff**, which is the method that eventually misses one.

## What the first run found

Run against `2.1.0 → 2.2.0` it reports six changes. All six are real, and **two of them were news**:

```
CHANGED: required arguments for IncrementalSigner#__construct() increased from 6 to 8
CHANGED: Parameter 0 of InvalidPdfFileException#__construct() changed name from currentFile to message
```

**The first is fixed here rather than documented.** Adding `SignatureFieldReader` and `CertificationReader` as required parameters broke anyone building the signer by hand instead of through the container. Nothing in the suite could have caught it, because the suite resolves everything from the container. Both now default to an instance, which restores the arity and is better for a manual caller anyway.

**The second is documented in `UPGRADE.md`**, where 2.2 should have covered it and did not. Behaviour is unchanged for a positional caller, since the first argument is still a string that becomes the message; only a named argument breaks.

The other four are the interface additions `UPGRADE.md` already maps.

## Two implementation notes, both measured

**Not `nyholm/roave-bc-check`**, the image the tool's own README suggests. It carries an older parser and fails outright on PHP 8.4's `new Foo()->bar()`, which this codebase uses throughout:

```
AST failed to parse in src/Seal/InterventionSealRenderer.php (line 39):
Syntax error, unexpected T_OBJECT_OPERATOR
```

A composer install of `^8.21` carries `nikic/php-parser` 5.8 and reads the same file without complaint.

**Not `require-dev` either.** The tool needs `ext-intl` and a dependency tree that would have to coexist with a pinned `phpunit/php-code-coverage` and Pest 5, and `composer-dependency-analyser` would report a binary nothing imports as an unused dependency. It installs into a directory of its own inside the workflow.

## Calibration result

Run as the gate will actually run it, from `2.2.0` to `HEAD`:

```
No backwards-incompatible changes detected
```

So the fix to `IncrementalSigner` is correctly *not* a break (reducing required arguments widens the contract), and the gate is green on the current baseline. From here the tool moves its own baseline as tags are cut, with no list to maintain.

A break that is deliberate is answered by saying so in `UPGRADE.md` and in the release notes, and by choosing the version accordingly, not by silencing the check.
