### PR TITLE
fix(seal): put the seal on the page it was asked for

### DIFF
--- a/docs/decisions/0017-the-seal-goes-where-it-was-asked-for.md
+++ b/docs/decisions/0017-the-seal-goes-where-it-was-asked-for.md
@@ -1,0 +1,120 @@
+# 0017: The seal goes where it was asked for
+
+**Status:** implemented.
+
+## Context
+
+`Data\SealPlacement` has carried `$page` and `$onEveryPage` since 2.0. Nothing
+read either of them.
+
+Every seal went onto whichever page `DocumentReader::findFirstPage()` happened to
+find, and the documentation told callers otherwise:
+
+> Position, size and page of your choosing
+>
+> `new SealPlacement(x: 155, y: 250, width: 50, page: SealPlacement::LAST_PAGE)`
+
+That example is from the published 2.x documentation, and running it put the seal
+on page 1. `appliesTo()` was written to answer exactly this question and had no
+caller anywhere in `src/`.
+
+This is the worst class of defect the package can carry. It is not a refusal, not
+a crash and not a missing feature that a reader can see is missing: it is a
+documented parameter that silently produces a plausible wrong result, and the
+wrong result is a signed contract with the signature on the wrong page.
+
+Proven before the fix, on a purpose-built three-page document: `page: 3` produced
+a widget whose `/P` named object 3, the **first** page.
+
+## Decision
+
+**The placement decides the page, and the page tree decides the order.**
+
+### Page order comes from the tree, not from object numbers
+
+`DocumentReader::pages()` walks `/Pages` and `/Kids` from the catalog, ISO
+32000-1 §7.7.3.2, and returns page object numbers in reading order.
+
+`findFirstPage()` used to scan the cross-reference table in object-number order
+and take the first `/Type/Page`. That answer is right only when the producer
+numbered its pages in reading order, which nothing requires: a producer may write
+the last page first, and any generator that rewrites one page gives it a fresh
+number at the end of the file. Object numbers carry no page order at all, so
+"page 3" cannot be resolved from them.
+
+The scan survives as the fallback behind `findFirstPage()`, for a document whose
+tree cannot be walked. A document with no walkable tree is treated as a document
+of one page, which keeps `LAST_PAGE` and `page: 1` both landing on it and makes
+`page: 3` say so rather than guess.
+
+The test fixture numbers its pages backwards on purpose. A fixture numbered in
+reading order cannot tell a tree walk apart from the scan it replaced.
+
+### The placement is asked page by page
+
+`RevisionWriter` does not read `$placement->page`. It walks the pages and asks
+`appliesTo($n, $count)` for each, so `LAST_PAGE` and `onEveryPage` are decided in
+the one class that defines them, and the enum-shaped logic has exactly one home.
+
+### Out of range raises
+
+`page: 7` on a three-page document throws `SealPlacementException`.
+
+Clamping to the last page is the quiet answer and quiet is the whole defect. A
+caller who asks for page 7 of a three-page contract has made a mistake, and a
+signed document with the seal on page 3 looks deliberate.
+
+### `onEveryPage` writes stamp annotations
+
+A signature is **one** form field with **one** widget, so the seal cannot be a
+widget on every page: a widget that is not a form field is invalid, and a second
+signature field would be a second signature.
+
+The widget goes on the first page the placement accepts; every further page gets
+a `/Subtype/Stamp` annotation (§12.5.6.12) whose `/AP` points at the **same** form
+XObject. One image object and one form object serve the whole document, so a
+ten-page seal embeds the JPEG once rather than ten times.
+
+The stamps are written inside the signature's own revision, so their bytes fall
+within `/ByteRange` and the signature covers them like everything else it wrote.
+They are not clickable signature widgets: a reader clicking one gets a stamp, and
+the signature panel still lists one signature. That is the honest shape of the
+feature, and it is how every other implementation does it.
+
+Only pages the placement accepts are rewritten. Rewriting all of them would make
+the revision the size of the document and would touch pages an earlier signature
+covers.
+
+## Consequences
+
+- **The default seal page changes from the first page to the last.**
+  `SealPlacement::$page` has always defaulted to `LAST_PAGE`, so `->seal()` with
+  no arguments was already asking for the last page and getting the first. On a
+  single-page document nothing moves, which is every fixture in the suite and
+  most contracts. On a multi-page document the seal now lands where the DTO has
+  always said it would. This is a behaviour change and is called out in the
+  release notes rather than buried as a fix.
+
+- `Exceptions\SealPlacementException` is new, and `sign()` can now raise it.
+
+- `Signing\Incremental\DocumentInfo::has()` and `DocumentReader::pages()` are
+  new. Both are `@internal`.
+
+- Invisible signatures are unchanged. Without a seal there is no appearance to
+  place, so the widget keeps its zero rectangle on the first page.
+
+- `intoField()` is unchanged. A field carries its own `/P`, and passing a
+  placement alongside it was already refused
+  ([0013](0013-signing-into-an-existing-field.md)), so there is nothing to
+  resolve between them.
+
+## Alternatives rejected
+
+| | Why not |
+|---|---|
+| Clamp an out-of-range page to the last | The same silence, one step smaller |
+| Resolve the page inside `RevisionWriter` from `$placement->page` | Two places would then define what `LAST_PAGE` means, and `appliesTo()` would stay dead |
+| Keep scanning the cross-reference table, and only add `LAST_PAGE` | It answers "the highest-numbered page object", which is not the last page |
+| Remove `$page` and `$onEveryPage` as dead API | They are documented, and the documentation is the promise |
+| A second signature field per page for `onEveryPage` | Each would be a separate signature. The caller asked for one signature shown in several places |
+| Copy the image XObject per page | The JPEG once per page, for an appearance that is identical on all of them |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -26,6 +26,7 @@ document drifts away from the code it describes.
 | [0014](0014-refuse-encrypted-documents.md) | Encrypted documents are refused, not signed badly |
 | [0015](0015-object-streams.md) | Objects packed into object streams are read, and written back uncompressed |
 | [0016](0016-trust-is-the-applications-policy.md) | Trust is the application's policy, and its verification is ours |
