### PR TITLE
docs(spec): reach for the framework, and use enums for sets

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,6 +14,7 @@ built, and cited a §12 that never had a section.
 | [docs/spec/invariants.md](docs/spec/invariants.md) | Rules that break the product or the project when violated. **Read before touching `src/Signing`, `src/Validation` or the dependency list.** |
 | [docs/spec/public-api.md](docs/spec/public-api.md) | What the package exposes, and what changing it costs. |
 | [docs/spec/quality-policy.md](docs/spec/quality-policy.md) | The gates a change has to pass, and why each sits where it does. |
+| [docs/spec/conventions.md](docs/spec/conventions.md) | How the code is written: reach for the framework before writing a helper, and use an enum where a set of values exists. |
 
 ## Decisions: why the design is what it is
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ Documentation is split by lifecycle, and `tests/SpecTest.php` fails when a refer
 | `docs/spec/invariants.md` | the rules that break the product or the project. **Read before touching `src/Signing`, `src/Validation` or the dependency list** |
 | `docs/spec/public-api.md` | what the package exposes, and what changing it costs |
 | `docs/spec/quality-policy.md` | the gates, and why each sits where it does |
+| `docs/spec/conventions.md` | how the code is written. **Read before writing a helper or a class constant** |
 | `docs/decisions/` | why the design is what it is: one numbered file per decision |
 | `docs/history/v2-modernization.md` | why v1 was shaped as it was, and where the build diverged from the plan |
 | `docs/history/decision-log.md` | which questions were put, and when they were answered |
