### PR TITLE
fix(validation): read a trust directory without GLOB_BRACE

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
     "tecnickcom/tc-lib-pdf-sign": "^1.1"
   },
   "require-dev": {
+    "ext-tokenizer": "*",
     "ergebnis/composer-normalize": "^2.52",
     "larastan/larastan": "^3.10",
     "laravel/pint": "^1.30",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ab624df52199e40744e1d731127ddd2c",
+    "content-hash": "dda889f6a4a0507ea9bcb83a06d08fdc",
     "packages": [
         {
             "name": "brick/math",
@@ -11588,6 +11588,8 @@
         "ext-openssl": "*",
         "ext-zlib": "*"
     },
-    "platform-dev": {},
+    "platform-dev": {
+        "ext-tokenizer": "*"
+    },
     "plugin-api-version": "2.9.0"
 }

--- a/docs/decisions/0016-trust-is-the-applications-policy.md
+++ b/docs/decisions/0016-trust-is-the-applications-policy.md
@@ -92,6 +92,14 @@ them into one bundle rather than handing the path to OpenSSL.
 - Revocation is still not evaluated. The store's OCSP responses and CRLs are
   counted, not read. That is the next step of the same shape, and this record
   does not pretend to cover it.
+- `fromDirectory()` shipped in 2.3.0 calling `glob()` with the brace form and
+  `GLOB_BRACE`. That constant is a GNU extension and PHP leaves it **undefined
+  on musl**, so the method was a fatal error on `php:8.4-alpine` for the whole
+  release while the suite stayed green: CI runs on Ubuntu, where the constant
+  exists. It is now one `glob()` per extension, and `tests/ArchTest.php` fails
+  on any platform-optional constant appearing in `src/`, since the behavioural
+  test can only ever check the platform it happens to run on.
+
 - `Support\Pem` came out of this. Four places had their own copy of
   `preg_match_all` over the certificate armour, and a fifth encoded DER back
   into it. Four copies of a pattern is four places to drop the `s` modifier, and

--- a/src/Validation/TrustStore.php
+++ b/src/Validation/TrustStore.php
@@ -24,6 +24,11 @@ use LSNepomuceno\LaravelA1PdfSign\Support\Pem;
 final readonly class TrustStore
 {
     /**
+     * The extensions a CA bundle ships under. All three hold PEM.
+     */
+    private const array EXTENSIONS = ['pem', 'crt', 'cer'];
+
+    /**
      * @param  list<string>  $certificates  Root certificates in PEM form.
      */
     private function __construct(
@@ -58,11 +63,26 @@ final readonly class TrustStore
      */
     public static function fromDirectory(string $path): self
     {
-        $files = glob(rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . '*.{pem,crt,cer}', GLOB_BRACE);
+        $directory = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $files = [];
 
-        if ($files === false) {
-            throw new FileNotFoundException($path);
+        // One call per extension rather than the brace form. GLOB_BRACE is a GNU
+        // extension, so PHP leaves the constant undefined on musl: on
+        // php:8.4-alpine, one of the most common images this package runs in,
+        // "*.{pem,crt,cer}" fatals on the constant before glob() is reached.
+        foreach (self::EXTENSIONS as $extension) {
+            $found = glob($directory . '*.' . $extension);
+
+            if ($found === false) {
+                throw new FileNotFoundException($path);
+            }
+
+            $files = [...$files, ...$found];
         }
+
+        // Grouped by extension otherwise, which would make the bundle's order
+        // depend on which extension the authority happened to publish under.
+        sort($files);
 
         $contents = '';
 

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -91,3 +91,36 @@ arch('only the shell helper opens processes')
 arch('console commands stay in Commands')
     ->expect('Illuminate\Console\Command')
     ->toOnlyBeUsedIn('LSNepomuceno\LaravelA1PdfSign\Commands');
+
+/**
+ * Constants PHP defines only where the host platform provides them.
+ *
+ * GLOB_BRACE is a GNU extension and is undefined on musl, so a call carrying it
+ * is a fatal error on php:8.4-alpine while passing everywhere CI runs. That is
+ * the shape of the failure worth guarding: the suite was green on Ubuntu for a
+ * whole release while `TrustStore::fromDirectory()` could not be called at all
+ * in one of the images this package most often ships in.
+ *
+ * A Pest arch rule cannot see constants, so this reads the sources.
+ */
+it('uses no constant the host platform may not define', function () {
+    $optional = ['GLOB_BRACE'];
+    $found = [];
+
+    /** @var SplFileInfo $file */
+    foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator(dirname(__DIR__) . '/src')) as $file) {
+        if ($file->getExtension() !== 'php') {
+            continue;
+        }
+
+        // Tokenised rather than grepped, so the comment above the fix can name
+        // the constant it is warning about without tripping the gate.
+        foreach (token_get_all((string) file_get_contents($file->getPathname())) as $token) {
+            if (is_array($token) && $token[0] === T_STRING && in_array($token[1], $optional, true)) {
+                $found[] = str_replace(dirname(__DIR__) . '/', '', $file->getPathname()) . ": {$token[1]}";
+            }
+        }
+    }
+
+    expect($found)->toBe([]);
+});

--- a/tests/TrustStoreTest.php
+++ b/tests/TrustStoreTest.php
@@ -130,12 +130,31 @@ it('reads a bundle from a file and from a directory', function () {
     $directory = A1PdfSign::tempPath() . '-trust';
     @mkdir($directory, 0o755, true);
 
-    file_put_contents("{$directory}/root.pem", testCertificate()->original);
+    // One certificate per extension a CA bundle ships under, and one file that
+    // is not a certificate at all: authorities publish notes and hash files
+    // beside the bundle, and reading them would put junk into the roots.
+    //
+    // Each testCertificate() call generates a fresh certificate, so the count is
+    // three only if all three extensions were read: identical bytes would be
+    // deduplicated and the assertion would pass on one file alone.
+    $files = [
+        'root.pem' => testCertificate()->original,
+        'intermediate.crt' => testCertificate()->original,
+        'other.cer' => testCertificate()->original,
+        'README.txt' => 'not a certificate',
+    ];
+
+    foreach ($files as $name => $contents) {
+        file_put_contents("{$directory}/{$name}", $contents);
+    }
 
     expect(TrustStore::fromFile("{$directory}/root.pem")->count())->toBe(1)
-        ->and(TrustStore::fromDirectory($directory)->count())->toBe(1);
+        ->and(TrustStore::fromDirectory($directory)->count())->toBe(3);
 
-    unlink("{$directory}/root.pem");
+    foreach (array_keys($files) as $name) {
+        unlink("{$directory}/{$name}");
+    }
+
     rmdir($directory);
 });
 


### PR DESCRIPTION
`TrustStore::fromDirectory()` globbed `"*.{pem,crt,cer}"` with `GLOB_BRACE`. That constant is a **GNU extension** and PHP leaves it undefined on musl, so on `php:8.4-alpine`, one of the most common images this package runs in, the call is a fatal error before `glob()` is ever reached:

```
Undefined constant "LSNepomuceno\LaravelA1PdfSign\Validation\GLOB_BRACE"
  at src/Validation/TrustStore.php:61
```

It shipped in **2.3.0** and the suite stayed green for the whole release: CI runs on Ubuntu, where the constant exists. Found by running the suite in the project's own Docker service, which is Alpine-based.

## The guard

The behavioural test can only ever check the platform it happens to run on, so the guard is structural. `tests/ArchTest.php` now fails on any platform-optional constant appearing in `src/`, tokenised rather than grepped so the comment explaining the fix can name what it warns about.

## The fix

One `glob()` per extension, results sorted. The brace form returned them grouped by pattern, which would make the bundle's order depend on which extension the authority published under.

The directory test now writes one certificate per extension plus a `README.txt` that must be ignored. Each certificate is generated separately, so the count reaches three only if all three extensions were read: identical bytes would be deduplicated and the assertion would pass on one file alone.

The outcome section of [`0016`](docs/decisions/0016-trust-is-the-applications-policy.md) records it, since `fromDirectory()`'s shape is that record's decision.