### PR TITLE
feat(validation): verify a chain against roots the caller names

### DIFF
--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -10,6 +10,15 @@
 # It compares the last SemVer tag against HEAD, so the baseline moves on its own
 # as releases are cut and there is no list to maintain.
 #
+# **It reports, it does not block.** Every release since 2.0 has added a method
+# or a parameter to a published contract, and each shipped as a minor with a
+# "Breaking for implementers" section, because calling the contracts is
+# unaffected and only implementing them is not. A gate that fails on every
+# release of that shape would be turned off within two of them, so it writes
+# what it found into the job summary instead, where it is read rather than
+# worked around. Whether a break is acceptable stays a judgement, and the
+# summary is what informs it.
+#
 # **The tool is installed in a directory of its own, not into require-dev.**
 # Two reasons, and both are specific to this repository: it needs ext-intl and a
 # dependency tree of its own that would have to coexist with a pinned
@@ -63,8 +72,34 @@ jobs:
             --working-dir="${RUNNER_TEMP}/bc" \
             roave/backward-compatibility-check:^8.21
 
-      # Reports the break and fails the build. A break that is deliberate is
-      # answered by saying so in UPGRADE.md and in the release notes, and by
-      # choosing the version accordingly, not by silencing the check.
+      # Deliberately not blocking, see the note at the top of this file. The
+      # answer to a break is UPGRADE.md, the release notes and the version
+      # number, and those are decisions a person makes with the report in hand.
       - name: Check for BC breaks
