### PR TITLE
docs: the 2.3.1 upgrade notes and the pdfsig trap

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,40 @@
 # Upgrading
 
+## From 2.3.0 to 2.3.1
+
+Two fixes. One of them **moves where an existing seal is drawn**, so read this
+before upgrading a multi-page document pipeline.
+
+### The seal now goes on the page the placement names
+
+`Data\SealPlacement` has carried `$page` and `$onEveryPage` since 2.0 and
+nothing read either of them: every seal landed on the first page, whatever was
+asked for.
+
+| | Before | Now |
+|---|---|---|
+| `new SealPlacement(...)`, no page given | first page | **last page**, which `$page`'s default, `LAST_PAGE`, has always named |
+| `page: 2` | first page | page 2 |
+| `onEveryPage: true` | first page | every page |
+| A page the document does not have | first page | `SealPlacementException` |
+
+Single-page documents are unaffected in every case.
+
+**If your seals were landing on page 1 of a multi-page document and you want
+them to stay there, pass `page: 1` explicitly.** The value was previously
+ignored, so no existing call site can be relying on it having meant anything
+else.
+
+`onEveryPage` still produces one signature: the widget goes on the first page it
+applies to, and every further page gets a stamp annotation drawing the same
+appearance ([0017](docs/decisions/0017-the-seal-goes-where-it-was-asked-for.md)).
+
+### `TrustStore::fromDirectory()` works on Alpine
+
+It globbed with `GLOB_BRACE`, a constant PHP leaves undefined on musl, so the
+call was a fatal error on `php:8.4-alpine`. No API change; if you were not on
+musl, nothing about it changes for you.
+
 ## From 2.2 to 2.3
 
 Additive for applications. Nothing was removed, no behaviour changed for code

--- a/docs/spec/quality-policy.md
+++ b/docs/spec/quality-policy.md
@@ -157,6 +157,19 @@ suite passed straight through. `samples/` holds one signed PDF per profile plus
 a six-signature document. Regenerate them with `poc/sign-samples.php` and
 re-check after any change to `src/Signing/`.
 
+**One trap in that cross-check.** `Testing\DebugCertificate` gives every
+certificate it generates the same subject, `CN=Test Certificate, O=Internet
+Widgits Pty Ltd`, and so does `samples/certificate.pfx`. `pdfsig` resolves the
+signer through NSS **by name**, so a document carrying signatures from two
+different keys under that one subject has its later signatures matched against
+the wrong certificate and reported as *Signature is Invalid*.
+
+It is a name collision in the checker, not a defect in the document: the
+package's own validator reads the certificate embedded in each CMS and reports
+the same file as valid, and re-signing a sample with the certificate that made
+it clears the report. Sign a sample with `samples/certificate.pfx` before
+concluding anything from a `pdfsig` failure on a multi-signature file.
+
 ## Development environment
 
 The local floor is PHP 8.4 and the matrix reaches 8.5, so version-specific work


### PR DESCRIPTION
Reintroduces the two documentation commits that #238 backed out, unchanged. They were wanted; they simply reached `main` by a direct push instead of a pull request.

### `UPGRADE.md`, "From 2.3.0 to 2.3.1"

2.3.1 **moves where an existing seal is drawn**, and an upgrade guide that does not say so leaves people to discover it from a signed document. The table gives before and after for each case, and the one-line workaround for anyone who wants the old position: pass `page: 1` explicitly. The value was previously ignored, so no call site can be relying on it having meant anything else.

### `docs/spec/quality-policy.md`, the `pdfsig` trap

Every certificate `Testing\DebugCertificate` generates shares one subject, `CN=Test Certificate, O=Internet Widgits Pty Ltd`, and so does `samples/certificate.pfx`. `pdfsig` resolves the signer through NSS **by name**, so a document carrying signatures from two different keys under that subject has its later signatures matched against the wrong certificate and reported as *Signature is Invalid*.

Found while cross-checking 2.3.1: re-signing a sample produced an apparently broken signature, on `main` and equally on `399d598` from before the change. Re-signing with `samples/certificate.pfx`, the certificate that made the sample, clears the report, and the package's own validator, which reads the certificate embedded in each CMS rather than looking one up by name, called every one of them valid throughout.

It cost real time to run down, and `pdfsig` is the project's stated independent check, so the trap is written where the next person will look before drawing a conclusion from a failure.

Documentation only. No source file is touched.