+| [0017](0017-the-seal-goes-where-it-was-asked-for.md) | The seal goes where it was asked for |
 
 Nothing is currently proposed and unbuilt. The four that were, 0009, 0010, 0012
 and 0013, all shipped in 2.2, and each carries the measurement that decided its

--- a/docs/spec/public-api.md
+++ b/docs/spec/public-api.md
@@ -148,6 +148,32 @@ you accept stays with the application.
 `isValid()` answers "does this signature match these bytes". It does not check
 the issuer against a trust store: that decision stays with the application.
 
+## Where the seal goes
+
+`Data\SealPlacement` carries position, size and page. All three are read.
+
+```php
+use LSNepomuceno\LaravelA1PdfSign\Data\SealPlacement;
+
+->seal(placement: new SealPlacement(x: 155, y: 250, width: 50, page: 2))
+->seal(placement: new SealPlacement(x: 155, y: 250, width: 50))                   // the last page
+->seal(placement: new SealPlacement(x: 155, y: 250, width: 50, onEveryPage: true))
+```
+
+| | |
+|---|---|
+| `page` | 1-based, in the order the page tree declares. `SealPlacement::LAST_PAGE`, the default, is the last page |
+| `onEveryPage` | the seal appears on every page, and wins over `page` |
+| A page the document does not have | `SealPlacementException`, rather than clamping to the nearest one |
+
+`onEveryPage` still produces **one** signature: the widget goes on the first page
+and every further page gets a stamp annotation drawing the same appearance, so
+the JPEG is embedded once whatever the page count
+([0017](../decisions/0017-the-seal-goes-where-it-was-asked-for.md)).
+
+Omitting `seal()` leaves the signature invisible, which is still a valid
+signature: the seal is an appearance, not part of the cryptography.
+
 ## Trust
 
 `isValid()` answers "does this signature match these bytes". Whether to accept

--- a/src/Contracts/PdfSigner.php
+++ b/src/Contracts/PdfSigner.php
@@ -40,6 +40,7 @@ interface PdfSigner
      *
      * @throws \LSNepomuceno\LaravelA1PdfSign\Exceptions\CertificationException
      * @throws \LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidPdfFileException
