### PR TITLE
docs(2.x): document 2.4, and correct what it made untrue

### DIFF
--- a/public/docs/2.x/installation.md
+++ b/public/docs/2.x/installation.md
@@ -58,8 +58,14 @@ return [
         'driver' => env('A1_PDF_SIGN_IMAGE_DRIVER', 'gd'), // gd | imagick
         'font'   => ['path' => null, 'size' => 'large', 'color' => '#16A085'],
         'background' => null,
+
+        // since 2.4
+        'transparent' => true,                    // honour the artwork's alpha channel
+        'text' => ['x' => 160, 'rows' => [80, 150, 250]],
     ],
 ];
 ```
+
+`transparent` defaults to **`true` since 2.4**, where a seal was previously flattened onto white. It costs bytes, since the alpha travels as a separate `/SMask` image rather than inside a JPEG, and it makes PDF/A-1 impossible: §6.4 forbids `/SMask`. Set it to `false` for the old opaque rectangle.
 
 Every argument that has a configured default is nullable at the call site: passing `null` means "use the configuration", so a call site never has to repeat an infrastructure decision.

--- a/public/docs/2.x/release-notes.md
+++ b/public/docs/2.x/release-notes.md
@@ -1,3 +1,104 @@
+# 2.4.0
+
+## Validation reads what signing writes
+
+2.3 could produce a PAdES B-LT document and then tell you almost nothing about one. The report said a signature verified; it could not say whether the timestamp on it was real, which level the signature actually reached, or what the document's own revocation material said about the signer.
+
+```PHP
+$report->signatures[0]->attestedAt();   // the authority's time, or null
+$report->signatures[0]->profile;        // the level it satisfies, not the one it claims
+$report->signatures[0]->isRevoked();    // what the embedded OCSP and CRLs say
+```
+
+`attestedAt()` returns null rather than falling back to `signedAt`. The signer's own clock answers a different question, and a caller reading an unattested time as an attested one is the exact mistake the method exists to prevent.
+
+`isRevoked()` is deliberately separate from `verified`. **A revoked certificate still produces a signature that matches the bytes perfectly.** What it stops being is one anyone should accept.
+
+<hr>
+
+## ⚠️ Two things change what you already get
+
+### The seal keeps its alpha channel
+
+`a1-pdf-sign.seal.transparent` defaults to `true`.
+
+| | Before | Now |
+|---|---|---|
+| A PNG with an alpha channel | flattened onto white | drawn transparent |
+| Bytes added | JPEG | deflated samples plus an `/SMask`, larger |
+| PDF/A-1 conformance | possible | **impossible**: §6.4 forbids `/SMask` |
+
+Set `'transparent' => false` for the old opaque rectangle. That is the whole reason the setting exists rather than the behaviour being unconditional.
+
+### `sealFrom()` uses the image you gave it
+
+`SealPlacement::$imagePath` was written by `sealFrom()` and read by nothing at all, so the caller's artwork was silently replaced by a render of the certificate. **If you called `sealFrom()`, your documents were not carrying your image, and now they will.**
+
+<hr>
+
+## Locks, and honouring the ones already there
+
+```PHP
+->lock()                                   // every field
+->lock(FieldLock::only(['Amount']))        // that one
+->lock(FieldLock::except(['Countersign'])) // everything else
+```
+
+Writes `/Lock` and `/FieldMDP` as two transforms in one `/Reference` array (ISO 32000-1 §12.7.4.5). A narrower claim than certifying: a certification governs the document, a lock governs named fields.
+
+**The other half is the half that matters.** A later `sign()` into a field an existing lock covers is now refused, instead of producing a document whose earlier signature silently broke.
+
+<hr>
+
+## The archive timestamp is a chain
+
+```PHP
+A1PdfSign::extendArchive($path);
+```
+
+No certificate, no key, no password. A DocTimeStamp is signed by the authority rather than by the signer, so refreshing a B-LTA archive is something a scheduled job can do with no key material anywhere near it.
+
+<hr>
+
+## Filters documents actually use
+
+`Support\PdfFilters` decodes Flate, LZW with `/EarlyChange`, ASCII85, ASCIIHex and run-length, with the PNG and TIFF predictors. 2.3 read compressed objects only when they happened to be plain Flate, which is a guess that holds until it does not.
+
+<hr>
+
+## What this release is really about
+
+Three of the five PAdES levels this package advertises could regress **without CI going red.** Everything above `pades-b-b` needs a timestamp authority, the tests for it were in the non-blocking `network` group, and that was demonstrably not theoretical: three of those tests were committed broken, went green, and were noticed only by reading a log.
+
+`Contracts\SignatureTransport` is the fix. The HTTP transport was already injected and already the only thing in `src/` that opens a connection, but it was `final` and its three collaborators took the concrete class. **Injection you cannot substitute is not injection.**
+
+`Testing\LocalTimestampAuthority` answers with real RFC 3161 tokens from `openssl ts -reply`, which needs no server and no network. They are signed, verifiable, and carry the imprint of the bytes they were handed, so the offline tests assert that the timestamp verified rather than asserting that something was embedded. A stub returning canned bytes would have proved nothing: the imprint has to match the signature value produced in that run.
+
+Six behaviours moved from reported to gated, including PDF/A conformance at B-LTA. The live tests against a real authority stay, because a local authority cannot establish that the package interoperates with somebody else's.
+
+<hr>
+
+## PDF/A, measured rather than assumed
+
+veraPDF now runs in the development image and in CI, and it blocks. The test command carries `--fail-on-skipped`, because every check has to run somewhere and a skip is how one quietly stops running.
+
+- **An invisible signature keeps a PDF/A-1b and PDF/A-2b document conformant.** That is now a supported claim. It was not true before this release: a signature field with no appearance dictionary fails §6.9, and all six combinations measured failed until it was fixed.
+- A visible seal costs conformance, and the reason is the colour space rather than the signature.
+
+<hr>
+
+## Also fixed
+
+- The appended revision carries the trailer `/ID`. Without it, a reader may treat the revision as belonging to a different document.
+- An OCSP response signed by a delegated responder is verified against the issuer before being read (RFC 6960 §4.2.2.2). It could previously vouch for itself.
+- The archive timestamp's widget gets an appearance dictionary, the same §6.9 rule the invisible signature hit.
+
+<hr>
+
+## Upgrading
+
+No public class was removed and no signature was narrowed, so an application that calls the facade upgrades without changes. Four contracts gained members, which matters only to someone implementing one, and the three collaborators of the HTTP transport now take `Contracts\SignatureTransport` rather than the concrete class.
+
 # 2.3.1
 
 ## The seal goes where it was asked for

--- a/public/docs/2.x/sign-pdf-file.md
+++ b/public/docs/2.x/sign-pdf-file.md
@@ -127,6 +127,7 @@ Signature fields must not collide, so each revision gets its own name automatica
 ```PHP
 <?php
 