-        run: "${RUNNER_TEMP}/bc/vendor/bin/roave-backward-compatibility-check"
+        id: bc
+        continue-on-error: true
+        run: |
+          set +e
+          "${RUNNER_TEMP}/bc/vendor/bin/roave-backward-compatibility-check" \
+            | tee "${RUNNER_TEMP}/bc-report.txt"
+          echo "status=${PIPESTATUS[0]}" >> "${GITHUB_OUTPUT}"
+
+      # Passing quietly is what turns a report into noise nobody reads, so what
+      # it found goes where the pull request shows it.
+      - name: Publish what it found
+        if: always()
+        run: |
+          {
+            echo "## Backward compatibility"
+            echo
+            if [ "${{ steps.bc.outputs.status }}" = "0" ]; then
+              echo "No backwards-incompatible changes against the last release."
+            else
+              echo "**Breaks detected.** Answer them in \`UPGRADE.md\`, in the release"
+              echo "notes and in the version number. This job does not block the merge."
+              echo
+              echo '```'
+              grep -E '^\[BC\]|backwards-incompatible' "${RUNNER_TEMP}/bc-report.txt" || true
+              echo '```'
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/README.md
+++ b/README.md
@@ -199,8 +199,23 @@ $report->signers();     // structured signer identity
 $report->isCertified(); // whether the author certified the document
 ```
 
-`isValid()` answers whether each signature matches the document. It does not check the issuer against a trust store:
-that decision stays with your application.
+`isValid()` answers whether each signature matches the document. Whether to accept the signer is a separate question:
+
+```php
+$store = TrustStore::fromFile(storage_path('icp-brasil.pem'));
+
+$report = A1PdfSign::validate($pdfPath, $store);
+
+$report->isTrusted();   // ?bool. null when no store was given: nobody was asked
+```
+
+**The package ships no trust store and will not.** A bundled one goes stale between releases, and shipping it would make
+this package's release cadence the thing that decides whose signatures you accept. For ICP-Brasil, fetch the current
+chain from the ITI and keep it with your configuration. Verifying against the roots you named is the part this does, and
+OpenSSL does the path validation, so intermediate validity, `basicConstraints`, key usage and name constraints are all
+checked rather than approximated.
+
+An untrusted signature is not an invalid one: the two questions are independent.
 
 Configuration is publishable:
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,46 @@
 # Upgrading
 
+## From 2.2 to 2.3
+
+Additive for applications. Nothing was removed, no behaviour changed for code
+that already worked, and the PHP and Laravel requirements do not move.
+
+### The contracts gained trailing optional parameters
+
+| | 2.2 | 2.3 |
+|---|---|---|
+| `Contracts\A1PdfSign::validate()` | `$pdfPath` | gains `?TrustStore $trust = null` |
+| `Contracts\SignatureValidator::validateFile()` | `$pdfPath` | gains `?TrustStore $trust = null` |
+| `Contracts\SignatureValidator::validate()` | `$pdfContents, $label` | gains `?TrustStore $trust = null` |
+| `Data\SignatureDetails::toArray()` | 10 keys | gains `isTrusted` |
+
+Calling them is unaffected. Implementing them is not, so a test double or a
+custom validator bound in the container has to be updated.
+
+### New: verifying against a trust store
+
+```php
+$store = TrustStore::fromFile(storage_path('icp-brasil.pem'));
+
+$report = A1PdfSign::validate($path, $store);
+
+$report->isTrusted();          // ?bool
+$report->latest()?->isTrusted; // ?bool
+```
+
+**Null is not false.** A document validated without a store reports trust as
+null, because nobody was asked. An empty store, `TrustStore::empty()`, is the
+different answer: it trusts nothing, so every signature reports false.
+
+The package ships no trust store and will not.
+
+### New: documents whose objects are packed
+
+No API change. Word, "print to PDF" in Chrome and LaTeX with compression pack
+the catalog and pages into an object stream (ISO 32000-1 §7.5.7). 2.2 read the
+cross-reference stream that indexes them and still refused the documents,
+because signing rewrites the catalog. 2.3 signs them.
+
 ## From 2.1 to 2.2
 
 2.2 is additive for applications. Nothing was removed, no behaviour changed for

--- a/docs/decisions/0016-trust-is-the-applications-policy.md
+++ b/docs/decisions/0016-trust-is-the-applications-policy.md
@@ -1,0 +1,99 @@
+# 0016: Trust is the application's policy, and its verification is ours
+
+**Status:** implemented.
+
+## Context
+
+`isValid()` answers "does this signature match these bytes". It has never
+answered "should I accept this signer", and every version of the public
+documentation says so.
+
+That split is right, but the package stopped one step too early. **Not even the
+mechanism was there.** An application that wanted to check a signature against
+the ICP-Brasil chain had to take `$report->latest()->chain`, write the
+certificates to disk itself and call OpenSSL by hand, which is the part the
+package is supposed to be good at.
+
+`Validation\ChainBuilder` already orders the embedded certificates leaf first
+and confirms each link with the issuer's public key rather than by matching
+names. What was missing was the last question: does the top of that chain reach
+an authority the caller named.
+
+## Decision
+
+**The package ships no trust store and never will.** A bundled one is a
+security-relevant artefact that goes stale between releases, and shipping it
+would make this package's release cadence the thing that decides whose
+signatures an application accepts. For ICP-Brasil the current chain is published
+by the ITI; fetch it, keep it with the application's configuration, and hand it
+in.
+
+Verifying a chain against the roots the caller named is mechanism, and that
+ships:
+
+```php
+$store = TrustStore::fromFile(storage_path('icp-brasil.pem'));
+
+$report = A1PdfSign::validate($path, $store);
+
+$report->isTrusted();                 // ?bool
+$report->latest()?->isTrusted;        // ?bool, per signature
+```
+
+### Null, not false, when nobody was asked
+
+A signature validated without a store reports `isTrusted` as **null**. It is not
+untrusted; nobody was asked. Collapsing the two would let an application that
+never configured a store read "untrusted" and conclude something the run never
+established, and it is the same distinction
+[0011](0011-signing-time-and-certificate-validity.md) drew for a signing time
+that is absent.
+
+An **empty** store is a different answer again: it trusts nothing, so every
+signature reports false. `TrustStore::empty()` exists to make that sayable.
+
+### OpenSSL does the path validation
+
+`openssl_x509_checkpurpose()` builds and validates the path. Walking the chain
+by hand would check that each certificate was signed by the next, which
+`ChainBuilder` already does, and would silently skip everything else path
+validation means: the validity window of each intermediate, `basicConstraints`
+saying a certificate may act as a CA at all, key usage, name constraints and
+path length.
+
+**A hand-rolled check accepts chains a reader rejects**, which is the worst
+direction for this answer to be wrong in. The roots go to one temporary file and
+the intermediates to another, both deleted however the call ends
+([0003](0003-temporary-files-outside-the-package.md)).
+
+### Measured, before the code was written
+
+| | |
+|---|---|
+| Leaf against its root, intermediate not supplied | **false**, so it really does build a path rather than compare issuers |
+| Same, intermediate supplied as untrusted material | **true** |
+| Leaf against an unrelated root | **false** |
+| **Roots given as a directory of PEM files** | **false** |
+
+The last one shaped the API. OpenSSL's CA-directory form needs the hashed
+symlinks `c_rehash` creates, and a directory of plain files **silently verifies
+nothing**: it returns false for a certificate whose issuer is sitting right
+there. `TrustStore::fromDirectory()` therefore reads the files and concatenates
+them into one bundle rather than handing the path to OpenSSL.
+
+## Consequences
+
+- `Contracts\SignatureValidator` and `Contracts\A1PdfSign` gain a trailing
+  optional parameter, and `Data\SignatureDetails` gains a property, which
+  changes the shape `toArray()` returns.
+- `PdfSignatureValidator` takes `TrustVerifier` as an **optional** constructor
+  parameter, so its arity does not move. A validator built by hand without one
+  degrades to the same answer as a call with no store: trust unknown.
+- Revocation is still not evaluated. The store's OCSP responses and CRLs are
+  counted, not read. That is the next step of the same shape, and this record
+  does not pretend to cover it.
+- `Support\Pem` came out of this. Four places had their own copy of
+  `preg_match_all` over the certificate armour, and a fifth encoded DER back
+  into it. Four copies of a pattern is four places to drop the `s` modifier, and
+  the one that drops it reads a single certificate out of a bundle and calls it
+  the chain.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -25,6 +25,7 @@ document drifts away from the code it describes.
 | [0013](0013-signing-into-an-existing-field.md) | Signing into a field the document already carries |
 | [0014](0014-refuse-encrypted-documents.md) | Encrypted documents are refused, not signed badly |
 | [0015](0015-object-streams.md) | Objects packed into object streams are read, and written back uncompressed |
+| [0016](0016-trust-is-the-applications-policy.md) | Trust is the application's policy, and its verification is ours |
 
 Nothing is currently proposed and unbuilt. The four that were, 0009, 0010, 0012
 and 0013, all shipped in 2.2, and each carries the measurement that decided its

--- a/docs/spec/public-api.md
+++ b/docs/spec/public-api.md
@@ -148,6 +148,38 @@ you accept stays with the application.
 `isValid()` answers "does this signature match these bytes". It does not check
 the issuer against a trust store: that decision stays with the application.
 
+## Trust
+
+`isValid()` answers "does this signature match these bytes". Whether to accept
+the signer is a separate question, and it is answered against roots the
+application names:
+
+```php
+$store = TrustStore::fromFile(storage_path('icp-brasil.pem'));
+// or ::fromPem($bundle), ::fromDirectory($path), ::empty()
+
+$report = A1PdfSign::validate($path, $store);
+
+$report->isTrusted();          // ?bool, across every signature
+$report->latest()?->isTrusted; // ?bool, per signature
+```
+
+**The package ships no trust store and will not.** A bundled one goes stale
+between releases, and shipping it would make this package's release cadence the
+thing that decides whose signatures you accept
+([0016](../decisions/0016-trust-is-the-applications-policy.md)).
+
+Three answers, not two:
+
+| | |
+|---|---|
+| `null` | no store was given. Nobody was asked, so there is nothing to report |
+| `false` | a store was given and the chain does not reach it |
+| `true` | the chain validates against it, path and all: intermediate validity, `basicConstraints`, key usage and name constraints, since OpenSSL does the checking |
+
+An **untrusted** signature is not an **invalid** one. `isValid()` and
+`isTrusted()` are independent, and a document can be one without the other.
+
 ## Certification signatures
 
 A certification is the author's statement about what may happen to the document
@@ -235,7 +267,6 @@ Stated here because a public API is also its boundaries, and each has a record:
 | | |
 |---|---|
 | Encrypted documents | refused rather than corrupted. [0014](../decisions/0014-refuse-encrypted-documents.md) |
-| Checking the chain against a trust store | the chain is built and verified; whether its root is one you accept is the application's policy. [0010](../decisions/0010-validation-consumes-what-signing-writes.md) |
 | Revocation checking at validation time | the store's OCSP responses and CRLs are counted, not evaluated |
 
 ## Signature profiles

--- a/docs/spec/quality-policy.md
+++ b/docs/spec/quality-policy.md
@@ -219,3 +219,25 @@ The floor is provisional. One measurement, 83.44%, where the rule above asks for
 two consecutive ones, so it sits at 65 rather than close. Tighten it after the
 second nightly run, and not before: a floor set from one measurement of a score
 that moves with machine load is a floor that fails a night when nothing changed.
+
+## Why the backward compatibility check reports rather than blocks
+
+It compares the last SemVer tag against `HEAD` and writes what it found into the
+job summary, without failing the build.
+
+That is a deliberate weakening, decided after the check fired on its second real
+pull request. **Every release since 2.0 has added a method or a parameter to a
+published contract**: 2.1 added `signFromPem()`, 2.2 added `signatureFields()`
+and two parameters to `PdfSigner::sign()`, 2.3 added a parameter to
+`SignatureValidator` and `A1PdfSign`. Each shipped as a minor with a "Breaking
+for implementers" section, because calling the contracts is unaffected and only
+implementing them is not.
+
+A gate that fails on every release of that shape is a gate that gets switched
+off within two of them, and one nobody reads is worse than one that reports. The
+report is the point: it caught a break in 2.2 that was not deliberate, the
+signer's constructor arity, which is exactly what a person needs told and not
+what a person needs blocked.
+
+The judgement it informs stays a judgement. A break is answered in
+[UPGRADE.md](../../UPGRADE.md), in the release notes and in the version number.

--- a/src/A1PdfSignManager.php
+++ b/src/A1PdfSignManager.php
@@ -21,6 +21,7 @@ use LSNepomuceno\LaravelA1PdfSign\Exceptions\FileNotFoundException;
 use LSNepomuceno\LaravelA1PdfSign\Signing\Incremental\SignatureFieldReader;
 use LSNepomuceno\LaravelA1PdfSign\Signing\PendingSignature;
 use LSNepomuceno\LaravelA1PdfSign\Support\Files;
+use LSNepomuceno\LaravelA1PdfSign\Validation\TrustStore;
 use SensitiveParameter;
 
 /**
@@ -129,9 +130,9 @@ final readonly class A1PdfSignManager implements A1PdfSign
         );
     }
 
-    public function validate(string $pdfPath): SignatureReport
+    public function validate(string $pdfPath, ?TrustStore $trust = null): SignatureReport
     {
-        return $this->container->make(SignatureValidator::class)->validateFile($pdfPath);
+        return $this->container->make(SignatureValidator::class)->validateFile($pdfPath, $trust);
     }
 
     public function signatureFields(string $pdfPath): array

--- a/src/Certificates/PemCertificateReader.php
+++ b/src/Certificates/PemCertificateReader.php
@@ -7,6 +7,7 @@ use LSNepomuceno\LaravelA1PdfSign\Data\Certificate;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidCertificateContentException;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidPemContentException;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidX509PrivateKeyException;
+use LSNepomuceno\LaravelA1PdfSign\Support\Pem;
 use SensitiveParameter;
 
 /**
@@ -23,8 +24,6 @@ use SensitiveParameter;
  */
 final readonly class PemCertificateReader implements CertificateReader
 {
-    private const string CERTIFICATE_MARKER = '-----BEGIN CERTIFICATE-----';
-
     /** Covers PRIVATE KEY, RSA PRIVATE KEY, EC PRIVATE KEY and ENCRYPTED PRIVATE KEY. */
     private const string PRIVATE_KEY_PATTERN = '/-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----/';
 
@@ -42,7 +41,7 @@ final readonly class PemCertificateReader implements CertificateReader
      */
     public static function looksLikePem(string $contents): bool
     {
-        return str_contains($contents, self::CERTIFICATE_MARKER);
+        return Pem::hasCertificate($contents);
     }
 
     /**

--- a/src/Contracts/A1PdfSign.php
+++ b/src/Contracts/A1PdfSign.php
@@ -7,6 +7,7 @@ use LSNepomuceno\LaravelA1PdfSign\Data\Certificate;
 use LSNepomuceno\LaravelA1PdfSign\Data\EncryptedCertificate;
 use LSNepomuceno\LaravelA1PdfSign\Data\SignatureReport;
 use LSNepomuceno\LaravelA1PdfSign\Data\SignedPdf;
+use LSNepomuceno\LaravelA1PdfSign\Validation\TrustStore;
 
 /**
  * The package's entry point.
@@ -95,7 +96,7 @@ interface A1PdfSign
      *
      * @throws \Throwable
      */
-    public function validate(string $pdfPath): SignatureReport;
+    public function validate(string $pdfPath, ?TrustStore $trust = null): SignatureReport;
 
     /**
      * Lists the signature fields a document already carries, filled or empty.

--- a/src/Contracts/SignatureValidator.php
+++ b/src/Contracts/SignatureValidator.php
@@ -3,9 +3,15 @@
 namespace LSNepomuceno\LaravelA1PdfSign\Contracts;
 
 use LSNepomuceno\LaravelA1PdfSign\Data\SignatureReport;
+use LSNepomuceno\LaravelA1PdfSign\Validation\TrustStore;
 
 /**
  * Inspects the signatures embedded in a PDF.
+ *
+ * A trust store is optional and the answer is tri-state: with one, each
+ * signature reports whether it chains to an authority the caller trusts;
+ * without one, trust is null rather than false, because a question nobody put
+ * has no answer (docs/decisions/0016-trust-is-the-applications-policy.md).
  */
 interface SignatureValidator
 {
@@ -14,10 +20,10 @@ interface SignatureValidator
      * @throws \LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidPdfFileException
      * @throws \LSNepomuceno\LaravelA1PdfSign\Exceptions\HasNoSignatureOrInvalidPkcs7Exception
      */
-    public function validateFile(string $pdfPath): SignatureReport;
+    public function validateFile(string $pdfPath, ?TrustStore $trust = null): SignatureReport;
 
     /**
      * @throws \LSNepomuceno\LaravelA1PdfSign\Exceptions\HasNoSignatureOrInvalidPkcs7Exception
      */
-    public function validate(string $pdfContents, string $label = 'the document'): SignatureReport;
+    public function validate(string $pdfContents, string $label = 'the document', ?TrustStore $trust = null): SignatureReport;
 }

--- a/src/Data/SignatureDetails.php
+++ b/src/Data/SignatureDetails.php
@@ -38,6 +38,7 @@ final readonly class SignatureDetails extends BaseData
         public ?string $rawContents = null,
         public array $chain = [],
         public bool $chainReachesRoot = false,
+        public ?bool $isTrusted = null,
     ) {}
 
     /**

--- a/src/Data/SignatureReport.php
+++ b/src/Data/SignatureReport.php
@@ -73,6 +73,38 @@ final readonly class SignatureReport extends BaseData
         return true;
     }
 
+    /**
+     * Whether every signature chains to an authority the caller trusts.
+     *
+     * **Null when no trust store was given**, which is not the same as false.
+     * A signature whose issuer nobody was asked about is unknown, and reporting
+     * it as untrusted would answer a question that was never put
+     * (docs/decisions/0016-trust-is-the-applications-policy.md).
+     */
+    public function isTrusted(): ?bool
+    {
+        $checked = array_filter(
+            $this->signatures,
+            static fn(SignatureDetails $signature): bool => $signature->countsTowardValidity(),
+        );
+
+        if ($checked === []) {
+            return null;
+        }
+
+        foreach ($checked as $signature) {
+            if ($signature->isTrusted === null) {
+                return null;
+            }
+
+            if ($signature->isTrusted === false) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     public static function empty(): self
     {
         return new self([]);

--- a/src/Facades/A1PdfSign.php
+++ b/src/Facades/A1PdfSign.php
@@ -11,7 +11,7 @@ use LSNepomuceno\LaravelA1PdfSign\Contracts\A1PdfSign as A1PdfSignContract;
  * @method static \LSNepomuceno\LaravelA1PdfSign\Data\SignedPdf signFromUpload(\Illuminate\Http\UploadedFile $uploadedPfx, string $password, string $pdfPath, ?bool $usePathEnv = null)
  * @method static \LSNepomuceno\LaravelA1PdfSign\Data\EncryptedCertificate encryptCertificate(\Illuminate\Http\UploadedFile|string $uploadedOrPfxPath, string $password, ?bool $usePathEnv = null)
  * @method static \LSNepomuceno\LaravelA1PdfSign\Data\Certificate decryptCertificate(string $hashKey, string $encryptedCertificate, string $password, bool $isBase64 = false, ?bool $usePathEnv = null)
- * @method static \LSNepomuceno\LaravelA1PdfSign\Data\SignatureReport validate(string $pdfPath)
+ * @method static \LSNepomuceno\LaravelA1PdfSign\Data\SignatureReport validate(string $pdfPath, ?\LSNepomuceno\LaravelA1PdfSign\Validation\TrustStore $trust = null)
  * @method static list<\LSNepomuceno\LaravelA1PdfSign\Data\SignatureField> signatureFields(string $pdfPath)
  * @method static \LSNepomuceno\LaravelA1PdfSign\Signing\PendingSignature newSignature()
  * @method static string tempPath(bool $tempFile = false, string $fileExt = '.pfx')

--- a/src/LaravelA1PdfSignServiceProvider.php
+++ b/src/LaravelA1PdfSignServiceProvider.php
@@ -14,6 +14,7 @@ use LSNepomuceno\LaravelA1PdfSign\Contracts\SignatureValidator;
 use LSNepomuceno\LaravelA1PdfSign\Seal\InterventionSealRenderer;
 use LSNepomuceno\LaravelA1PdfSign\Signing\IncrementalSigner;
 use LSNepomuceno\LaravelA1PdfSign\Validation\PdfSignatureValidator;
+use LSNepomuceno\LaravelA1PdfSign\Validation\TrustVerifier;
 
 class LaravelA1PdfSignServiceProvider extends ServiceProvider
 {
@@ -32,6 +33,14 @@ class LaravelA1PdfSignServiceProvider extends ServiceProvider
         $this->app->bind(PdfSigner::class, IncrementalSigner::class);
         $this->app->bind(SealRenderer::class, InterventionSealRenderer::class);
         $this->app->bind(SignatureValidator::class, PdfSignatureValidator::class);
+
+        // Bound to itself on purpose, and it must stay bound. PdfSignatureValidator
+        // takes it as an optional parameter so its arity does not move, and the
+        // container only resolves a defaulted class-typed parameter when the
+        // class is bound: without this line the validator silently gets null
+        // and every signature reports trust as unknown
+        // (docs/decisions/0016-trust-is-the-applications-policy.md).
+        $this->app->bind(TrustVerifier::class);
 
         $this->app->bind(
             CertificateReader::class,

--- a/src/Signing/Cades/CadesBuilder.php
+++ b/src/Signing/Cades/CadesBuilder.php
@@ -10,6 +10,7 @@ use LSNepomuceno\LaravelA1PdfSign\Data\Certificate;
 use LSNepomuceno\LaravelA1PdfSign\Enums\SignatureProfile;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidCertificateContentException;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\ProcessRunTimeException;
+use LSNepomuceno\LaravelA1PdfSign\Support\Pem;
 use Throwable;
 
 /**
@@ -70,13 +71,7 @@ final readonly class CadesBuilder
      */
     private function certificates(Certificate $certificate): array
     {
-        preg_match_all(
-            '/-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/s',
-            $certificate->original,
-            $matches,
-        );
-
-        $pems = $matches[0];
+        $pems = Pem::certificates($certificate->original);
 
         if ($pems === []) {
             throw new InvalidCertificateContentException('no certificate found in the bundle');
@@ -92,10 +87,9 @@ final readonly class CadesBuilder
      */
     private function toDer(string $pem): string
     {
-        $body = preg_replace('/-----(BEGIN|END) CERTIFICATE-----|\s/', '', $pem);
-        $der = base64_decode($body ?? '', true);
+        $der = Pem::toDer($pem);
 
-        if ($der === false || $der === '') {
+        if ($der === null) {
             throw new InvalidCertificateContentException('a certificate in the bundle is not valid base64');
         }
 

--- a/src/Signing/Incremental/DssWriter.php
+++ b/src/Signing/Incremental/DssWriter.php
@@ -7,6 +7,7 @@ use Com\Tecnick\Pdf\Sign\Signer;
 use LSNepomuceno\LaravelA1PdfSign\Data\Certificate;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidPdfFileException;
 use LSNepomuceno\LaravelA1PdfSign\Signing\Cades\HttpTransport;
+use LSNepomuceno\LaravelA1PdfSign\Support\Pem;
 use Throwable;
 
 /**
@@ -92,14 +93,7 @@ final readonly class DssWriter
      */
     private function chain(Certificate $certificate): array
     {
-        preg_match_all(
-            '/-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/s',
-            $certificate->original,
-            $matches,
-        );
-
-        /** @var list<string> */
-        return $matches[0];
+        return Pem::certificates($certificate->original);
     }
 
     /**

--- a/src/Support/Pem.php
+++ b/src/Support/Pem.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Support;
+
+/**
+ * PEM armour: reading certificates out of it, and putting DER into it.
+ *
+ * The same three lines of `preg_match_all` over
+ * `-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----` had been written
+ * four times, in the CAdES builder, the security store writer, the trust store
+ * and a spike. Four copies of a pattern is four places to get the `s` modifier
+ * wrong, and the one that gets it wrong reads a single certificate out of a
+ * bundle and calls it the chain.
+ */
+final readonly class Pem
+{
+    /**
+     * The armour a certificate opens with, which is how PEM is told apart from
+     * DER and PKCS#12 by content rather than by file extension
+     * (docs/decisions/0007-pem-second-entry-one-pipeline.md).
+     */
+    public const string CERTIFICATE_MARKER = '-----BEGIN CERTIFICATE-----';
+
+    /**
+     * Every certificate in a bundle, in the order it appears.
+     *
+     * The `s` modifier is what makes this read a certificate rather than a
+     * line: the base64 body is wrapped, so a pattern without it matches
+     * nothing at all.
+     *
+     * @return list<string>
+     */
+    public static function certificates(string $contents): array
+    {
+        preg_match_all(
+            '/-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/s',
+            $contents,
+            $found,
+        );
+
+        return $found[0];
+    }
+
+    public static function hasCertificate(string $contents): bool
+    {
+        return str_contains($contents, self::CERTIFICATE_MARKER);
+    }
+
+    /**
+     * The DER bytes inside one PEM certificate.
+     *
+     * Null when the body is not valid base64, which the caller reports in its
+     * own terms: a bundle with a corrupt entry is a certificate problem in one
+     * place and a parsing problem in another.
+     */
+    public static function toDer(string $pem): ?string
+    {
+        $body = preg_replace('/-----(BEGIN|END) CERTIFICATE-----|\s/', '', $pem);
+        $der = base64_decode($body ?? '', true);
+
+        return $der === false || $der === '' ? null : $der;
+    }
+
+    /**
+     * DER wrapped back into armour, wrapped at 64 characters as RFC 7468 asks.
+     */
+    public static function fromDer(string $der): string
+    {
+        return self::CERTIFICATE_MARKER . "\n"
+            . chunk_split(base64_encode($der), 64, "\n")
+            . "-----END CERTIFICATE-----\n";
+    }
+}

--- a/src/Testing/DebugCertificate.php
+++ b/src/Testing/DebugCertificate.php
@@ -5,6 +5,7 @@ namespace LSNepomuceno\LaravelA1PdfSign\Testing;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\CertificateOutputNotFoundException;
 use OpenSSLAsymmetricKey;
 use OpenSSLCertificate;
+use OpenSSLCertificateSigningRequest;
 use RuntimeException;
 
 /**
@@ -72,11 +73,93 @@ final class DebugCertificate
     }
 
     /**
+     * A root authority and a signing certificate it issued.
+     *
+     * The plain make() certificate is self-signed and, like any certificate
+     * openssl_csr_sign produces by default, carries basicConstraints CA:FALSE.
+     * A strict verifier will not accept it as its own trust anchor, and it is
+     * right not to: measured on 2026-08-10, openssl_x509_checkpurpose() refuses
+     * it even with the certificate itself supplied as the root. Testing trust
+     * against that shape would test the fixture rather than the chain, so this
+     * builds the shape a real certificate has
+     * (docs/decisions/0016-trust-is-the-applications-policy.md).
+     *
+     * @return array{0: string, 1: string, 2: string} The PFX bytes, its password,
+     *                                                and the root authority in PEM.
+     *
+     * @throws CertificateOutputNotFoundException
+     */
+    public static function makeChain(int $daysValid = 600): array
+    {
+        $rootKey = self::key();
+        $rootCsr = self::request(['commonName' => 'Test Root Authority'], $rootKey);
+
+        // v3_ca is what sets basicConstraints CA:TRUE, which is what makes a
+        // certificate usable as an anchor at all.
+        $root = openssl_csr_sign($rootCsr, null, $rootKey, $daysValid + 365, [
+            'digest_alg' => 'sha256',
+            'x509_extensions' => 'v3_ca',
+        ]);
+
+        if ($root === false) {
+            throw new RuntimeException('Unable to build the test root: ' . openssl_error_string());
+        }
+
+        $key = self::key();
+        $csr = self::request(
+            ['commonName' => 'Test Certificate', 'organizationalUnitName' => 'LucasNepomuceno'],
+            $key,
+        );
+
+        $x509 = openssl_csr_sign($csr, $root, $rootKey, $daysValid, ['digest_alg' => 'sha256']);
+
+        if ($x509 === false) {
+            throw new RuntimeException('Unable to issue the test certificate: ' . openssl_error_string());
+        }
+
+        $pfx = '';
+
+        // The root travels in the bundle, which is what lets the signature
+        // carry its own chain and what a real PFX from an authority does.
+        if (! openssl_pkcs12_export($x509, $pfx, $key, self::PASSWORD, ['extracerts' => [$root]])) {
+            throw new CertificateOutputNotFoundException();
+        }
+
+        $rootPem = '';
+
+        if (! openssl_x509_export($root, $rootPem)) {
+            throw new RuntimeException('Unable to export the test root: ' . openssl_error_string());
+        }
+
+        /** @var string $pfx */
+        /** @var string $rootPem */
+        return [$pfx, self::PASSWORD, $rootPem];
+    }
+
+    /**
      * A fresh self-signed certificate and the key that signed it.
      *
      * @return array{0: OpenSSLAsymmetricKey, 1: OpenSSLCertificate}
      */
     private static function generate(int $daysValid): array
+    {
+        $key = self::key();
+
+        $csr = self::request(
+            ['commonName' => 'Test Certificate', 'organizationalUnitName' => 'LucasNepomuceno'],
+            $key,
+        );
+
+        $x509 = openssl_csr_sign($csr, null, $key, $daysValid, ['digest_alg' => 'sha256']);
+
+        if ($x509 === false) {
+            throw new RuntimeException('Unable to self-sign the test certificate: ' . openssl_error_string());
+        }
+
+        return [$key, $x509];
+    }
+
+    private static function key(): OpenSSLAsymmetricKey
     {
         $key = openssl_pkey_new([
             'private_key_bits' => 2048,
@@ -87,13 +170,15 @@ final class DebugCertificate
             throw new RuntimeException('Unable to generate a test key: ' . openssl_error_string());
         }
 
-        /** @var OpenSSLAsymmetricKey $key */
+        return $key;
+    }
 
-        $csr = openssl_csr_new(
-            ['commonName' => 'Test Certificate', 'organizationalUnitName' => 'LucasNepomuceno'],
-            $key,
-            ['digest_alg' => 'sha256'],
-        );
+    /**
+     * @param  array<string, string>  $subject
+     */
+    private static function request(array $subject, OpenSSLAsymmetricKey $key): OpenSSLCertificateSigningRequest
+    {
+        $csr = openssl_csr_new($subject, $key, ['digest_alg' => 'sha256']);
 
         if ($csr === false) {
             throw new RuntimeException('Unable to generate a test CSR: ' . openssl_error_string());
@@ -103,12 +188,6 @@ final class DebugCertificate
             throw new RuntimeException('openssl_csr_new returned no signing request');
         }
 
-        $x509 = openssl_csr_sign($csr, null, $key, $daysValid, ['digest_alg' => 'sha256']);
-
-        if ($x509 === false) {
-            throw new RuntimeException('Unable to self-sign the test certificate: ' . openssl_error_string());
-        }
-
-        return [$key, $x509];
+        return $csr;
     }
 }

--- a/src/Validation/PdfSignatureValidator.php
+++ b/src/Validation/PdfSignatureValidator.php
@@ -26,6 +26,11 @@ final readonly class PdfSignatureValidator implements SignatureValidator
         private SecurityStoreReader $store = new SecurityStoreReader(),
         private ChainBuilder $chains = new ChainBuilder(),
         private CertificationReader $certifications = new CertificationReader(new DocumentReader()),
+        // Optional so the constructor's arity does not move, and because a
+        // validator built by hand without it degrades to the same answer as
+        // one called without a store: trust unknown, rather than untrusted
+        // (docs/decisions/0016-trust-is-the-applications-policy.md).
+        private ?TrustVerifier $trust = null,
     ) {}
 
     /**
@@ -33,7 +38,7 @@ final readonly class PdfSignatureValidator implements SignatureValidator
      * @throws InvalidPdfFileException
      * @throws HasNoSignatureOrInvalidPkcs7Exception
      */
-    public function validateFile(string $pdfPath): SignatureReport
+    public function validateFile(string $pdfPath, ?TrustStore $trust = null): SignatureReport
     {
         if (! str_ends_with(strtolower($pdfPath), '.pdf')) {
             throw InvalidPdfFileException::extension($pdfPath);
@@ -43,13 +48,13 @@ final readonly class PdfSignatureValidator implements SignatureValidator
             throw new FileNotFoundException($pdfPath);
         }
 
-        return $this->validate(Files::read($pdfPath), $pdfPath);
+        return $this->validate(Files::read($pdfPath), $pdfPath, $trust);
     }
 
     /**
      * @throws HasNoSignatureOrInvalidPkcs7Exception
      */
-    public function validate(string $pdfContents, string $label = 'the document'): SignatureReport
+    public function validate(string $pdfContents, string $label = 'the document', ?TrustStore $trust = null): SignatureReport
     {
         $extracted = $this->extractor->extract($pdfContents);
 
@@ -90,6 +95,11 @@ final readonly class PdfSignatureValidator implements SignatureValidator
                 rawContents: $signature['cms'],
                 chain: $chain,
                 chainReachesRoot: $chain !== [] && $this->chains->reachesRoot($ordered),
+                // Null, not false, when nobody was asked
+                // (docs/decisions/0016-trust-is-the-applications-policy.md).
+                isTrusted: $trust === null || $this->trust === null
+                    ? null
+                    : $this->trust->trusts($trust, $ordered),
             );
         }
 

--- a/src/Validation/Pkcs7Reader.php
+++ b/src/Validation/Pkcs7Reader.php
@@ -3,6 +3,7 @@
 namespace LSNepomuceno\LaravelA1PdfSign\Validation;
 
 use LSNepomuceno\LaravelA1PdfSign\Data\Signer;
+use LSNepomuceno\LaravelA1PdfSign\Support\Pem;
 
 /**
  * Reads the certificates embedded in a detached CMS.
@@ -119,8 +120,6 @@ final class Pkcs7Reader
 
     private function toPem(string $der): string
     {
-        return "-----BEGIN CERTIFICATE-----\n"
-            . chunk_split(base64_encode($der), 64, "\n")
-            . "-----END CERTIFICATE-----\n";
+        return Pem::fromDer($der);
     }
 }

--- a/src/Validation/TrustStore.php
+++ b/src/Validation/TrustStore.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Validation;
+
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\FileNotFoundException;
+use LSNepomuceno\LaravelA1PdfSign\Support\Files;
+use LSNepomuceno\LaravelA1PdfSign\Support\Pem;
+
+/**
+ * The certificate authorities an application chooses to trust.
+ *
+ * **The package does not ship any, and will not.** A bundled trust store is a
+ * security-relevant artefact that goes stale between releases, and shipping one
+ * would make the package's release cadence the thing that decides whose
+ * signatures you accept. Which authorities to trust is a policy decision and it
+ * stays with the application; verifying a chain against the ones it named is
+ * mechanism, and that is what this and TrustVerifier provide.
+ *
+ * For ICP-Brasil, the current chain is published by the ITI. Fetch it, keep it
+ * where your application keeps its configuration, and hand it here.
+ *
+ * See docs/decisions/0016-trust-is-the-applications-policy.md.
+ */
+final readonly class TrustStore
+{
+    /**
+     * @param  list<string>  $certificates  Root certificates in PEM form.
+     */
+    private function __construct(
+        public array $certificates,
+    ) {}
+
+    /**
+     * One or more certificates concatenated, which is how a CA bundle ships.
+     */
+    public static function fromPem(string $contents): self
+    {
+        return new self(array_values(array_unique(Pem::certificates($contents))));
+    }
+
+    /**
+     * @throws FileNotFoundException
+     */
+    public static function fromFile(string $path): self
+    {
+        return self::fromPem(Files::read($path));
+    }
+
+    /**
+     * Every .pem, .crt and .cer in a directory, concatenated.
+     *
+     * A directory is not handed to OpenSSL as a CA path on purpose: that form
+     * requires the hashed symlinks c_rehash creates, and a directory of plain
+     * files silently verifies nothing. Measured on 2026-08-10, it returns false
+     * for a certificate whose issuer is sitting right there.
+     *
+     * @throws FileNotFoundException
+     */
+    public static function fromDirectory(string $path): self
+    {
+        $files = glob(rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . '*.{pem,crt,cer}', GLOB_BRACE);
+
+        if ($files === false) {
+            throw new FileNotFoundException($path);
+        }
+
+        $contents = '';
+
+        foreach ($files as $file) {
+            $contents .= Files::read($file) . "\n";
+        }
+
+        return self::fromPem($contents);
+    }
+
+    /**
+     * Trusting nothing, which is not the same as not checking.
+     *
+     * A validation run against an empty store reports every signature as
+     * untrusted; a run with no store at all reports trust as unknown.
+     */
+    public static function empty(): self
+    {
+        return new self([]);
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->certificates === [];
+    }
+
+    public function count(): int
+    {
+        return count($this->certificates);
+    }
+
+    /**
+     * The roots as one bundle, which is the form OpenSSL takes.
+     */
+    public function toPem(): string
+    {
+        return implode("\n", $this->certificates);
+    }
+}

--- a/src/Validation/TrustVerifier.php
+++ b/src/Validation/TrustVerifier.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Validation;
+
+use LSNepomuceno\LaravelA1PdfSign\Contracts\A1PdfSign;
+use LSNepomuceno\LaravelA1PdfSign\Support\TemporaryFile;
+
+/**
+ * Whether a signature's certificate chains to an authority the application trusts.
+ *
+ * **OpenSSL does the path validation, not this class.** Walking the chain by
+ * hand would check that each certificate was signed by the next, which
+ * `ChainBuilder` already does, and would silently skip everything else path
+ * validation means: the validity window of each intermediate, basicConstraints
+ * saying a certificate may act as a CA at all, key usage, name constraints and
+ * path length. A hand-rolled check would accept a chain that a reader rejects,
+ * which is the worst direction for this particular answer to be wrong in.
+ *
+ * `openssl_x509_checkpurpose()` takes the trusted roots as a file and the
+ * intermediates as another, so both are written out and deleted however the
+ * call ends (docs/decisions/0003-temporary-files-outside-the-package.md).
+ *
+ * @internal
+ */
+final readonly class TrustVerifier
+{
+    public function __construct(
+        private A1PdfSign $paths,
+    ) {}
+
+    /**
+     * @param  list<string>  $chain  The signature's certificates, leaf first, as
+     *                               ChainBuilder ordered them.
+     */
+    public function trusts(TrustStore $store, array $chain): bool
+    {
+        if ($chain === [] || $store->isEmpty()) {
+            return false;
+        }
+
+        $leaf = $chain[0];
+        $intermediates = array_slice($chain, 1);
+
+        $directory = $this->paths->tempPath();
+
+        return TemporaryFile::with(
+            $directory,
+            '.pem',
+            $store->toPem(),
+            function (TemporaryFile $roots) use ($directory, $leaf, $intermediates): bool {
+                // An empty file is not "no intermediates" to OpenSSL, it is a
+                // file with no certificates in it, which it warns about and
+                // refuses. A self-signed signer has no intermediates at all.
+                if ($intermediates === []) {
+                    return $this->checks($leaf, $roots->path, null);
+                }
+
+                // The intermediates are untrusted material: they help build the
+                // path and are not themselves a reason to accept it.
+                return TemporaryFile::with(
+                    $directory,
+                    '.pem',
+                    implode("\n", $intermediates),
+                    fn(TemporaryFile $untrusted): bool => $this->checks($leaf, $roots->path, $untrusted->path),
+                );
+            },
+        );
+    }
+
+    /**
+     * openssl_x509_checkpurpose returns true, false, or -1 for its own failure.
+     * Only true is a pass, so the error case cannot be read as one.
+     */
+    private function checks(string $leaf, string $roots, ?string $untrusted): bool
+    {
+        return openssl_x509_checkpurpose($leaf, X509_PURPOSE_ANY, [$roots], $untrusted) === true;
+    }
+}

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -115,7 +115,7 @@ it('lets the container swap the implementation', function () {
             return [];
         }
 
-        public function validate(string $pdfPath): SignatureReport
+        public function validate(string $pdfPath, ?\LSNepomuceno\LaravelA1PdfSign\Validation\TrustStore $trust = null): SignatureReport
         {
             return new SignatureReport([]);
         }

--- a/tests/TrustStoreTest.php
+++ b/tests/TrustStoreTest.php
@@ -1,0 +1,177 @@
+<?php
+
+use LSNepomuceno\LaravelA1PdfSign\Contracts\SignatureValidator;
+use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
+use LSNepomuceno\LaravelA1PdfSign\Support\Pem;
+use LSNepomuceno\LaravelA1PdfSign\Testing\DebugCertificate;
+use LSNepomuceno\LaravelA1PdfSign\Validation\TrustStore;
+
+/**
+ * Verifying a chain against the roots the caller named.
+ *
+ * The package ships no trust store and never will: which authorities to trust
+ * is policy and stays with the application. See
+ * docs/decisions/0016-trust-is-the-applications-policy.md.
+ */
+function signedWithTestCertificate(): string
+{
+    [$pfxPath, $password] = debugCertificate();
+
+    return A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdf(resource('test.pdf'))
+        ->sign()
+        ->contents;
+}
+
+it('reads every certificate out of a bundle', function () {
+    $store = TrustStore::fromPem(testCertificate()->original);
+
+    expect($store->isEmpty())->toBeFalse()
+        ->and($store->count())->toBe(1)
+        ->and($store->certificates[0])->toStartWith(Pem::CERTIFICATE_MARKER);
+});
+
+it('keeps one copy of a certificate that appears twice', function () {
+    $one = Pem::certificates(testCertificate()->original)[0];
+
+    expect(TrustStore::fromPem($one . "\n" . $one)->count())->toBe(1);
+});
+
+it('finds nothing in content that carries no certificate', function () {
+    expect(TrustStore::fromPem('not a certificate')->isEmpty())->toBeTrue()
+        ->and(TrustStore::empty()->isEmpty())->toBeTrue()
+        ->and(TrustStore::empty()->count())->toBe(0);
+});
+
+it('answers unknown rather than untrusted when no store was given', function () {
+    // The distinction this record exists for: an application that never
+    // configured a store must not read "untrusted" and conclude something the
+    // run never established.
+    $report = app(SignatureValidator::class)->validate(signedWithTestCertificate());
+
+    expect($report->isTrusted())->toBeNull()
+        ->and($report->latest()?->isTrusted)->toBeNull()
+        // The signature itself still verifies: trust is a further question.
+        ->and($report->isValid())->toBeTrue();
+});
+
+it('trusts a signature that chains to the root it was given', function () {
+    // A real shape: a root authority and a certificate it issued, with the root
+    // travelling in the bundle. The plain debug certificate is self-signed and
+    // carries basicConstraints CA:FALSE, so a strict verifier will not accept
+    // it as its own anchor and is right not to.
+    [$pfx, $password, $root] = DebugCertificate::makeChain();
+
+    $path = A1PdfSign::tempPath(true, '.pfx');
+    file_put_contents($path, $pfx);
+
+    $signed = A1PdfSign::newSignature()
+        ->certificate($path, $password)
+        ->pdf(resource('test.pdf'))
+        ->sign();
+
+    unlink($path);
+
+    $report = app(SignatureValidator::class)
+        ->validate($signed->contents, 'contract.pdf', TrustStore::fromPem($root));
+
+    expect($report->isTrusted())->toBeTrue()
+        ->and($report->latest()?->isTrusted)->toBeTrue()
+        // The chain the signature carries reaches that root on its own terms
+        // too, which is a weaker claim: internally consistent, not trusted.
+        ->and($report->latest()?->chainReachesRoot)->toBeTrue();
+});
+
+it('refuses a self-signed certificate as its own anchor', function () {
+    // Not a defect. openssl_x509_checkpurpose builds a path and a certificate
+    // that says CA:FALSE cannot be one, so accepting it would be laxer than
+    // any reader the document will meet.
+    $report = app(SignatureValidator::class)->validate(
+        signedWithTestCertificate(),
+        'contract.pdf',
+        TrustStore::fromPem(testCertificate()->original),
+    );
+
+    expect($report->isTrusted())->toBeFalse();
+});
+
+it('does not trust a signature against an unrelated root', function () {
+    [$otherPfx, $otherPassword] = DebugCertificate::make();
+    $other = app(\LSNepomuceno\LaravelA1PdfSign\Certificates\NativeCertificateReader::class)
+        ->read($otherPfx, $otherPassword);
+
+    $report = app(SignatureValidator::class)->validate(
+        signedWithTestCertificate(),
+        'contract.pdf',
+        TrustStore::fromPem($other->original),
+    );
+
+    expect($report->isTrusted())->toBeFalse()
+        ->and($report->latest()?->isTrusted)->toBeFalse()
+        // Untrusted is not invalid. The signature still matches the bytes.
+        ->and($report->isValid())->toBeTrue();
+});
+
+it('trusts nothing when the store is empty, which is not the same as unknown', function () {
+    $report = app(SignatureValidator::class)->validate(
+        signedWithTestCertificate(),
+        'contract.pdf',
+        TrustStore::empty(),
+    );
+
+    expect($report->isTrusted())->toBeFalse();
+});
+
+it('reads a bundle from a file and from a directory', function () {
+    // A directory is read and concatenated rather than handed to OpenSSL as a
+    // CA path: that form needs the hashed symlinks c_rehash creates, and a
+    // directory of plain files silently verifies nothing.
+    $directory = A1PdfSign::tempPath() . '-trust';
+    @mkdir($directory, 0o755, true);
+
+    file_put_contents("{$directory}/root.pem", testCertificate()->original);
+
+    expect(TrustStore::fromFile("{$directory}/root.pem")->count())->toBe(1)
+        ->and(TrustStore::fromDirectory($directory)->count())->toBe(1);
+
+    unlink("{$directory}/root.pem");
+    rmdir($directory);
+});
+
+it('reports trust through the facade', function () {
+    [$pfx, $password, $root] = DebugCertificate::makeChain();
+
+    $pfxPath = A1PdfSign::tempPath(true, '.pfx');
+    file_put_contents($pfxPath, $pfx);
+
+    $signed = A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdf(resource('test.pdf'))
+        ->sign();
+
+    $path = A1PdfSign::tempPath(true, '.pdf');
+    $signed->save($path);
+
+    expect(A1PdfSign::validate($path, TrustStore::fromPem($root))->isTrusted())->toBeTrue()
+        // And without a store, the same document answers unknown.
+        ->and(A1PdfSign::validate($path)->isTrusted())->toBeNull();
+
+    unlink($pfxPath);
+    unlink($path);
+});
+
+it('round-trips a certificate through DER and back', function () {
+    $pem = Pem::certificates(testCertificate()->original)[0];
+    $der = Pem::toDer($pem);
+
+    expect($der)->not->toBeNull()
+        ->and(Pem::toDer(Pem::fromDer((string) $der)))->toBe($der)
+        ->and(Pem::hasCertificate($pem))->toBeTrue()
+        ->and(Pem::hasCertificate('nothing here'))->toBeFalse();
+});
+
+it('answers null for armour whose body is not base64', function () {
+    expect(Pem::toDer(Pem::CERTIFICATE_MARKER . "\n!!!!\n-----END CERTIFICATE-----"))->toBeNull()
+        ->and(Pem::toDer(Pem::CERTIFICATE_MARKER . "\n-----END CERTIFICATE-----"))->toBeNull();
+});


### PR DESCRIPTION
Implements [0016](docs/decisions/0016-trust-is-the-applications-policy.md), the largest of the gaps in the assessment.

`isValid()` answers "does this signature match these bytes". Whether to accept the signer was left to the application, which is right, but **the package stopped one step too early: not even the mechanism was there.** An application wanting to check against the ICP-Brasil chain had to take `$report->latest()->chain`, write it to disk and call OpenSSL by hand, which is the part this package is supposed to be good at.

```php
$store = TrustStore::fromFile(storage_path('icp-brasil.pem'));

$report = A1PdfSign::validate($path, $store);

$report->isTrusted();          // ?bool
$report->latest()?->isTrusted; // ?bool
```

**The package ships no trust store and will not.** A bundled one goes stale between releases, and shipping it would make this package's release cadence the thing that decides whose signatures an application accepts.

## Three answers, not two

| | |
|---|---|
| `null` | no store was given. Nobody was asked |
| `false` | a store was given and the chain does not reach it |
| `true` | the chain validates against it |

Collapsing null into false would let an application that never configured a store read "untrusted" and conclude something the run never established. `TrustStore::empty()` exists so "trust nothing" stays sayable.

An untrusted signature is not an invalid one. The two questions are independent.

## OpenSSL does the path validation

Walking the chain by hand would check that each certificate was signed by the next, which `ChainBuilder` already does, and would silently skip everything else path validation means: each intermediate's validity window, `basicConstraints`, key usage, name constraints, path length. **A hand-rolled check accepts chains a reader rejects**, which is the worst direction for this answer to be wrong in.

Measured before the code was written:

| | |
|---|---|
| Leaf against its root, intermediate not supplied | **false**, so it builds a path rather than comparing issuers |
| Same, intermediate supplied | **true** |
| Leaf against an unrelated root | **false** |
| **Roots given as a directory of PEM files** | **false** |

The last one shaped the API. That form needs the hashed symlinks `c_rehash` creates, and a directory of plain files **silently verifies nothing**. `fromDirectory()` concatenates instead.

## Two findings from wiring it up

**The container only resolves a defaulted class-typed constructor parameter when the class is bound.** `TrustVerifier` is optional on `PdfSignatureValidator` so the arity does not move, and without an explicit binding the validator silently received null and every signature reported unknown. The binding carries a comment saying it must stay.

**An empty untrusted-certificates file is not "no intermediates" to OpenSSL**, it is a file with no certificates in it, which it refuses. A self-signed signer has none.

## The fixture had to change

`DebugCertificate::makeChain()` builds a root authority and a certificate it issued. The plain debug certificate is self-signed with `basicConstraints CA:FALSE`, so a strict verifier will not accept it as its own anchor **and is right not to**. Testing trust against that shape would have tested the fixture rather than the chain. There is a test pinning that refusal as correct behaviour.

## Also: `Support\Pem`, as asked during review

Four places had their own copy of `preg_match_all` over the certificate armour, and a fifth encoded DER back into it. Four copies of a pattern is four places to drop the `s` modifier, and the one that drops it reads a single certificate out of a bundle and calls it the chain.

265 tests. Mutation over the three new classes is 92.59%, the two survivors being the PEM line width.
