### PR TITLE
test(validation): make the dictionary walker testable, and test it

### DIFF
--- a/src/Signing/Incremental/SignatureFieldReader.php
+++ b/src/Signing/Incremental/SignatureFieldReader.php
@@ -4,6 +4,7 @@ namespace LSNepomuceno\LaravelA1PdfSign\Signing\Incremental;
 
 use LSNepomuceno\LaravelA1PdfSign\Data\SignatureField;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidPdfFileException;
+use LSNepomuceno\LaravelA1PdfSign\Support\PdfDictionary;
 
 /**
  * Lists the signature fields a document already carries.
@@ -21,6 +22,7 @@ final readonly class SignatureFieldReader
 {
     public function __construct(
         private DocumentReader $reader,
+        private PdfDictionary $dictionaries = new PdfDictionary(),
     ) {}
 
     /**
@@ -96,38 +98,7 @@ final readonly class SignatureFieldReader
 
         $open = strpos($catalog, '<<', $position);
 
-        return $open === false ? null : $this->balanced($catalog, $open);
-    }
-
-    /**
-     * The dictionary starting at $open, closed at its own depth.
-     */
-    private function balanced(string $contents, int $open): ?string
-    {
-        $depth = 0;
-        $length = strlen($contents);
-
-        for ($i = $open; $i < $length; $i++) {
-            $pair = substr($contents, $i, 2);
-
-            if ($pair === '<<') {
-                $depth++;
-                $i++;
-
-                continue;
-            }
-
-            if ($pair === '>>') {
-                $depth--;
-                $i++;
-
-                if ($depth === 0) {
-                    return substr($contents, $open, $i + 1 - $open);
-                }
-            }
-        }
-
-        return null;
+        return $open === false ? null : $this->dictionaries->at($catalog, $open);
     }
 
     /**

--- a/src/Support/PdfDictionary.php
+++ b/src/Support/PdfDictionary.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Support;
+
+/**
+ * Reads a PDF dictionary by counting its own delimiters.
+ *
+ * Two places need this and both had their own copy: the Document Security Store
+ * reader and the signature field reader. Neither could be tested precisely,
+ * because both only ever asked the result for counts, and a boundary off by a
+ * byte gives the same count. Here it is one implementation whose exact output a
+ * test can assert.
+ *
+ * **A fixed window does not work, and neither does the first `>>`.** A window
+ * wide enough for the largest dictionary swallows whatever follows the
+ * smallest, and dictionaries nest: `/VRI` inside a store, `/DR` inside an
+ * interactive form. Stopping at the first closing marker returns a fragment
+ * that parses as if the rest were absent, which is worse than failing.
+ */
+final readonly class PdfDictionary
+{
+    /**
+     * The dictionary that opens at $start, including both delimiters.
+     *
+     * Null when it never closes, which is a truncated file rather than a
+     * dictionary this cannot read. The caller decides what to do with the
+     * remainder: the store reader parses what it has, the field reader treats
+     * the form as unreadable.
+     */
+    public function at(string $contents, int $start): ?string
+    {
+        if (substr($contents, $start, 2) !== '<<') {
+            return null;
+        }
+
+        $depth = 0;
+        $length = strlen($contents);
+
+        for ($position = $start; $position < $length - 1; $position++) {
+            $pair = substr($contents, $position, 2);
+
+            if ($pair === '<<') {
+                $depth++;
+                // Past the second delimiter character, so "<<<<" reads as two
+                // openings rather than three overlapping ones.
+                $position++;
+
+                continue;
+            }
+
+            if ($pair === '>>') {
+                $depth--;
+                $position++;
+
+                if ($depth === 0) {
+                    return substr($contents, $start, $position - $start + 1);
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Validation/SecurityStoreReader.php
+++ b/src/Validation/SecurityStoreReader.php
@@ -3,6 +3,7 @@
 namespace LSNepomuceno\LaravelA1PdfSign\Validation;
 
 use LSNepomuceno\LaravelA1PdfSign\Data\SecurityStore;
+use LSNepomuceno\LaravelA1PdfSign\Support\PdfDictionary;
 
 /**
  * Reads the Document Security Store a B-LT or B-LTA document carries.
@@ -16,6 +17,10 @@ use LSNepomuceno\LaravelA1PdfSign\Data\SecurityStore;
  */
 final readonly class SecurityStoreReader
 {
+    public function __construct(
+        private PdfDictionary $dictionaries = new PdfDictionary(),
+    ) {}
+
     /**
      * Null when the document has no store at all, which is the ordinary case
      * for legacy, B-B and B-T. An empty store and an absent one are different
@@ -30,15 +35,16 @@ final readonly class SecurityStoreReader
             return null;
         }
 
+        // preg_match_all returned at least one match above, so the list is not
+        // empty and the offset is not the -1 that a non-participating group
+        // would report.
+        /** @var non-empty-list<array{0: string, 1: int<0, max>}> $offsets */
         $offsets = $found[0];
-        $last = end($offsets);
+        $start = end($offsets)[1];
 
-        if (! is_array($last)) {
-            return null;
-        }
-
-        $start = (int) $last[1];
-        $dictionary = $this->dictionaryAt($pdf, $start);
+        // A store the file cuts off is still worth reading: what is there is
+        // there, and reporting nothing would be less true than reporting less.
+        $dictionary = $this->dictionaries->at($pdf, $start) ?? substr($pdf, $start);
 
         return new SecurityStore(
             certificates: $this->countReferences($dictionary, 'Certs'),
@@ -46,41 +52,6 @@ final readonly class SecurityStoreReader
             crls: $this->countReferences($dictionary, 'CRLs'),
             signatureKeys: $this->vriKeys($dictionary),
         );
-    }
-
-    /**
-     * The dictionary starting at $start, read by counting its own delimiters.
-     *
-     * A fixed window would have to be wide enough for the largest store and
-     * would then swallow whatever follows the smallest, and /VRI nests, so the
-     * first `>>` is not the end.
-     */
-    private function dictionaryAt(string $pdf, int $start): string
-    {
-        $depth = 0;
-        $length = strlen($pdf);
-
-        for ($position = $start; $position < $length - 1; $position++) {
-            $pair = substr($pdf, $position, 2);
-
-            if ($pair === '<<') {
-                $depth++;
-                $position++;
-
-                continue;
-            }
-
-            if ($pair === '>>') {
-                $depth--;
-                $position++;
-
-                if ($depth === 0) {
-                    return substr($pdf, $start, $position - $start + 1);
-                }
-            }
-        }
-
-        return substr($pdf, $start);
     }
 
     /**

--- a/tests/PdfDictionaryTest.php
+++ b/tests/PdfDictionaryTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use LSNepomuceno\LaravelA1PdfSign\Support\PdfDictionary;
+
+/**
+ * The dictionary walker, asserted on the exact bytes it returns.
+ *
+ * Both callers previously had their own copy and only ever asked the result for
+ * counts, which a boundary off by a byte gives identically. Asserting the
+ * substring is what makes the boundary testable at all, and it is the reason
+ * this is one class rather than two private methods.
+ */
+it('returns the dictionary and nothing after it', function () {
+    // The trap: a fixed window wide enough for the largest dictionary swallows
+    // whatever follows the smallest.
+    $contents = '<</Type/DSS/Certs[1 0 R]>> <</Certs[2 0 R 3 0 R 4 0 R]>>';
+
+    expect(new PdfDictionary()->at($contents, 0))->toBe('<</Type/DSS/Certs[1 0 R]>>');
+});
+
+it('closes at its own depth, not at the first marker it meets', function () {
+    // Stopping at the first ">>" returns a fragment that parses as if the rest
+    // were absent, which reads as a valid answer and is not one.
+    $contents = '<</VRI<</AB<</Cert[1 0 R]>>>>/Certs[1 0 R]>>';
+
+    expect(new PdfDictionary()->at($contents, 0))->toBe($contents);
+});
+
+it('reads a dictionary that starts partway through the string', function () {
+    $contents = 'trailing junk <</Type/DSS>> more junk';
+
+    expect(new PdfDictionary()->at($contents, 14))->toBe('<</Type/DSS>>');
+});
+
+it('reads consecutive openings as separate levels', function () {
+    // "<<<<" is two openings, not three overlapping ones, which is what
+    // advancing past the second delimiter character buys.
+    $contents = '<<<</A 1>>>>';
+
+    expect(new PdfDictionary()->at($contents, 0))->toBe($contents);
+});
+
+it('answers null when the dictionary never closes', function () {
+    expect(new PdfDictionary()->at('<</Type/DSS/Certs[1 0 R]', 0))->toBeNull()
+        ->and(new PdfDictionary()->at('<</A<</B 1>>', 0))->toBeNull();
+});
+
+it('answers null when nothing opens at the offset given', function () {
+    expect(new PdfDictionary()->at('/Type/DSS>>', 0))->toBeNull()
+        ->and(new PdfDictionary()->at('<</Type/DSS>>', 2))->toBeNull()
+        ->and(new PdfDictionary()->at('', 0))->toBeNull()
+        // One delimiter character is not an opening.
+        ->and(new PdfDictionary()->at('<', 0))->toBeNull();
+});
+
+it('reads a dictionary that ends exactly at the end of the string', function () {
+    // The loop stops at length - 1 because it reads two bytes at a time, so a
+    // dictionary closing on the final byte is the case that catches an
+    // off-by-one in the bound.
+    expect(new PdfDictionary()->at('<</A 1>>', 0))->toBe('<</A 1>>');
+});
+
+it('keeps the empty dictionary distinct from an unclosed one', function () {
+    expect(new PdfDictionary()->at('<<>>', 0))->toBe('<<>>');
+});
+
+it('does not go looking for a dictionary that starts elsewhere', function () {
+    // Without the check at the offset, the walker would scan forward and return
+    // a "dictionary" that begins with whatever preceded it. The caller asked
+    // about this position, so a dictionary one byte later is not the answer.
+    expect(new PdfDictionary()->at('x<</A 1>>', 0))->toBeNull()
+        ->and(new PdfDictionary()->at('x<</A 1>>', 1))->toBe('<</A 1>>');
+});


### PR DESCRIPTION
Closes the gap the mutation run on `main` exposed. Validation scored **75.19% against a floor of 75**. Passing by 0.19 of a point on a metric that is not reproducible is not passing, it is waiting to fail a night when nothing changed.

## The survivors were untestable by construction

They were concentrated in `SecurityStoreReader`, and almost all in one private method that walks a PDF dictionary by counting delimiters. It was only ever exercised through **counts of what the result contained**, and a boundary off by a byte gives the same count. An off-by-one in it could not be caught by any test written that way.

`SignatureFieldReader` had its own copy of the same walk, added later, with the same problem.

Both now use `Support\PdfDictionary`, one implementation whose **exact output** a test asserts. Killing the mutations is a side effect of the tests being able to see the boundary at all.

## Two behaviours reconciled rather than merged silently

The shared method answers `null` when a dictionary never closes. The store reader then parses the remainder, because a store the file cut off is still worth reading; the field reader treats the form as unreadable. That difference is now explicit at each call site instead of buried in two copies.

## One dead guard went with it

`SecurityStoreReader` checked that `end()` on the match list returned an array. It always did: the branch above already returned on an empty list, so nothing could reach it. Mutation testing reported it as **uncovered**, which is what dead code looks like from there.

## Numbers

Survivors in Validation fall from **43 to 24**. `PdfDictionary` itself is at 100%.

**The CI number will be lower than the local one, and it is the one that counts.** The plugin derives its timeout from the suite duration, so a slower runner gives mutations more room to finish and survive rather than dying on the clock:

| | CI | Local |
|---|---|---|
| Validation, mutations killed by timeout | 9 | 65 |

That is the whole of the gap between 93% locally and 75% in CI, and it means every local score I have quoted in this repository has been optimistic. I will run the workflow on `main` after this merges and report the real figure.