+use LSNepomuceno\LaravelA1PdfSign\Data\SealLayout;
 use LSNepomuceno\LaravelA1PdfSign\Data\SealPlacement;
 use LSNepomuceno\LaravelA1PdfSign\Enums\FontSize;
 use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
@@ -162,7 +163,19 @@ $signed = A1PdfSign::newSignature()
     ->pdf('path/to/document.pdf')
     ->sealFrom('path/to/seal.png')
     ->sign();
+
+// What the seal says and where, overriding the certificate-derived lines
+// (since 2.4)
+$signed = A1PdfSign::newSignature()
+    ->certificate('path/to/certificate.pfx', 'password')
+    ->pdf('path/to/document.pdf')
+    ->seal(layout: SealLayout::saying(['Approved', 'Protocol 4471']))
+    ->sign();
 ```
+
+> **Fixed in 2.4.** `sealFrom()` wrote the image path into the placement and nothing read it back, so the artwork was silently replaced by a render of the certificate. If you called `sealFrom()` before 2.4, your documents were not carrying your image.
+
+**A seal with an alpha channel stays transparent since 2.4**, where before it was flattened onto white. It costs more bytes, because PDF has no PNG filter and the alpha travels as a separate `/SMask` image, and **it makes PDF/A-1 impossible**: §6.4 forbids `/SMask` outright. `'transparent' => false` in the config is the lever, and that is the whole reason the setting exists.
 
 **The page is counted from one, in the order the page tree declares.** `SealPlacement::LAST_PAGE` is the default, so a placement that names no page puts the seal on the last one. A page the document does not have raises `SealPlacementException` rather than being clamped to the nearest one: a seal asked for on page 7 of a three-page contract is a mistake, and putting it on page 3 would look deliberate.
 
@@ -308,3 +321,43 @@ The two cross-reference forms cannot be mixed: appending a classic table to a do
 Object streams took a further release because reading the index is not enough. The catalog is a dictionary, and a dictionary is exactly what gets packed; signing rewrites the catalog to register the field, so a catalog it cannot read is a document it cannot sign. **2.2 read the index and still refused most of these documents.** Nothing is unpacked in place: the revision writes the changed objects back at the top level, and the newer cross-reference entry supersedes the packed one.
 
 If you are signing documents from a source that previously failed, this is why.
+
+<hr>
+
+#### 10 - Locking the fields a signature covers. <small>(since 2.4)</small>
+
+```PHP
+<?php
+
+use LSNepomuceno\LaravelA1PdfSign\Data\FieldLock;
+use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
+
+A1PdfSign::newSignature()
+    ->certificate('path/to/certificate.pfx', 'password')
+    ->pdf('path/to/contract.pdf')
+    ->lock()                                    // every field
+    ->sign();
+
+->lock(FieldLock::only(['Amount', 'DueDate'])) // those two
+->lock(FieldLock::except(['Countersign']))     // everything but that one
+```
+
+A lock is **a narrower claim than certifying**. A certification governs the whole document; a lock governs the fields you name. One signature can make both, and they are written as two transforms in one `/Reference` array (ISO 32000-1 §12.7.4.5).
+
+**The half that matters is the reading, not the writing.** A later `sign()` into a field an existing lock covers raises `FieldLockException` instead of producing a document whose earlier signature silently stopped verifying. Locks other producers wrote are honoured the same way as the ones this package writes.
+
+<hr>
+
+#### 11 - Extending an archive. <small>(since 2.4)</small>
+
+```PHP
+<?php
+
+use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
+
+$extended = A1PdfSign::extendArchive('path/to/archived.pdf');
+```
+
+**No certificate, no key, no password.** A DocTimeStamp is signed by the timestamp authority rather than by the signer, so extending a `pades-b-lta` archive is something a scheduled job can do with no key material anywhere near it.
+
+An archive timestamp is a chain, not a state. Each new one covers the whole file including the previous timestamp, so the evidence can be renewed before the algorithms behind the older links weaken. It needs the same authority configured as `pades-b-t` and above.

--- a/public/docs/2.x/signature-profiles.md
+++ b/public/docs/2.x/signature-profiles.md
@@ -56,6 +56,18 @@ Without a configured URL, requesting a timestamped profile throws rather than si
 
 <hr>
 
+## Extending the archive <small>(since 2.4)</small>
+
+```PHP
+A1PdfSign::extendArchive('path/to/archived.pdf');
+```
+
+An archive timestamp is a **chain, not a state**. Each new one covers the whole file including the timestamp before it, which is what lets the evidence outlive the algorithms it was built on.
+
+No certificate is involved: a DocTimeStamp is signed by the authority, not by the signer, so this is something a scheduled job can do to an archive with no key material anywhere near it.
+
+<hr>
+
 ## What happens when the material is unavailable
 
 A self-signed certificate has neither an OCSP responder nor a CRL distribution point, and a responder can simply be unreachable. In both cases the document stays at the level below rather than failing the signature, since signing must not depend on a third party being up.
@@ -64,4 +76,13 @@ A self-signed certificate has neither an OCSP responder nor a CRL distribution p
 
 ## A note on network access
 
-Timestamp, OCSP and CRL requests go through an injected HTTP transport. **The host application owns that SSRF surface**: the URLs come from your configuration, and the package never derives an endpoint from the document being signed.
+Timestamp, OCSP and CRL requests go through an injected transport. **The host application owns that SSRF surface**: the URLs come from your configuration, and the package never derives an endpoint from the document being signed.
+
+Since 2.4 that transport is an interface, `Contracts\SignatureTransport`, bound in the container. Rebinding it replaces every outbound request this package makes, which is how an application routes them through its own client, its own proxy or its own allowlist:
+
+```PHP
+// A service provider
+$this->app->bind(SignatureTransport::class, YourOwnTransport::class);
+```
+
+It is also what makes the profiles above `pades-b-b` testable without reaching an authority, which is why they are checked on every run rather than reported.

--- a/public/docs/2.x/tests.md
+++ b/public/docs/2.x/tests.md
@@ -27,3 +27,30 @@ Tests in the `network` group reach a live timestamp authority and fail without i
 ```Shell
 vendor/bin/pest --exclude-group=network
 ```
+
+<hr>
+
+#### Nothing skips. <small>(since 2.4)</small>
+
+`composer test` carries `--fail-on-skipped`. Every check has to run somewhere, and a skip is how one quietly stops running: the PDF/A group spent a release skipping itself by default, which left the conformance claims unverified on the machine where the work was happening.
+
+The suite therefore expects two tools present, both installed in the project's Docker image:
+
+| | |
+|---|---|
+| **veraPDF** | the reference PDF/A validator. It decides the conformance verdicts, and it blocks |
+| **qpdf** | structural check, applied comparatively: signing must not introduce a complaint the input did not already have |
+
+Both are **development and CI instruments only**. Nothing in `src/` may invoke one, and the architecture tests fail if it does: a package that shelled out to a JVM to answer a runtime question would be a different package, and consuming applications would inherit an installation requirement nobody wrote down.
+
+```Shell
+docker compose -f .docker/compose.yaml run --rm php composer check
+```
+
+<hr>
+
+#### What the `network` group is still for. <small>(since 2.4)</small>
+
+The timestamped profiles used to be testable only against a live authority, which meant `pades-b-t`, `pades-b-lt` and `pades-b-lta` could regress without CI going red. `Contracts\SignatureTransport` made the transport substitutable, and the suite now answers with real RFC 3161 tokens locally, so those levels are checked on every run.
+
+What stays in the `network` group is the question the local one cannot answer: **whether this package interoperates with somebody else's authority.** Those tests are reported rather than blocking, because an outage on a third party's side is not a defect here.

--- a/public/docs/2.x/validating-signature.md
+++ b/public/docs/2.x/validating-signature.md
@@ -44,6 +44,15 @@ foreach ($report->signatures as $signature) {
     $signature->chain;                       // list<Signer>, leaf first
     $signature->chainReachesRoot;            // bool, does it end at a self-signed root
 
+    // since 2.4
+    $signature->hasTimestamp();       // bool, is there an RFC 3161 token at all
+    $signature->timestampVerified;    // ?bool, does it verify and really stamp this signature
+    $signature->attestedAt();         // ?int, the authority's time, never the signer's
+    $signature->profile;              // ?SignatureProfile, the level it actually satisfies
+    $signature->subFilter;            // ?string, the /SubFilter as written
+    $signature->revocation;           // RevocationStatus
+    $signature->isRevoked();          // bool
+
     $signer = $signature->signer();
     $signer?->commonName;
     $signer?->organization;
@@ -113,11 +122,61 @@ $store?->crls;                       // int
 $store?->covers($signature);         // is there material for this signature specifically?
 ```
 
