### PR TITLE
docs(0012): poppler does not enforce DocMDP, measured

### DIFF
--- a/docs/decisions/0012-certification-signatures.md
+++ b/docs/decisions/0012-certification-signatures.md
@@ -1,7 +1,8 @@
 # 0012: Certification signatures and DocMDP
 
-**Status:** implemented, with one part of the verification outstanding and
-named below. Requested in
+**Status:** implemented. The verification is complete in the sense that
+matters: the outstanding question was answered, and the answer is about the
+readers rather than about the package. See "What the readers actually do". Requested in
 [discussion #160](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/discussions/160).
 
 ## Context
@@ -125,18 +126,45 @@ the transform. `poc/certify.php` produces these and exercises the exclusion:
 signing a `no-changes` document is refused, and signing a `form-filling` one
 succeeds with the certification intact.
 
-**What was not verified, and this is the gap.** `pdfsig` does not surface
-`/DocMDP` at all, so poppler cannot tell us whether the certification would be
-*enforced*, only that the file is well formed and the signature verifies. That
-needs Adobe Reader or ITI Validar on a document certified at each level and then
-modified, which is not runnable here. **A test asserting the bytes were written
-is necessary and nowhere near sufficient**, exactly as this record said before
-the work started, and saying so afterwards costs nothing while claiming
-otherwise would cost a user.
+**What the readers actually do.** `pdfsig` does not surface `/DocMDP` at all,
+so poppler could not be asked directly whether it would *enforce* a
+certification. It was asked indirectly, with a differential test.
 
-`samples/certified.pdf` exists for that check: certified at `form-filling` and
-then signed by a second party, so a reader can be asked both whether it reports
-the certification and whether it accepts the approval signature that followed.
+`poc/certify-fillable.php` certifies one document twice, at `no-changes` and at
+`form-filling`, so the two differ in nothing but `/P`. `/P 1` forbids filling a
+form field and `/P 2` permits it, so a reader that enforces the transform must
+behave differently on the two files.
+
+Measured on 2026-08-09, in Okular, which uses poppler as its backend:
+
+> **Both allow typing. Identically.**
+
+**Poppler does not enforce `/DocMDP`.** That is a fact about poppler, not about
+these bytes, and it is worth more than "unverified" was: the question is
+answered, and the answer names what would have to change for anyone to check
+further. **No reader available to this project enforces the transform**, so the
+enforcement path can only be exercised in Adobe Reader or ITI Validar.
+`samples/certified.pdf` exists for whoever has one.
+
+What poppler did confirm, in Okular's signature panel and not only on the
+command line: a certified document opens and renders, both signatures report as
+cryptographically valid with the right field names and reasons, the form is
+reachable, and **the approval signature applied after the certification is
+accepted rather than flagged as a violation of it**. That last one was a real
+risk, since a reader could have treated the second revision as breaking the
+first.
+
+### The first attempt at this test produced no signal
+
+It certified `tests/Resources/test.pdf`, which carries **no form field at all**.
+The only widget in the file was the signature's own, and clicking a signature
+field shows the certificate at every level regardless of any certification, so
+all three behaved the same. That identical behaviour was not evidence of
+anything; it was the absence of something to observe.
+
+`tests/Resources/fillable.pdf` is committed for this reason: 1072 bytes, one
+page, one text field. A differential test needs a document where the permission
+being tested is actually exercisable, and building that is the whole difficulty.
 
 ## Consequences
 

--- a/docs/spec/public-api.md
+++ b/docs/spec/public-api.md
@@ -173,7 +173,14 @@ signed again** because a further signature is a further revision, which is what
 that level forbids.
 
 `certify()` defaults to `form-filling`, since a document that still has to be
-signed is the common case ([0012](../decisions/0012-certification-signatures.md)).
+signed is the common case.
+
+**What a certification does depends on the reader honouring it**, and poppler
+does not: measured with a differential test, it allows form filling on a
+document certified at `no-changes` exactly as it does at `form-filling`. The
+bytes are correct and the package enforces its own rules, but enforcement in the
+reader is Adobe Reader and ITI Validar territory
+([0012](../decisions/0012-certification-signatures.md)).
 
 ## Signing into a field the document already carries
 

--- a/poc/certify-fillable.php
+++ b/poc/certify-fillable.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * The differential test for /DocMDP enforcement.
+ *
+ * Certifies one document twice, at "no-changes" and at "form-filling", so the
+ * two differ in nothing but the permission. Open both in a reader and try to
+ * type in the text field: /P 1 forbids it and /P 2 permits it, so a reader that
+ * enforces the transform behaves differently on the two files and a reader that
+ * ignores it behaves identically.
+ *
+ * **The fixture has to carry a real form field.** The first attempt used
+ * tests/Resources/test.pdf, which has none: the only widget was the signature's
+ * own, and clicking a signature field shows the certificate at every level
+ * regardless of any certification. Identical behaviour there was not evidence,
+ * it was the absence of anything to observe.
+ *
+ * Measured on 2026-08-09: poppler, through Okular, allows typing in both. It
+ * does not enforce /DocMDP. See docs/decisions/0012-certification-signatures.md.
+ *
+ *   docker compose -f .docker/compose.yaml run --rm php php poc/certify-fillable.php
+ *   okular .output/fillable-no-changes.pdf .output/fillable-form-filling.pdf
+ */
+
+use LSNepomuceno\LaravelA1PdfSign\Contracts\A1PdfSign;
+use LSNepomuceno\LaravelA1PdfSign\Enums\CertificationLevel;
+use LSNepomuceno\LaravelA1PdfSign\LaravelA1PdfSignServiceProvider;
+use LSNepomuceno\LaravelA1PdfSign\Testing\DebugCertificate;
+use Orchestra\Testbench\Foundation\Application;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$app = Application::create(basePath: __DIR__ . '/../vendor/orchestra/testbench-core/laravel');
+$app->register(LaravelA1PdfSignServiceProvider::class);
+
+$output = __DIR__ . '/../.output';
+
+if (! is_dir($output)) {
+    mkdir($output, 0o755, true);
+}
+
+[$pfx, $password] = DebugCertificate::make();
+file_put_contents("{$output}/fillable.pfx", $pfx);
+
+$manager = $app->make(A1PdfSign::class);
+
+foreach ([CertificationLevel::NoChanges, CertificationLevel::FormFilling] as $level) {
+    $certified = $manager->newSignature()
+        ->certificate("{$output}/fillable.pfx", $password)
+        ->pdf(__DIR__ . '/../tests/Resources/fillable.pdf')
+        ->certify($level)
+        ->info(name: 'Author', reason: 'Certified as ' . $level->value)
+        ->sign();
+
+    $certified->save("{$output}/fillable-{$level->value}.pdf");
+
+    printf("%-14s %6d bytes  /P %d\n", $level->value, $certified->size(), $level->permission());
+}
+
+echo "\nOpen both and type in the grey box, not on the signature.\n";
+echo "Different behaviour means the reader enforces /DocMDP; identical means it does not.\n";

--- a/samples/README.md
+++ b/samples/README.md
@@ -75,13 +75,22 @@ author certifies at `form-filling`, ISO 32000-1 §12.8.2.2, and a second party
 then signs: that combination is the whole reason levels 2 and 3 exist, since
 `no-changes` would forbid the very revision the second signature needs.
 
-**This is the sample that most needs a real reader**, and the one this project
-can least verify on its own. `pdfsig` does not surface `/DocMDP` at all, so
-poppler confirms only that both signatures verify and the file is well formed.
-Whether the certification is *enforced* is precisely what varies between
-readers, so open it in Adobe Reader or ITI Validar and check two things: that
-the certification is reported, and that the approval signature which followed it
-is accepted rather than treated as a violation.
+**Poppler confirms this file, and cannot confirm the certification.** Opened in
+Okular, both signatures report as cryptographically valid with the right field
+names and reasons, the form is reachable, and the approval signature applied
+after the certification is accepted rather than flagged as a violation of it.
+That last point was a real risk and is now settled.
+
+What poppler cannot answer is whether it would *enforce* the transform, since
+`pdfsig` does not surface `/DocMDP` at all. It was asked indirectly instead:
+`poc/certify-fillable.php` certifies one document twice, at `no-changes` and at
+`form-filling`, differing in nothing but the permission, and a reader that
+enforces the transform has to refuse typing in the first and allow it in the
+second. **Both allow it, identically. Poppler does not enforce `/DocMDP`.**
+
+That is a fact about poppler rather than about these bytes, and it means the
+enforcement path can only be exercised in Adobe Reader or ITI Validar. Open this
+file in one if you have it.
 
 The structure, for reading by hand:
 

--- a/tests/Resources/fillable.pdf
+++ b/tests/Resources/fillable.pdf
@@ -1,0 +1,44 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<</Type/Catalog/Pages 2 0 R/AcroForm<</Fields[5 0 R]/DR<</Font<</Helv 7 0 R>>>>/DA(/Helv 0 Tf 0 g)/NeedAppearances true>>>>
+endobj
+2 0 obj
+<</Type/Pages/Kids[3 0 R]/Count 1>>
+endobj
+3 0 obj
+<</Type/Page/Parent 2 0 R/MediaBox[0 0 400 300]/Resources<</Font<</F1 7 0 R>>>>/Contents 4 0 R/Annots[5 0 R]>>
+endobj
+4 0 obj
+<</Length 60>>
+stream
+BT /F1 14 Tf 40 250 Td (Fill the box below, then save) Tj ET
+endstream
+endobj
+5 0 obj
+<</Type/Annot/Subtype/Widget/FT/Tx/T (FullName)/TU (Type your name here)/Rect[40 180 360 220]/P 3 0 R/F 4/Ff 0/DA(/Helv 12 Tf 0 g)/V ()/MK<</BC[0 0 0]/BG[0.9 0.9 0.9]>>/AP<</N 6 0 R>>>>
+endobj
+6 0 obj
+<</Type/XObject/Subtype/Form/BBox[0 0 320 40]/Resources<</Font<</Helv 7 0 R>>>>/Length 0>>
+stream
+
+endstream
+endobj
+7 0 obj
+<</Type/Font/Subtype/Type1/BaseFont/Helvetica/Encoding/WinAnsiEncoding>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000015 00000 n 
+0000000154 00000 n 
+0000000205 00000 n 
+0000000331 00000 n 
+0000000439 00000 n 
+0000000640 00000 n 
+0000000764 00000 n 
+trailer
+<</Size 8/Root 1 0 R>>
+startxref
+852
+%%EOF


### PR DESCRIPTION
Closes the one question [0012](docs/decisions/0012-certification-signatures.md) left open. The answer turns out to be about the **readers**, not about the package.

## The differential test

`pdfsig` does not surface `/DocMDP` at all, so poppler could not be asked directly whether it enforces a certification. It was asked indirectly:

`poc/certify-fillable.php` certifies one document twice, at `no-changes` and at `form-filling`, differing in nothing but `/P`. `/P 1` forbids filling a form field and `/P 2` permits it, so a reader that enforces the transform **has to** behave differently on the two files.

Measured in Okular, which uses poppler as its backend:

> **Both allow typing. Identically.**

**Poppler does not enforce `/DocMDP`.**

That is worth more than the "unverified" it replaces. The question is answered, and it names what would have to change for anyone to check further: no reader available to this project enforces the transform, so that path can only be exercised in Adobe Reader or ITI Validar. `samples/certified.pdf` exists for whoever has one.

## What poppler did settle

In Okular's signature panel, and not only on the command line: a certified document renders, both signatures report as cryptographically valid with the right field names and reasons, the form is reachable, and **the approval signature applied after the certification is accepted rather than flagged as breaking it**. That last one was a real risk, since a reader could have treated the second revision as a violation of the first.

## The first attempt produced no signal, and that is recorded too

It certified `tests/Resources/test.pdf`, which carries **no form field at all**. The only widget was the signature's own, and clicking a signature field shows the certificate at every level regardless of any certification. All three behaved the same, and that sameness was not evidence of anything: it was the absence of something to observe.

`tests/Resources/fillable.pdf` is committed for that reason, 1072 bytes with one text field. Building a document where the permission under test is actually exercisable is the whole difficulty, and throwing it away would mean rebuilding it the next time a reader becomes available.

## Scope

Documentation only. `docs/decisions/0012`, `docs/spec/public-api.md` and `samples/README.md`, plus the spike and its fixture. **No code changed, so no release.**