@@ -147,6 +148,13 @@ Conventional Commits, in English (`feat:`, `fix:`, `chore(deps):`, `test:`, `doc
 This is not advice that a green check absolves you of. GitHub carries the same rule and the owner's token can bypass it, so the push **succeeds** and prints `Bypassed rule violations for refs/heads/main` where it is easy to read past. It happened on 2026-08-10 with two documentation commits, which had to be reverted (#238) and reapplied (#239) to put the history back on the process. A `pre-push` hook now refuses it locally; treat the hook as a backstop, not as the rule.
 
 ## Conventions
+
+The two that decide whether a piece of code should exist at all are in `docs/spec/conventions.md`, and they are mandatory rather than preferences:
+
+- **Laravel first.** This package only runs inside Laravel, so before writing a helper, check whether the framework already has it and use that. Write the bespoke version only after establishing there is none, put it in `src/Support/`, and say in the docblock what was missing. **Except on bytes:** `Str::substr()` and `Str::length()` are multibyte-aware, so over PDF or DER they return the wrong offsets and corrupt a signature while passing the whole suite. `tests/ArchTest.php` fails on any use of `Illuminate\Support\Str` inside `src/Signing` or `src/Validation`.
+- **Enums, not class constants.** A closed set of values is an enum; a constant is for a lone fact, like one cipher or one reserved width. The test is "could a second value of this kind ever be right?". If yes, it is an enum now.
+
+Both are justified in `docs/decisions/0018-prefer-the-platforms-own-constructs.md`.
 
 ### Writing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,15 @@ We accept contributions via Pull Requests on [Github](https://github.com/lsnepom
 
 - **Static analysis must stay clean** - PHPStan runs at `level: max` with no baseline, so the gate is "no errors", not "no new errors". Run `composer analyse`.
 
+- **Reach for Laravel before writing a helper** - the package only runs inside the framework, so
+  `Str`, `Arr`, `File`, `Http` and the rest are already there. Write your own only after
+  establishing there is no framework equivalent, and say so in the docblock. The one exception is
+  byte work on PDF and DER, where the multibyte helpers return wrong offsets: see
+  [the conventions](docs/spec/conventions.md).
+
+- **A set of values is an enum, not a group of class constants** - constants are for a lone fact,
+  like one cipher or one reserved width.
+
 - **Add tests!** - Your patch won't be accepted if it doesn't have tests.
 
 - **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.

--- a/docs/decisions/0018-prefer-the-platforms-own-constructs.md
+++ b/docs/decisions/0018-prefer-the-platforms-own-constructs.md
@@ -1,0 +1,112 @@
+# 0018: Prefer the platform's own constructs
+
+**Status:** implemented.
+
+## Context
+
+Two habits had been accumulating, and they are the same habit.
+
+**The package hand-rolls things Laravel ships.** It requires
+`illuminate/support`, `illuminate/http`, `illuminate/process` and
+`illuminate/filesystem` outright, and it is not usable outside the framework at
+all: the facade, the service provider and the container bindings are the API.
+Everything in those packages is therefore already installed, already tested and
+already familiar to whoever reads the code. `Signing\Cades\HttpTransport` builds
+a `stream_context_create` and calls `file_get_contents` anyway, where `Http::`
+would give timeouts, retries and `Http::fake()`.
+
+**And it reaches for class constants where a set of values exists.** PHP has had
+enums since 8.1, the floor here is 8.4, and `Enums\SignatureProfile` and
+`Enums\CertificationLevel` already show what that buys: the language checks the
+set, the IDE completes it, and `resolve()` can turn a configuration string into
+the type once instead of at every call site. A group of related `const int`s is
+the same thing with the checking removed.
+
+Neither is a defect today. Both are the kind of thing that is invisible for a
+release and then everywhere.
+
+## Decision
+
+**Use what the platform provides. Write the bespoke version only after
+establishing there is no platform version, and say so in the docblock.**
+
+Both halves are stated as standing rules in
+[the conventions](../spec/conventions.md), which is where someone reads them
+before writing code. This record is why.
+
+### The framework first
+
+The rule is "look, then use, then if it genuinely is not there, write it in
+`src/Support/` with a docblock that says what was missing". A helper whose
+docblock cannot answer "why is this not `Str::something`" is a helper that
+should not exist.
+
+`Support\Files::read()` is the shape a legitimate one takes: it exists because
+`file_get_contents()` **and** `File::get()` both return `false`, and that `false`
+reaching a `string` parameter was this package's single most common typing
+defect. The docblock says exactly that.
+
+### Except on bytes, where it is the opposite
+
+**`Str::substr()` and `Str::length()` are multibyte-aware.** Running them over a
+PDF or a DER blob reinterprets binary as UTF-8, so the offsets come back wrong,
+and in this package a wrong offset is a corrupted signature.
+
+This is not a style preference with a caveat. It is the one place where reaching
+for the framework helper is a defect, and it is a defect that **passes the whole
+test suite**, because the fixtures are ASCII and the failure needs a multi-byte
+sequence in the payload to show up.
+
+So the carve-out is enforced bluntly: `tests/ArchTest.php` fails when
+`Illuminate\Support\Str` is used anywhere in `src/Signing` or `src/Validation`.
+Those two namespaces are where every byte-exact operation lives. "Not here at
+all" is a rule that survives review; "here, but only these five methods" is not.
+
+`preg_match` and `preg_match_all` stay for the same reason: `Str::match()`
+returns the matched text and discards the offsets, and offsets are what the
+incremental writer is built on.
+
+### Enums for sets, constants for facts
+
+A closed set of values is an enum. A constant is for a lone fact: one cipher,
+one reserved width, one placeholder shape, one path.
+
+The test is **"could a second value of this kind ever be right?"** If it could,
+it is an enum now, because otherwise the sibling arrives later and arrives as a
+constant beside the first one, and by then there are three call sites comparing
+integers.
+
+**Enums nobody configures may be int-backed.** The existing arch rule requires
+string-backed enums so configuration can name a case in plain text, and that
+reason does not reach an ASN.1 tag whose values are fixed by ISO/IEC 8825-1 and
+are natural integers. Those are exempted by name, the way `sha1` is exempted for
+`SignatureDetails`, rather than by weakening the rule for every enum.
+
+## Consequences
+
+- `tests/ArchTest.php` gains two rules: no `Illuminate\Support\Str` in
+  `src/Signing` or `src/Validation`, and the string-backed requirement now names
+  its exemptions instead of applying to every enum.
+
+- **`HttpTransport` is left as it is, and recorded as outstanding.** Moving the
+  TSA, OCSP and CRL calls onto `Http::` is the right change and it is not a
+  documentation change: it alters the network path of every `pades-b-t` and
+  above, and the tests that would cover it are in the `network` group. Doing it
+  inside a documentation commit would be exactly the quiet behaviour change this
+  project keeps saying it does not want.
+
+- **`Data\SealPlacement::LAST_PAGE` stays an `int` sentinel**, against the enum
+  rule. It was `Enums\SealPage` and was deliberately removed during the v2 work,
+  and reversing that now would change the type of a public property for a
+  cosmetic gain. Named in the conventions so the next reader finds a decision
+  rather than an oversight.
+
+## Alternatives rejected
+
+| | Why not |
+|---|---|
+| Leave both as review-time taste | Taste does not survive a busy week. The `Str` half is a defect the suite cannot catch, so it needs a gate |
+| Ban `Str` package-wide | `Support\TemporaryFile` and `Data\SignedPdf` use `Str::orderedUuid()` correctly, and naming a temporary file is not byte work |
+| Allow `Str` in `Signing` and `Validation` with a method allowlist | An allowlist is a rule you have to read to apply. "Not in these two namespaces" is one you can apply from memory |
+| Convert every existing constant to an enum in one sweep | Most of them are lone facts and would become single-case enums, which is ceremony without checking |
+| Rewrite `HttpTransport` here | A behaviour change riding in on a conventions commit, with its tests in the group that needs the network |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -27,6 +27,7 @@ document drifts away from the code it describes.
 | [0015](0015-object-streams.md) | Objects packed into object streams are read, and written back uncompressed |
 | [0016](0016-trust-is-the-applications-policy.md) | Trust is the application's policy, and its verification is ours |
 | [0017](0017-the-seal-goes-where-it-was-asked-for.md) | The seal goes where it was asked for |
+| [0018](0018-prefer-the-platforms-own-constructs.md) | Prefer the platform's own constructs: Laravel's helpers, and enums over class constants |
 
 Nothing is currently proposed and unbuilt. The four that were, 0009, 0010, 0012
 and 0013, all shipped in 2.2, and each carries the measurement that decided its

--- a/docs/spec/conventions.md
+++ b/docs/spec/conventions.md
@@ -1,0 +1,145 @@
+# Conventions
+
+Rules about how the code is written, as opposed to what it must do. The rules
+that break the product live in [the invariants](invariants.md); these break the
+codebase slowly instead, which is why they are written down rather than left to
+whoever reviews.
+
+Each is checked at review. Where a rule can be checked by a machine, it is, and
+that is noted.
+
+---
+
+# 1. Laravel first
+
+**This package is a Laravel package. Before writing a helper, check whether the
+framework already has it, and use that.**
+
+The package requires `illuminate/support`, `illuminate/http`, `illuminate/process`
+and `illuminate/filesystem` outright. Everything in them is already installed, already
+tested, already documented, and already familiar to the person reading the code.
+A private reimplementation of any of it is code this project has to maintain,
+test and explain, in exchange for nothing.
+
+This is a rule, not a preference. It is checked at review, and part of it is
+checked by `tests/ArchTest.php`.
+
+---
+
+## The rule
+
+1. **Look in the framework first.** `Illuminate\Support\Str`, `Arr`,
+   `Collection`, `Facades\File`, `Facades\Process`, `Facades\Http`,
+   `Facades\Config`, `Facades\Cache`, the `Illuminate\Contracts\*` interfaces.
+2. **If it exists there, use it**, even when the native call is two characters
+   shorter.
+3. **If it does not, write it**, put it in `src/Support/`, and say in the
+   docblock what the framework does not provide. A helper whose docblock cannot
+   answer "why is this not `Str::something`" is a helper that should not exist.
+
+Exceptions are below and they are narrow. Everything not listed there follows
+the rule.
+
+---
+
+## Reach for
+
+| Instead of | Use | Why |
+|---|---|---|
+| `file_get_contents`, `file_put_contents` | `Support\Files::read()`, `File::put()` | `Files::read()` exists because both the native call and `File::get()` return `false`, and that `false` reaching a `string` parameter was this package's most common typing defect |
+| `is_dir`, `mkdir`, `unlink`, `glob` | `File::isDirectory()`, `File::makeDirectory()`, `File::delete()`, `File::glob()` | one filesystem abstraction, fakeable in a host application's tests |
+| `uniqid`, `random_bytes` for a name | `Str::orderedUuid()`, `Str::random()` | already how `Support\TemporaryFile` names its files |
+| `exec`, `shell_exec`, `proc_open` | `Support\ProcessRunner` on `Illuminate\Process` | invariant 8, and `Process::fake()` in a consuming application |
+| `curl_*`, `stream_context_create` + `file_get_contents` | `Illuminate\Support\Facades\Http` | timeouts, retries and `Http::fake()`, instead of a hand-rolled stream context |
+| `array_map` / `array_filter` / `array_merge` chained over one value | `collect()` | one pipeline instead of three nested calls, when it genuinely reads better |
+| a hand-written `get($array, 'a.b.c')` | `Arr::get()` | |
+| reading config with a cast and a default | `Illuminate\Contracts\Config\Repository`, injected | already how the package reads every configuration key |
+| a hand-rolled `toArray()` on a value object | `Illuminate\Contracts\Support\Arrayable` | `Data\BaseData` already implements it |
+
+## Do not reach for
+
+These are the narrow exceptions, and each is load-bearing.
+
+| Keep the native call | Why |
+|---|---|
+| **`substr`, `strlen`, `strpos`, `str_replace` on PDF or DER bytes** | **`Str::substr()` and `Str::length()` are multibyte-aware.** Running them over a PDF or a CMS reinterprets binary as UTF-8 and returns the wrong offsets, which in this package means a corrupted signature. Byte work uses byte functions, always |
+| `preg_match`, `preg_match_all` | `Str::match()` returns the match and throws the offsets away, and offsets are what the incremental writer is built on. `Str::isMatch()` is fine where only the boolean is wanted |
+| `openssl_*` | the framework wraps none of it |
+| `pack`, `unpack`, `bin2hex`, `hex2bin`, `gzuncompress` | no framework equivalent, and all byte-exact |
+| `hash(..., binary: true)` | `Hash::` is password hashing, a different thing entirely |
+
+The first row is the one that matters. If a change swaps a byte-level `substr`
+for `Str::substr`, it will pass every test in this suite on ASCII fixtures and
+corrupt real documents in production.
+
+*Enforced by* `tests/ArchTest.php`, which fails when `Illuminate\Support\Str` is
+used inside `src/Signing` or `src/Validation` at all: those namespaces are where
+the byte work lives, and the rule is easier to keep as "not here" than as "here,
+but only these methods".
+
+---
+
+## Known outstanding
+
+`Signing\Cades\HttpTransport` builds its own `stream_context_create` and calls
+`file_get_contents` for the TSA, OCSP and CRL requests. `Http::` is the right
+tool and `guzzlehttp/guzzle` is already in the tree, so this is a gap in the
+rule rather than an exception to it. It is called out here rather than left for
+someone to find, and moving it also makes the network surface fakeable, which is
+the same argument that put `ProcessRunner` on `Illuminate\Process`.
+
+Rationale and alternatives: [0018](../decisions/0018-prefer-the-platforms-own-constructs.md).
+
+---
+
+# 2. Enums, not class constants
+
+**A closed set of values is an enum.** A class constant is for the case where
+exactly one value can ever exist, and for nothing else.
+
+PHP has had enums since 8.1 and this package's floor is 8.4, so a set of related
+constants is a type the language will check for you that has been written as a
+set of integers it will not.
+
+| Write | Instead of |
+|---|---|
+| `enum SignatureProfile: string` | `const PADES_B_B = 'pades-b-b'` beside four siblings |
+| `enum CertificationLevel: string` | `const NO_CHANGES = 1`, `const FORM_FILLING = 2`, … |
+| `enum Asn1Tag: int` | `const SEQUENCE = 0x30`, `const SET = 0x31`, … |
+
+A constant stays a constant when it is a lone fact about the world rather than
+one of several choices:
+
+| Legitimate constant | Why |
+|---|---|
+| `CertificateVault::CIPHER` | one cipher, chosen once |
+| `IncrementalSigner::CONTENTS_HEX_LENGTH` | one reserved width |
+| `Pem::CERTIFICATE_MARKER` | one string, fixed by RFC 7468 |
+| `ByteRangeCalculator::FIELD` | one placeholder shape |
+| `LaravelA1PdfSignServiceProvider::CONFIG_PATH` | one path |
+| `XrefStreamWriter::WIDTHS` | one column layout, fixed by §7.5.8 |
+
+The test is not "is it private" or "is it an array". It is **"could a second
+value of this kind ever be right?"** If yes, it is an enum today, because the
+sibling arrives later and arrives as a constant beside the first one.
+
+## Enums that are not configuration may be int-backed
+
+`tests/ArchTest.php` requires enums in `Enums\` to be string-backed, so a
+configuration file can name a case in plain text. That reason does not reach an
+enum nobody configures, like an ASN.1 tag whose values are fixed by
+ISO/IEC 8825-1 and are natural integers. Those are exempt by name in the arch
+rule, the way `sha1` is exempt for `SignatureDetails`, rather than by weakening
+the rule for every enum.
+
+## Known tension
+
+`Data\SealPlacement::LAST_PAGE` is an `int` sentinel of `-1`, and by this rule it
+would be an enum. It was one: `Enums\SealPage` existed and was removed during the
+v2 work on the grounds that "the page is one field of a placement, not a concept
+with its own behaviour"
+([the modernisation record](../history/v2-modernization.md)).
+
+That reasoning predates this rule and is not obviously wrong, and reversing it
+now would change the type of a public property. It stays as it is, named here so
+the next person finds a decision rather than an oversight.

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -67,9 +67,36 @@ arch('no deprecated namespace lingers')
     ->expect('LSNepomuceno\LaravelA1PdfSign\Entities')
     ->not->toBeUsed();
 
+/**
+ * The reason is the one in the name, so it reaches only the enums a
+ * configuration file can name. An enum whose values are fixed by a standard and
+ * are natural integers, like an ASN.1 tag, is exempted here rather than by
+ * weakening the rule for every enum
+ * (docs/decisions/0018-prefer-the-platforms-own-constructs.md).
+ */
 arch('enums are string-backed, so configuration can express them as plain strings')
     ->expect('LSNepomuceno\LaravelA1PdfSign\Enums')
-    ->toBeStringBackedEnums();
+    ->toBeStringBackedEnums()
+    ->ignoring('LSNepomuceno\LaravelA1PdfSign\Enums\Asn1Tag');
+
+/**
+ * Str::substr() and Str::length() are multibyte-aware, so running them over a
+ * PDF or a DER blob reinterprets binary as UTF-8 and returns the wrong offsets.
+ * In this package a wrong offset is a corrupted signature, and the failure
+ * passes the whole suite: every fixture is ASCII, and it takes a multi-byte
+ * sequence in the payload to show.
+ *
+ * These two namespaces are where every byte-exact operation lives, so the rule
+ * is "not here at all" rather than a list of permitted methods: an allowlist is
+ * a rule you have to look up, and this one has to survive review from memory
+ * (docs/spec/conventions.md).
+ */
+arch('the byte-exact namespaces do not reach for multibyte string helpers')
+    ->expect('Illuminate\Support\Str')
+    ->not->toBeUsedIn([
+        'LSNepomuceno\LaravelA1PdfSign\Signing',
+        'LSNepomuceno\LaravelA1PdfSign\Validation',
+    ]);
 
 arch('contracts are interfaces')
     ->expect('LSNepomuceno\LaravelA1PdfSign\Contracts')


### PR DESCRIPTION
Two conventions, registered as rules rather than left to review taste.

They are recorded in **both** places on purpose, and the split answers a fair question about which one they are:

| | |
|---|---|
| [`docs/decisions/0018`](docs/decisions/0018-prefer-the-platforms-own-constructs.md) | **why**: the context, the alternatives weighed, the consequences |
| [`docs/spec/conventions.md`](docs/spec/conventions.md) | **the standing rule**, which is what someone reads before writing code |

That is the pattern the repository already uses: `invariants.md` states rules and cites 0006, 0009 and 0015; `quality-policy.md` states gates and cites 0005 and 0013.

## 1. Laravel first

The package requires `illuminate/support`, `illuminate/http`, `illuminate/process` and `illuminate/filesystem` outright, and is not usable outside the framework at all: the facade, the provider and the container bindings *are* the API. Everything in those packages is already installed, tested and familiar, so a private reimplementation is code this project maintains in exchange for nothing.

Look, then use, then if it genuinely is not there, write it in `src/Support/` **with a docblock saying what was missing**. A helper whose docblock cannot answer "why is this not `Str::something`" is a helper that should not exist. `Support\Files::read()` is the shape a legitimate one takes.

### Except on bytes, where the rule inverts

**`Str::substr()` and `Str::length()` are multibyte-aware.** Over a PDF or a DER blob they reinterpret binary as UTF-8 and return the wrong offsets, and in this package a wrong offset is a corrupted signature.

That failure **passes the entire test suite**: every fixture is ASCII, and it takes a multi-byte sequence in the payload to show. So it is gated rather than documented: `tests/ArchTest.php` fails on any use of `Illuminate\Support\Str` inside `src/Signing` or `src/Validation`, the two namespaces where every byte-exact operation lives.

"Not here at all" is a rule that survives review from memory. "Here, but only these five methods" is one you have to look up.

## 2. Enums, not class constants

A closed set of values is an enum. A constant is for a lone fact: one cipher, one reserved width, one placeholder shape, one path. The test is **"could a second value of this kind ever be right?"** If yes, it is an enum now, because otherwise the sibling arrives later, as a constant beside the first, and by then three call sites compare integers.

The string-backed arch rule now names its exemptions instead of applying to every enum: "so configuration can name a case in plain text" does not reach an ASN.1 tag whose values are fixed by ISO/IEC 8825-1 and are natural integers.

## Two tensions, named rather than papered over

- **`HttpTransport` still builds its own `stream_context_create`** where `Http::` belongs, with Guzzle already in the tree. Moving it is right and it is not a documentation change: it alters the network path of every `pades-b-t` and above, and its tests are in the `network` group. Doing that inside a conventions commit is exactly the quiet behaviour change this project keeps saying it does not want, so it is listed as outstanding.
- **`SealPlacement::LAST_PAGE` stays an `int` sentinel**, against the enum rule. It *was* `Enums\SealPage` and was deliberately removed in the v2 work; reversing that would change the type of a public property for a cosmetic gain.

Documentation, plus two arch rules. No source file is touched.