-This reports **what is there, not that it is good**. Counting an OCSP response is not evaluating it: revocation is not checked at validation time, and a store with certificates but no entry for a given signature is carrying material for a different one.
+Up to 2.3 this reported **what was there, not that it was good**: counting an OCSP response is not evaluating one. Since 2.4 the material is evaluated, and section 8 is that.
+
+A store with certificates but no entry for a given signature is still carrying material for a different one, which is what `covers()` answers.
 
 <hr>
 
-#### 7 - Certification. <small>(since 2.2)</small>
+#### 7 - The timestamp, verified. <small>(since 2.4)</small>
+
+A `pades-b-t` document carries an RFC 3161 token. Up to 2.3 the report could say the signature verified and nothing about the token on it.
+
+```PHP
+$signature = $report->latest();
+
+$signature?->hasTimestamp();      // is there a token at all
+$signature?->timestampVerified;   // ?bool
+$signature?->attestedAt();        // ?int, the genTime a verified token asserts
+$signature?->profile;             // ?SignatureProfile
+$signature?->subFilter;           // ?string
+```
+
+**`attestedAt()` returns `null` rather than falling back to `signedAt`.** They answer different questions: one is a third party's clock, the other is the signer's own, and a caller reading an unattested time as an attested one is the mistake the method exists to prevent.
+
+`timestampVerified` is `null` when there is no token, which is the ordinary case at `pades-b-b`. **An absence is not a failure**, and reporting it as `false` would say the token was checked and rejected.
+
+`profile` reports the level the signature **actually satisfies**, read from what the document carries. `subFilter` is the value as written, for a caller who would rather read it themselves:
+
+```PHP
+$signature?->subFilter;   // 'ETSI.CAdES.detached', what it claims
+$signature?->profile;     // SignatureProfile::PadesBB, what it can prove
+```
+
+A document can claim a level it does not reach. A `/SubFilter` of `ETSI.CAdES.detached` says nothing about whether a timestamp is present, so the two are reported separately rather than one being derived from the other.
+
+<hr>
+
+#### 8 - Revocation, evaluated. <small>(since 2.4)</small>
+
+```PHP
+$signature = $report->latest();
+
+$signature?->revocation;   // RevocationStatus: Good, Revoked or Unknown
+$signature?->isRevoked();  // bool
+```
+
+The OCSP responses and CRLs the document carries are parsed, **verified against the issuer**, and then read. All three steps matter: an OCSP response signed by a delegated responder is only believed once that responder is shown to have been issued by a certificate in the chain (RFC 6960 §4.2.2.2). Without that check a response could vouch for itself.
+
+`Unknown` is a real answer, and it covers three different situations: the document carries no material, it carries some but none mentioning this certificate, or what it carries does not verify against the issuer. None of those is evidence of revocation, and reporting them as `Good` would be inventing evidence.
+
+> **`isRevoked()` is separate from `verified`, and it has to be.** A revoked certificate still produces a signature that matches the bytes perfectly. What it stops being is one anyone should accept.
+
+This reads only what the document already carries. **Nothing is fetched at validation time**, so validation makes no network request and cannot be made to.
+
+<hr>
+
+#### 9 - Certification. <small>(since 2.2)</small>
 
 Whether the document's author certified it, and what that permits:
 
