### PR TITLE
docs(2.x): add the 2.2.1 release notes

### DIFF
--- a/public/docs/2.x/release-notes.md
+++ b/public/docs/2.x/release-notes.md
@@ -1,3 +1,44 @@
+# 2.2.1
+
+## A break 2.2.0 shipped, and the gate that found it
+
+2.2.0 raised `IncrementalSigner`'s constructor from six required arguments to eight. Resolving the signer from the container, which every documented path does, is unaffected. **Building it by hand is not**, and that is a break a patch release should undo rather than a note in an upgrade guide.
+
+Both new parameters now default to an instance:
+
+```PHP
+new IncrementalSigner($reader, $writer, $byteRange, $cades, $dss, $archiveTimestamp);
+```
+
+Nothing else changed. There is no reason to upgrade from 2.2.0 unless you construct that class directly.
+
+<hr>
+
+## How it was found
+
+The Roave backward compatibility check now runs on every pull request, comparing the last release against `HEAD`. It was deliberately held back from the 2.2 work so its first run could be read rather than merged blind, and it earned its place immediately: **nothing in the test suite could have caught this**, because the suite resolves everything from the container.
+
+It also surfaced a second change 2.2.0 made and failed to document: `InvalidPdfFileException::__construct()` renamed its first parameter from `currentFile` to `message`. Behaviour is unchanged for a positional caller, since the argument is still a string that becomes the message. Only a named argument breaks:
+
+```PHP
+new InvalidPdfFileException(currentFile: $path);  // 2.1
+new InvalidPdfFileException(message: $text);      // 2.2
+```
+
+The one case the old wording described kept it byte for byte, as `InvalidPdfFileException::extension($path)`.
+
+<hr>
+
+## Fixed
+
+- **`Signing\IncrementalSigner::__construct()` accepts six arguments again.** `SignatureFieldReader` and `CertificationReader` default to an instance instead of being required.
+
+## Added
+
+- **A backward compatibility gate on every pull request**, comparing the last SemVer tag against `HEAD`. The baseline moves on its own as releases are cut, so there is no list to maintain.
+
+<hr>
+
 # 2.2.0
 
 ## Templates, certification, and the documents 2.1 refused


### PR DESCRIPTION
Release notes for [2.2.1](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/releases/tag/2.2.1).

A patch that undoes a break 2.2.0 shipped: `IncrementalSigner`'s constructor went from six required arguments to eight, which is invisible to anyone resolving it from the container and breaks anyone building it by hand.

Worth the space it takes because of **how it was found**. The Roave backward compatibility check was held back from the 2.2 work so its first run could be read rather than merged blind, and it reported this immediately. Nothing in the test suite could have: the suite resolves everything from the container.

The notes also carry the `InvalidPdfFileException` constructor rename that 2.2.0 made and failed to document, with the one case that still breaks (a named argument) spelled out.

No navigation changes.