+     * @throws \LSNepomuceno\LaravelA1PdfSign\Exceptions\SealPlacementException
      * @throws \LSNepomuceno\LaravelA1PdfSign\Exceptions\SignatureFieldException
      */
     public function sign(

--- a/src/Exceptions/SealPlacementException.php
+++ b/src/Exceptions/SealPlacementException.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Exceptions;
+
+use Exception;
+use Stringable;
+
+/**
+ * A seal that cannot be placed where it was asked for.
+ *
+ * Clamping to the nearest page would be the quiet answer, and quiet is the
+ * problem: a seal asked for on page 7 of a three-page contract is a caller
+ * mistake, and putting it on page 3 produces a signed document that looks
+ * deliberate and is not.
+ *
+ * See docs/decisions/0017-the-seal-goes-where-it-was-asked-for.md.
+ */
+class SealPlacementException extends Exception implements Stringable
+{
+    public static function pageOutOfRange(int $page, int $pageCount): self
+    {
+        $pages = $pageCount === 1 ? '1 page' : "{$pageCount} pages";
+
+        return new self(
+            "the seal was placed on page {$page}, but the document has {$pages}",
+        );
+    }
+
+    public function __toString(): string
+    {
+        return __CLASS__ . ": [{$this->getCode()}]: {$this->getMessage()}\n";
+    }
+}

--- a/src/Signing/Incremental/DocumentInfo.php
+++ b/src/Signing/Incremental/DocumentInfo.php
@@ -38,6 +38,14 @@ final readonly class DocumentInfo
     }
 
     /**
+     * Whether the document locates this object at all, in either map.
+     */
+    public function has(int $number): bool
+    {
+        return isset($this->xref[$number]) || isset($this->compressed[$number]);
+    }
+
+    /**
      * Every object the document declares, however it stores them.
      *
      * @return list<int>

--- a/src/Signing/Incremental/DocumentReader.php
+++ b/src/Signing/Incremental/DocumentReader.php
@@ -146,10 +146,83 @@ final class DocumentReader
     }
 
     /**
+     * The document's pages, in the order a reader displays them.
+     *
+     * Walks the page tree from the catalog's /Pages, ISO 32000-1 §7.7.3.2,
+     * because that order is the only thing that makes "page 3" mean anything.
+     * Object numbers do not carry it: a producer is free to write the last page
+     * first, and any generator that rewrites a page gives it a fresh number.
+     *
+     * Returns an empty list when the tree cannot be walked, which leaves the
+     * caller to fall back rather than deciding here what a missing tree means.
+     *
+     * @return list<int>
+     *
+     * @throws InvalidPdfFileException
+     */
+    public function pages(string $pdf, DocumentInfo $document): array
+    {
+        $catalog = $this->rawObject($pdf, $document, $document->root);
+
+        if (preg_match('/\/Pages\s+(\d+)\s+\d+\s+R/', $catalog, $root) !== 1) {
+            return [];
+        }
+
+        $pages = [];
+        $seen = [];
+
+        $this->collectPages($pdf, $document, (int) $root[1], $pages, $seen);
+
+        return $pages;
+    }
+
+    /**
+     * @param  list<int>  $pages
+     * @param  array<int, true>  $seen  Shared across the whole walk: a tree that
+     *                                  names a node twice is malformed, and
+     *                                  following it would not terminate.
+     *
+     * @throws InvalidPdfFileException
+     */
+    private function collectPages(string $pdf, DocumentInfo $document, int $number, array &$pages, array &$seen): void
+    {
+        if (isset($seen[$number]) || ! $document->has($number)) {
+            return;
+        }
+
+        $seen[$number] = true;
+
+        $node = $this->rawObject($pdf, $document, $number);
+
+        // /Kids decides, not /Type. An intermediate node is required to declare
+        // /Type/Pages and a leaf /Type/Page, but a node carrying kids is a node
+        // to descend into whatever it calls itself.
+        if (preg_match('/\/Kids\s*\[(.*?)\]/s', $node, $kids) === 1) {
+            preg_match_all('/(\d+)\s+\d+\s+R/', $kids[1], $references);
+
+            foreach ($references[1] as $reference) {
+                $this->collectPages($pdf, $document, (int) $reference, $pages, $seen);
+            }
+
+            return;
+        }
+
+        if (preg_match('/\/Type\s*\/Page(?![s\w])/', $node) === 1) {
+            $pages[] = $number;
+        }
+    }
+
+    /**
      * @throws InvalidPdfFileException
      */
     public function findFirstPage(string $pdf, DocumentInfo $document): int
     {
+        $pages = $this->pages($pdf, $document);
+
+        if ($pages !== []) {
+            return $pages[0];
+        }
+
         // Packed objects are searched too, and by their unpacked body: a page
         // dictionary is exactly the kind of object a producer packs.
         foreach ($document->compressed as $number => $stream) {

--- a/src/Signing/Incremental/RevisionWriter.php
+++ b/src/Signing/Incremental/RevisionWriter.php
@@ -9,6 +9,7 @@ use LSNepomuceno\LaravelA1PdfSign\Data\SignatureInfo;
 use LSNepomuceno\LaravelA1PdfSign\Enums\CertificationLevel;
 use LSNepomuceno\LaravelA1PdfSign\Enums\SignatureProfile;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidPdfFileException;
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\SealPlacementException;
 
 /**
  * Builds the revision appended to a document when it is signed.
@@ -31,7 +32,7 @@ final class RevisionWriter
     /**
      * Appends the signature revision, leaving the /Contents placeholder empty.
      *
-     * @throws InvalidPdfFileException
+     * @throws InvalidPdfFileException|SealPlacementException
      */
     public function append(
         string           $pdf,
@@ -47,6 +48,11 @@ final class RevisionWriter
     ): string {
         $visible = $seal !== null && $placement !== null;
 
+        // Where the seal was asked for, in page-tree order. Empty whenever the
+        // signature is invisible, since a zero rectangle appears on no page at
+        // all and the widget then only has to sit somewhere legal.
+        $sealed = $visible ? $this->sealedPages($pdf, $document, $placement) : [];
+
         $number = $document->nextObjectNumber();
         $signatureNumber = $number++;
         // Filling a field keeps the widget's own number: the revision replaces
@@ -54,19 +60,29 @@ final class RevisionWriter
         // whole point (docs/decisions/0013-signing-into-an-existing-field.md).
         $widgetNumber = $target === null ? $number++ : $target->objectNumber;
         $imageNumber = $number++;
-        $formNumber = $number;
+        $formNumber = $number++;
 
         // Null keeps the signature invisible, and it is what both widget
         // builders read to decide whether to write an /AP at all.
         $appearanceNumber = $visible ? $formNumber : null;
 
         $catalogNumber = $document->root;
-        // A field states its own page through /P. Falling back to the first page
-        // covers the field that declares none, which is legal and leaves the
-        // widget wherever the form puts it.
+        // A field states its own page through /P, and that wins: intoField()
+        // refuses a placement precisely so there is nothing to resolve here.
+        // Falling back to the first page covers the field that declares no page,
+        // which is legal and leaves the widget wherever the form puts it.
         $pageNumber = $target !== null && $target->pageNumber > 0
             ? $target->pageNumber
-            : $this->reader->findFirstPage($pdf, $document);
+            : ($sealed[0] ?? $this->reader->findFirstPage($pdf, $document));
+
+        // The signature is one widget on one page, so every further page the
+        // placement names gets a stamp annotation drawing the same appearance
+        // (docs/decisions/0017-the-seal-goes-where-it-was-asked-for.md).
+        $stampNumbers = [];
+
+        foreach (array_slice($sealed, 1) as $page) {
+            $stampNumbers[$page] = $number++;
+        }
 
         $base = strlen($pdf);
         $body = "\n";
@@ -93,6 +109,13 @@ final class RevisionWriter
 
             $offsets[$formNumber] = $base + strlen($body);
             $body .= $this->appearance->formObject($formNumber, $imageNumber, $placement, $seal);
+
+            $rectangle = $this->appearance->rectangle($placement, $seal);
+
+            foreach ($stampNumbers as $page => $stampNumber) {
+                $offsets[$stampNumber] = $base + strlen($body);
+                $body .= $this->stampObject($stampNumber, $formNumber, $page, $rectangle);
+            }
         }
 
         // A field the document already carries is already registered on the
@@ -121,6 +144,13 @@ final class RevisionWriter
         if ($target === null || preg_match('/\/Annots\s*\[[^\]]*\b' . $widgetNumber . '\s+\d+\s+R/', $page) !== 1) {
             $offsets[$pageNumber] = $base + strlen($body);
             $body .= "{$pageNumber} 0 obj\n" . $this->withAnnotation($page, $widgetNumber) . "\nendobj\n";
+        }
+
+        foreach ($stampNumbers as $stampPage => $stampNumber) {
+            $offsets[$stampPage] = $base + strlen($body);
+            $body .= "{$stampPage} 0 obj\n"
+                . $this->withAnnotation($this->reader->rawObject($pdf, $document, $stampPage), $stampNumber)
+                . "\nendobj\n";
         }
 
         $body .= $this->crossReference(
@@ -347,6 +377,68 @@ final class RevisionWriter
             . "/P {$pageNumber} 0 R"
             . '/F 132'
             . '/Ff 0'
+            . ">>\nendobj\n";
+    }
+
+    /**
+     * The pages the placement puts the seal on, in page-tree order.
+     *
+     * The placement answers page by page rather than being interrogated for a
+     * number, so SealPlacement::LAST_PAGE and $onEveryPage are decided in the
+     * one place that defines them.
+     *
+     * @return list<int> Object numbers. Never empty: a placement that matches no
+     *                   page is a caller mistake and raises rather than resolving
+     *                   to something plausible.
+     *
+     * @throws InvalidPdfFileException|SealPlacementException
+     */
+    private function sealedPages(string $pdf, DocumentInfo $document, SealPlacement $placement): array
+    {
+        // A tree that cannot be walked still has a page, and treating it as a
+        // document of one keeps the fallback honest: LAST_PAGE and page 1 both
+        // land on it, and page 3 says so instead of guessing.
+        $pages = $this->reader->pages($pdf, $document);
+
+        if ($pages === []) {
+            $pages = [$this->reader->findFirstPage($pdf, $document)];
+        }
+
+        $count = count($pages);
+        $sealed = [];
+
+        foreach ($pages as $index => $number) {
+            if ($placement->appliesTo($index + 1, $count)) {
+                $sealed[] = $number;
+            }
+        }
+
+        if ($sealed === []) {
+            throw SealPlacementException::pageOutOfRange($placement->page, $count);
+        }
+
+        return $sealed;
+    }
+
+    /**
+     * A stamp annotation drawing the seal's appearance on a further page.
+     *
+     * ISO 32000-1 §12.5.6.12. It is not a widget: a widget that is not a form
+     * field is invalid, and the signature has exactly one field. The stamp is
+     * written in the signature's own revision, so the bytes it adds fall inside
+     * /ByteRange and the signature covers it like everything else.
+     *
+     * @param  array{0: float, 1: float, 2: float, 3: float}  $rectangle
+     */
+    private function stampObject(int $number, int $formNumber, int $pageNumber, array $rectangle): string
+    {
+        return "{$number} 0 obj\n"
+            . '<</Type/Annot/Subtype/Stamp'
+            . sprintf('/Rect[%s %s %s %s]', ...$rectangle)
+            . "/AP<</N {$formNumber} 0 R>>"
+            . "/P {$pageNumber} 0 R"
+            // Print, and locked against a reader offering to move or delete it.
+            . '/F 132'
             . ">>\nendobj\n";
     }
 

--- a/src/Signing/PendingSignature.php
+++ b/src/Signing/PendingSignature.php
@@ -19,6 +19,7 @@ use LSNepomuceno\LaravelA1PdfSign\Exceptions\CertificationException;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\FileNotFoundException;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidPemContentException;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidPFXException;
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\SealPlacementException;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\SignatureFieldException;
 use LSNepomuceno\LaravelA1PdfSign\Support\Files;
 use SensitiveParameter;
@@ -300,6 +301,7 @@ final class PendingSignature
     /**
      * @throws CertificationException
      * @throws FileNotFoundException
+     * @throws SealPlacementException
      * @throws SignatureFieldException
      */
     public function sign(): SignedPdf

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -92,6 +92,37 @@ function template(): string
 }
 
 /**
+ * A document of $count pages whose tree order is the reverse of its object
+ * numbering.
+ *
+ * Deliberately reversed. A fixture numbered in reading order cannot tell a page
+ * tree walk apart from a scan of the cross-reference table, and the scan is what
+ * used to answer here: object 3 is the *last* page, so anything reading page
+ * order out of object numbers reports it as the first
+ * (docs/decisions/0017-the-seal-goes-where-it-was-asked-for.md).
+ *
+ * @return array{0: string, 1: list<int>} The document, and its page object
+ *                                        numbers in reading order.
+ */
+function reversedPages(int $count = 3): array
+{
+    $numbers = range($count + 2, 3);
+
+    $objects = [
+        1 => '<</Type/Catalog/Pages 2 0 R>>',
+        2 => '<</Type/Pages/Kids['
+            . implode(' ', array_map(static fn(int $number): string => "{$number} 0 R", $numbers))
+            . "]/Count {$count}>>",
+    ];
+
+    foreach ($numbers as $number) {
+        $objects[$number] = '<</Type/Page/Parent 2 0 R/MediaBox[0 0 595 842]>>';
+    }
+
+    return [pdfWith($objects), $numbers];
+}
+
+/**
  * A minimal PDF around the given objects, with a correct cross-reference table.
  *
  * Structural cases are built rather than patched into the committed fixture:

--- a/tests/SealPlacementTest.php
+++ b/tests/SealPlacementTest.php
@@ -1,0 +1,212 @@
+<?php
+
+use LSNepomuceno\LaravelA1PdfSign\Contracts\SignatureValidator;
+use LSNepomuceno\LaravelA1PdfSign\Data\SealPlacement;
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\SealPlacementException;
+use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
+use LSNepomuceno\LaravelA1PdfSign\Signing\Incremental\DocumentReader;
+
+/**
+ * Which page the seal lands on, ISO 32000-1 §7.7.3.2 and §12.5.6.12.
+ *
+ * SealPlacement has carried $page and $onEveryPage since 2.0 and nothing read
+ * either of them: every seal went onto the first page the cross-reference table
+ * happened to mention. See docs/decisions/0017-the-seal-goes-where-it-was-asked-for.md.
+ */
+function sealedOn(?int $page = null, bool $onEveryPage = false): string
+{
+    [$pdf, $pages] = reversedPages();
+    [$pfxPath, $password] = debugCertificate();
+
+    $placement = new SealPlacement(
+        width: 40,
+        page: $page ?? SealPlacement::LAST_PAGE,
+        onEveryPage: $onEveryPage,
+    );
+
+    return A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdfContents($pdf, 'contract.pdf')
+        ->seal(placement: $placement)
+        ->sign()
+        ->contents;
+}
+
+/**
+ * The object numbers of the pages carrying an annotation, in tree order.
+ *
+ * @return list<int>
+ */
+function annotatedPages(string $pdf): array
+{
+    [, $pages] = reversedPages();
+
+    preg_match_all('/(\d+) 0 obj\s*(.*?)endobj/s', $pdf, $objects, PREG_SET_ORDER);
+
+    $annotated = [];
+
+    foreach ($objects as [, $number, $body]) {
+        if (str_contains($body, '/Annots')) {
+            $annotated[] = (int) $number;
+        }
+    }
+
+    return array_values(array_filter($pages, static fn(int $number): bool => in_array($number, $annotated, true)));
+}
+
+it('reads the pages in the order the tree declares, not the order they were written', function () {
+    // Object numbers carry no page order: a producer is free to write the last
+    // page first, and this fixture does exactly that.
+    [$pdf, $pages] = reversedPages();
+
+    $reader = app(DocumentReader::class);
+
+    expect($reader->pages($pdf, $reader->read($pdf)))->toBe($pages)
+        ->and($pages)->toBe([5, 4, 3]);
+});
+
+it('reports the first page of the tree, not the lowest-numbered page object', function () {
+    // The scan this replaced walked the cross-reference table in number order
+    // and would answer 3, which is the last page.
+    [$pdf] = reversedPages();
+
+    $reader = app(DocumentReader::class);
+
+    expect($reader->findFirstPage($pdf, $reader->read($pdf)))->toBe(5);
+});
+
+it('puts the seal on the page that was asked for', function () {
+    // The defect this closes: page 2 produced a widget on page 1, silently, in
+    // a parameter the documentation tells callers to use.
+    expect(sealedOn(page: 2))->toContain('/P 4 0 R');
+});
+
+it('puts the seal on the last page when the placement says so', function () {
+    expect(sealedOn(page: SealPlacement::LAST_PAGE))->toContain('/P 3 0 R');
+});
+
+it('defaults to the last page, which is what SealPlacement has always declared', function () {
+    // Not a free choice: SealPlacement::$page defaults to LAST_PAGE, so a caller
+    // who passes no page has already asked for the last one.
+    [$pfxPath, $password] = debugCertificate();
+    [$pdf] = reversedPages();
+
+    $signed = A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdfContents($pdf, 'contract.pdf')
+        ->seal()
+        ->sign();
+
+    expect($signed->contents)->toContain('/P 3 0 R');
+});
+
+it('leaves an invisible signature on the first page', function () {
+    // Without a seal there is no appearance to place, so the widget only has to
+    // sit somewhere legal, and the first page is where it has always sat.
+    [$pfxPath, $password] = debugCertificate();
+    [$pdf] = reversedPages();
+
+    $signed = A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdfContents($pdf, 'contract.pdf')
+        ->sign();
+
+    expect($signed->contents)->toContain('/P 5 0 R');
+});
+
+it('marks every page when the placement asks for it', function () {
+    $pdf = sealedOn(onEveryPage: true);
+
+    // One widget, because a signature is one field, and a stamp on each of the
+    // other pages drawing the same appearance.
+    expect(preg_match_all('/\/Subtype\/Widget/', $pdf))->toBe(1)
+        ->and(preg_match_all('/\/Subtype\/Stamp/', $pdf))->toBe(2)
+        ->and(annotatedPages($pdf))->toBe([5, 4, 3]);
+});
+
+it('draws every stamp from the one form the seal already produced', function () {
+    // A copy of the image per page would multiply the JPEG by the page count.
+    $pdf = sealedOn(onEveryPage: true);
+
+    $form = preg_match('/(\d+) 0 obj\n<<\/Type\/XObject\/Subtype\/Form/', $pdf, $matches) === 1
+        ? $matches[1]
+        : '';
+
+    expect(preg_match_all('/\/Subtype\/Image/', $pdf))->toBe(1)
+        ->and(preg_match_all('/\/Subtype\/Form/', $pdf))->toBe(1)
+        ->and($form)->not->toBe('')
+        // The widget and both stamps name that one form.
+        ->and(preg_match_all("/\/AP<<\/N {$form} 0 R>>/", $pdf))->toBe(3);
+});
+
+it('touches only the page it seals', function () {
+    // A revision that rewrote every page would be a revision the size of the
+    // document, and each rewritten page is a page an earlier signature covered.
+    expect(annotatedPages(sealedOn(page: 2)))->toBe([4]);
+});
+
+it('refuses a page the document does not have', function () {
+    // Clamping to the last page is the quiet answer, and quiet is the defect
+    // this whole record exists to remove.
+    expect(fn() => sealedOn(page: 7))
+        ->toThrow(SealPlacementException::class, 'the seal was placed on page 7, but the document has 3 pages');
+});
+
+it('refuses page zero, since pages are counted from one', function () {
+    expect(fn() => sealedOn(page: 0))->toThrow(SealPlacementException::class);
+});
+
+it('keeps the signature valid when the seal spans every page', function () {
+    // The stamps are written in the signature's own revision, so they fall
+    // inside /ByteRange and the signature covers them.
+    $report = app(SignatureValidator::class)->validate(sealedOn(onEveryPage: true));
+
+    expect($report->isValid())->toBeTrue()
+        ->and($report->signatures)->toHaveCount(1)
+        ->and($report->signatures[0]->coversWholeDocument)->toBeTrue();
+});
+
+it('gives each signature its own page', function () {
+    // The seal belongs to a signature, not to the document, which is what the
+    // documentation promises and what two revisions have to keep true.
+    [$pfxPath, $password] = debugCertificate();
+    [$pdf] = reversedPages();
+
+    $first = A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdfContents($pdf, 'contract.pdf')
+        ->seal(placement: new SealPlacement(width: 40, page: 1))
+        ->sign();
+
+    $second = A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdfContents($first->contents, 'contract.pdf')
+        ->seal(placement: new SealPlacement(width: 40, page: 3))
+        ->sign();
+
+    // The first revision survives byte for byte, so both /P entries are present
+    // and they name different pages.
+    expect(substr($second->contents, 0, $first->size()))->toBe($first->contents)
+        ->and($second->contents)->toContain('/P 5 0 R')
+        ->and($second->contents)->toContain('/P 3 0 R')
+        ->and(app(SignatureValidator::class)->validate($second->contents)->isValid())->toBeTrue();
+});
+
+it('answers which pages a placement applies to', function () {
+    $last = new SealPlacement(page: SealPlacement::LAST_PAGE);
+
+    expect($last->appliesTo(3, 3))->toBeTrue()
+        ->and($last->appliesTo(1, 3))->toBeFalse()
+        ->and(new SealPlacement(page: 2)->appliesTo(2, 3))->toBeTrue()
+        ->and(new SealPlacement(page: 2)->appliesTo(3, 3))->toBeFalse()
+        ->and(new SealPlacement(onEveryPage: true)->appliesTo(2, 3))->toBeTrue()
+        // onEveryPage wins over a page that names one of them.
+        ->and(new SealPlacement(page: 1, onEveryPage: true)->appliesTo(3, 3))->toBeTrue();
+});
+
+it('names the page count it measured against', function () {
+    expect(SealPlacementException::pageOutOfRange(4, 1)->getMessage())
+        ->toBe('the seal was placed on page 4, but the document has 1 page')
+        ->and((string) SealPlacementException::pageOutOfRange(4, 1))
+        ->toContain('the seal was placed on page 4');
+});


### PR DESCRIPTION
`SealPlacement` has carried `$page` and `$onEveryPage` since 2.0 and **nothing read either of them**. Every seal went onto whichever page `findFirstPage()` happened to find first, while the published 2.x documentation showed:

> Position, size and page of your choosing
>
> `new SealPlacement(x: 155, y: 250, width: 50, page: SealPlacement::LAST_PAGE)`

`appliesTo()` was written to answer exactly this and had no caller anywhere in `src/`.

Proven on a purpose-built three-page document before the fix: `page: 3` produced a widget whose `/P` named object 3, the **first** page. A documented parameter that silently produces a plausible wrong result, and the wrong result is a signed contract with the signature on the wrong page.

## What changed

**Page order comes from the tree.** `DocumentReader::pages()` walks `/Pages` and `/Kids` from the catalog (ISO 32000-1 §7.7.3.2). Object numbers carry no page order: a producer may write the last page first, and any generator that rewrites a page gives it a fresh number, so the cross-reference scan this replaces could only ever be right by accident. It survives as the fallback behind `findFirstPage()`.

The fixture numbers its pages backwards on purpose. A fixture numbered in reading order cannot tell a tree walk apart from the scan it replaced.

**The placement is asked page by page.** `RevisionWriter` never reads `$placement->page`; it calls `appliesTo($n, $count)`, so `LAST_PAGE` and `onEveryPage` stay defined in the one class that owns them.

**`onEveryPage` writes stamp annotations.** A signature is one field with one widget, so the widget goes on the first page the placement accepts and every further page gets a `/Subtype/Stamp` (§12.5.6.12) pointing at the **same** form XObject. One image object serves the whole document. Every stamp is written in the signature's own revision, so it falls inside `/ByteRange`.

**Out of range raises.** `page: 7` on a three-page document throws `SealPlacementException`. Clamping is the quiet answer and quiet is the defect.

## Verification

Beyond the 15 new tests, independently with poppler:

| | |
|---|---|
| `pdfsig` on all three probes | `Signature is Valid`, `Total document signed` |
| `pdftoppm`, `page: 2` | page 2 alone carries the seal |
| `pdftoppm`, `LAST_PAGE` | page 3 alone |
| `pdftoppm`, `onEveryPage` | all three |

## Breaking change

**The default seal page moves from the first page to the last.** `SealPlacement::$page` has always defaulted to `LAST_PAGE`, so `->seal()` with no arguments was already asking for the last page and being given the first. Single-page documents are unaffected, which is every fixture in the suite.

`Contracts\PdfSigner::sign()` can now raise `SealPlacementException`; no signature changed.

See [`docs/decisions/0017`](docs/decisions/0017-the-seal-goes-where-it-was-asked-for.md).