@@ -133,7 +192,7 @@ Half a certification is not reported as one: a `/Perms` entry naming a signature
 
 <hr>
 
-#### 8 - Trust. <small>(since 2.3)</small>
+#### 10 - Trust. <small>(since 2.3)</small>
 
 `isValid()` answers whether each signature matches the document. Whether to accept the signer is a separate question, and it is answered against roots you name:
 
@@ -168,13 +227,15 @@ OpenSSL does the path validation, so each intermediate's validity window, `basic
 
 <hr>
 
-#### 9 - What validation still does not do.
+#### 11 - What validation still does not do.
 
-**Revocation is not evaluated.** A `pades-b-lt` document carries OCSP responses and CRLs, and section 6 counts them. It does not read them, so "the material is present" is the answer, not "the certificate was not revoked".
+**It never goes to the network.** Revocation is evaluated since 2.4, but only from the material the document already carries. A signature whose certificate was revoked *after* signing, with no OCSP response in the file saying so, reports `Unknown`: the answer is somewhere on the internet, and fetching it is the host application's decision rather than the validator's.
+
+That is the same rule as everywhere else here. Signing reaches an authority because it has to; validation reads bytes.
 
 <hr>
 
-#### 10 - Verifying independently.
+#### 12 - Verifying independently.
 
 Our validator shares its assumptions with the code that produced the signature, so it is worth checking against something that does not. Poppler's `pdfsig` has caught bugs in this package that the whole test suite passed straight through:
 


