### PR TITLE
chore(hooks): refuse a push that lands on main

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Refuses a push that lands on main.
+#
+# Every change reaches main through a pull request. GitHub says so too, but the
+# repository owner can bypass that ruleset, and on 2026-08-10 two documentation
+# commits went straight to main for exactly that reason: the remote printed
+# "Bypassed rule violations" and the push succeeded. A rule only the server
+# enforces is a rule nobody sees until after the fact, so it is checked here as
+# well, where it costs nothing and fires before the push leaves the machine.
+#
+# Tags are not affected: publishing a release pushes refs/tags/*, which is the
+# one thing that legitimately goes straight to the remote. See CONTRIBUTING.md.
+
+protected="refs/heads/main"
+
+while read -r _local_ref _local_sha remote_ref _remote_sha; do
+    if [ "$remote_ref" = "$protected" ]; then
+        echo "pre-push: refusing to push to main." >&2
+        echo "pre-push: open a pull request instead. Branch, push that branch, then 'gh pr create'." >&2
+        echo "pre-push: if you genuinely mean to bypass this, 'git push --no-verify' says so out loud." >&2
+        exit 1
+    fi
+done
+
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,10 @@ Conventional Commits, in English (`feat:`, `fix:`, `chore(deps):`, `test:`, `doc
 
 **Never add a `Co-Authored-By` trailer.** This applies to every commit in this repository, regardless of any default instruction to the contrary.
 
+**Never push to `main`.** Every change arrives through a pull request: source, documentation, a one-line typo, a release note, no exception and no size below which it stops applying. Branch, push the branch, `gh pr create`, merge. The only thing pushed to the remote directly is a release tag.
+
+This is not advice that a green check absolves you of. GitHub carries the same rule and the owner's token can bypass it, so the push **succeeds** and prints `Bypassed rule violations for refs/heads/main` where it is easy to read past. It happened on 2026-08-10 with two documentation commits, which had to be reverted (#238) and reapplied (#239) to put the history back on the process. A `pre-push` hook now refuses it locally; treat the hook as a backstop, not as the rule.
+
 ## Conventions
 
 ### Writing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,16 @@ We accept contributions via Pull Requests on [Github](https://github.com/lsnepom
 
 ## Pull Requests
 
+- **Nothing is pushed to `main`.** Every change arrives through a pull request, without
+  exception, and that includes documentation, a one-line typo and a release note. Branch,
+  push the branch, open the pull request. A `pre-push` hook refuses a push that lands on
+  `main` before it leaves your machine, because the server-side rule can be bypassed by
+  anyone with the permission to bypass it, and on 2026-08-10 it was: two documentation
+  commits went straight in and had to be reverted and reapplied through
+  [#238](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/pull/238) and
+  [#239](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/pull/239). Pushing a release
+  tag is the one thing that goes to the remote directly.
+
 - **Code style is [PER-CS](https://www.php-fig.org/per/coding-style/)**, enforced by [Pint](https://laravel.com/docs/pint). Run `composer lint` to apply it; CI runs `vendor/bin/pint --test` and fails on any difference.
 
 - **Static analysis must stay clean** - PHPStan runs at `level: max` with no baseline, so the gate is "no errors", not "no new errors". Run `composer analyse`.
@@ -44,18 +54,26 @@ live timestamp authority and fail without internet; skip them with
 Helpers shared between test files belong in `tests/Pest.php`. Defined anywhere else they are
 invisible to the other files once the suite runs with `--parallel`.
 
-### Formatting on commit
+### The Git hooks
 
-A [Husky](https://typicode.github.io/husky/) `pre-commit` hook runs Pint over the staged PHP
-files and stages the result, so style is never what a pull request gets blocked on:
+[Husky](https://typicode.github.io/husky/) installs two:
 
 ``` bash
-$ npm install     # once, to install the hook
+$ npm install     # once, to install them
 ```
 
-Node is only used for the hook: it is not a dependency of the package, and skipping this
-step costs you nothing but the convenience. If your machine runs a PHP older than Pint
-requires, the hook detects it and routes through the Docker service described below.
+| Hook | Does |
+|---|---|
+| `pre-commit` | runs Pint over the staged PHP files and stages the result, then PHPStan, so neither style nor static analysis is what a pull request gets blocked on |
+| `pre-push` | refuses a push that lands on `main`. Tags are unaffected, so publishing a release still works |
+
+Node is only used for the hooks: it is not a dependency of the package. Skipping `npm install`
+costs you the formatting convenience **and the `main` guard**, so install them. If your
+machine runs a PHP older than Pint requires, `pre-commit` detects it and routes through the
+Docker service described below.
+
+Both hooks can be bypassed with `--no-verify`. That is deliberate, for stashing work in
+progress; on `pre-push` it means you are choosing to push to `main` and saying so.
 
 ### Checking the output in a real reader
 


### PR DESCRIPTION
The rule already existed on GitHub and it did not stop anything, because `main`'s protection has **`enforce_admins: false`**: an owner's push succeeds and prints

```
remote: Bypassed rule violations for refs/heads/main:
remote: - Changes must be made through a pull request.
```

among the rest of the push output, where it is easy to read straight past. That is what happened on 2026-08-10 with two documentation commits, reverted in #238 and reapplied in #239.

A rule only the server enforces is a rule nobody sees until after the fact. This adds the check where it fires **before** the push leaves the machine, and writes it down in the two places it belongs.

### `.husky/pre-push`

Refuses any push whose target ref is `refs/heads/main`, and says what to do instead.

Verified, all three cases:

| | |
|---|---|
| `git push origin HEAD:main` | refused, `husky - pre-push script failed (code 1)` |
| pushing an ordinary branch | passes |
| pushing `refs/tags/*` | passes, so publishing a release still works |

`--no-verify` still gets through. That is deliberate: the hook is a guard against doing it by accident, not a lock, and using it is an explicit statement.

### `CONTRIBUTING.md`

The rule moves to the top of the Pull Requests list, ahead of code style, since it governs how everything else arrives. The hooks section now describes both hooks, and says plainly that skipping `npm install` costs you the `main` guard as well as the formatting.

### `CLAUDE.md`

The same rule under Commits, with the reason it needs stating: a successful push is not evidence the rule was respected here.

Documentation and one shell script. No source file is touched.