### PR DESCRIPTION
The site stopped at 2.3.1 while 2.4.0 shipped.

## Two corrections, which matter more than the missing entry

A missing release note is a gap. A page that states the opposite of what the code does is worse, and there were two:

- **`validating-signature`** said *"revocation is not checked at validation time"*, in section 6 and again under "what validation still does not do". It is checked since 2.4, from the material the document carries. The remaining limit is that nothing is **fetched**, which is what that section says now.
- **`sign-pdf-file`** showed `sealFrom()` as working. It wrote the image path into the placement and nothing read it back, so the caller's artwork was silently replaced by a render of the certificate until 2.4. Flagged where the method is documented.

## Added

| Page | |
|---|---|
| `release-notes` | the 2.4.0 entry |
| `validating-signature` | two new sections: the verified timestamp with `attestedAt()` and `profile`, and evaluated revocation. Sections renumbered |
| `sign-pdf-file` | field locks, `extendArchive()`, `SealLayout`, and the transparent-seal default with its PDF/A-1 consequence |
| `signature-profiles` | extending the archive, and `Contracts\SignatureTransport` as a rebindable seam |
| `installation` | the two new `seal` config keys, checked against `config/a1-pdf-sign.php` |
| `tests` | veraPDF and qpdf as expected tools, `--fail-on-skipped`, and why the `network` group still exists now that the timestamped profiles are gated locally |

Markdown only, under `public/docs/2.x/`, so nothing needs building.

**The seal's colour space is not here.** That is #244, still open, and documenting an unreleased behaviour on the site would be a claim ahead of the release. It gets a 2.5.0 entry when it ships.