### PR TITLE
feat(certificates): read the identity a Brazilian signer is known by

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -35,6 +35,37 @@ Nothing here is configurable, and that is deliberate: the previous behaviour was
 a conformant document going in and a non-conformant one coming out.
 `seal.transparent => false` is still the lever for PDF/A-1.
 
+### Who signed, in the number Brazil knows them by
+
+A validated document now answers the first question anyone asks of one:
+
+```php
+$signer = A1PdfSign::validate($path)->signers()[0];
+
+$signer->icpBrasil?->cpf;                 // '11144477735'
+$signer->icpBrasil?->cnpj;                // the company, for an e-CNPJ
+$signer->icpBrasil?->formattedRegistry(); // '11.222.333/0001-81'
+$signer->name();                          // 'JOAO DA SILVA', without the number
+```
+
+Before this, the CPF was only available glued to the end of `commonName`, so
+every consumer wrote the same `explode(':')`, which is wrong for an e-CNPJ:
+its common name carries the company while the CPF in the extension belongs to
+whoever answers for it.
+
+`A1PdfSign::icpBrasil($pfxPath, $password)` checks the certificate against the
+rules its own specification states, and says which field is wrong before
+anything is signed.
+
+**`conforms()` is not `isTrusted()`.** Every rule checked is decidable from the
+certificate alone, so a self-signed certificate built to satisfy them will
+conform. Whether the chain reaches an ICP-Brasil root is `TrustStore`'s
+question ([0029](docs/decisions/0029-the-identity-a-brazilian-signer-is-known-by.md)).
+
+`Contracts\A1PdfSign` gained `icpBrasil()`, which matters only to someone
+implementing the interface. `Data\Signer` gained `$icpBrasil` and `name()`,
+appended with defaults.
+
 ## From 2.3.1 to 2.4.0
 
 No public class was removed and no signature was narrowed, so an application

--- a/docs/decisions/0029-the-identity-a-brazilian-signer-is-known-by.md
+++ b/docs/decisions/0029-the-identity-a-brazilian-signer-is-known-by.md
@@ -1,0 +1,112 @@
+# 0029: The identity a Brazilian signer is known by
+
+**Status:** implemented.
+
+## Context
+
+This package exists for Brazilian signing, and could not answer the first
+question anyone asks of a signed document: **who signed it.**
+
+In Brazil that answer is a CPF or a CNPJ, and the package handed back this:
+
+```php
+$signer->commonName;   // "JOAO DA SILVA:11144477735"
+```
+
+The number is glued onto the name with a colon, and the structured data, birth
+date, NIS, RG, voter registration, the company and whoever answers for it, lives
+somewhere the package never looked: the `subjectAlternativeName`, as `otherName`
+entries under the 2.16.76.1.3 arc.
+
+**Every consumer was therefore writing `explode(':', $commonName)`**, which
+breaks on the first name containing a colon and gives the wrong answer entirely
+for an e-CNPJ, whose common name carries the company's CNPJ while the CPF in the
+extension belongs to a different person.
+
+### Why it was not read before
+
+`openssl_x509_parse()` cannot do it. It renders the extension as text, and an
+`otherName` under an OID it does not know comes back as
+`othername:<unsupported>`, which is every ICP-Brasil field. There was no reader
+that could go further until [0019](0019-validation-reads-what-it-writes.md) built
+`Validation\Asn1Reader` for the CMS.
+
+## Decision
+
+Read the fields from the DER, model them, and check them.
+
+### Reading
+
+`Certificates\SubjectAlternativeNameReader` walks the certificate to the
+extension (RFC 5280 §4.2.1.6) and returns the `otherName` entries by OID.
+`Certificates\IcpBrasilReader` slices each one by the widths the Receita
+Federal's specification fixes, §2.2.5 for e-CPF and §3.2.5 for e-CNPJ, and
+returns a `Data\IcpBrasilIdentity`.
+
+Three details in that layout are worth stating, because each one is a way to
+read a field wrong:
+
+- **There are no separators.** A field read one character short reads the next
+  one wrong rather than failing, so the widths are the whole grammar.
+- **One field is allowed to be short**, and only the last of its layout: the
+  six positions for the RG's issuing authority "refer to the maximum size, and
+  only the positions needed are used". It is therefore read as the remainder.
+- **"Unavailable" is written as zeros**, which the specification requires. A
+  caller gets null, because eleven zeros and an absent field are the same fact
+  and only one of them is worth handing over.
+
+`Data\Signer` gained `$icpBrasil`, so validating a document answers the question
+directly, and `name()`, which returns the common name without the number stuck
+to it.
+
+### Checking, and the word "structural"
+
+`Validation\IcpBrasilValidator` returns a `Data\IcpBrasilReport`. Every rule it
+applies is one the specification states about the bytes:
+
+| | |
+|---|---|
+| Required fields | three `otherName` entries for an e-CPF, four for an e-CNPJ |
+| Widths | the layout's, with the last field allowed to run short |
+| Alphabet | "only the characters A to Z and 0 to 9 may be used" |
+| Check digits | modulus eleven, for both CPF and CNPJ |
+| Birth date | a real date in `ddmmyyyy` |
+| RG | an issuing authority named for a number that is absent is a fault the specification names |
+| The CPF twice | the common name and the extension both carry it, and nothing in the format makes them agree |
+
+**`conforms()` is not `isTrusted()`, and keeping those apart is the whole risk
+this feature carries.** A self-signed certificate can be built to satisfy every
+rule above, and `Testing\DebugCertificate::icpBrasil()` builds exactly that, for
+the tests. What it cannot do is chain to an ICP-Brasil root, which is the
+question [0016](0016-trust-is-the-applications-policy.md) answers and this one
+does not touch.
+
+The value is upstream of trust rather than instead of it: a certificate that
+fails here will be read wrong by everything downstream, and finding that out
+from the bytes beats finding it out from a rejected filing.
+
+## Consequences
+
+- **`Data\Signer` gained two members**, `$icpBrasil` and `name()`. Appended with
+  a default, so existing construction is unaffected.
+- **`Contracts\A1PdfSign` gained `icpBrasil()`**, a break for anyone
+  implementing the interface, which the Roave check reports.
+- `Pkcs7Reader::signers()` now goes through the PEM rather than through a parse,
+  because the identity is only in the bytes.
+- `Support\NationalRegistry` is new, and bespoke by necessity: neither Laravel
+  nor any dependency here validates a CPF (docs/spec/conventions.md).
+- **It says a number is well formed, never that it exists.** Whether the Receita
+  Federal issued it is a question only the Receita Federal answers, and asking
+  would mean a network call from validation, which nothing here does.
+- `Enums\Asn1Tag` gained `Context3`, the certificate extensions tag.
+
+## Alternatives rejected
+
+| | Why not |
+|---|---|
+| Leave it to the application | Everyone writes the same `explode(':')`, and it is wrong for an e-CNPJ |
+| Parse the common name only | The CPF there is unstructured text, and an e-CNPJ's names the company |
+| Wait for `openssl_x509_parse()` to render otherName | It has not in twenty years, and the DER is right there |
+| Check the number against the Receita Federal | A network call from validation, and an availability dependency on somebody else's service |
+| Call the structural check "validation" without qualification | It would read as trust, and a self-signed certificate passes it |
+| A `CertificatePolicies` check for the A1/A3 arc | Worth having, and it says which kind of certificate rather than whether it is well formed. Left out rather than half done |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -38,6 +38,7 @@ document drifts away from the code it describes.
 | [0026](0026-verification-tools-are-instruments.md) | The verification tools are instruments, and nothing skips |
 | [0027](0027-the-transport-is-a-seam.md) | The transport is a seam, so the profiles can be gated |
 | [0028](0028-the-seal-carries-its-own-colour-space.md) | The seal carries its own colour space, built rather than vendored |
+| [0029](0029-the-identity-a-brazilian-signer-is-known-by.md) | The identity a Brazilian signer is known by |
 
 Nothing is currently proposed and unbuilt. The four that were, 0009, 0010, 0012
 and 0013, all shipped in 2.2, and each carries the measurement that decided its

--- a/src/A1PdfSignManager.php
+++ b/src/A1PdfSignManager.php
@@ -12,9 +12,11 @@ use LSNepomuceno\LaravelA1PdfSign\Certificates\CertificateVault;
 use LSNepomuceno\LaravelA1PdfSign\Certificates\PemCertificateReader;
 use LSNepomuceno\LaravelA1PdfSign\Certificates\ReaderFactory;
 use LSNepomuceno\LaravelA1PdfSign\Contracts\A1PdfSign;
+use LSNepomuceno\LaravelA1PdfSign\Contracts\CertificateReader;
 use LSNepomuceno\LaravelA1PdfSign\Contracts\SignatureValidator;
 use LSNepomuceno\LaravelA1PdfSign\Data\Certificate;
 use LSNepomuceno\LaravelA1PdfSign\Data\EncryptedCertificate;
+use LSNepomuceno\LaravelA1PdfSign\Data\IcpBrasilReport;
 use LSNepomuceno\LaravelA1PdfSign\Data\SignatureReport;
 use LSNepomuceno\LaravelA1PdfSign\Data\SignedPdf;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\FileNotFoundException;
@@ -22,6 +24,8 @@ use LSNepomuceno\LaravelA1PdfSign\Signing\ArchiveExtender;
 use LSNepomuceno\LaravelA1PdfSign\Signing\Incremental\SignatureFieldReader;
 use LSNepomuceno\LaravelA1PdfSign\Signing\PendingSignature;
 use LSNepomuceno\LaravelA1PdfSign\Support\Files;
+use LSNepomuceno\LaravelA1PdfSign\Support\Pem;
+use LSNepomuceno\LaravelA1PdfSign\Validation\IcpBrasilValidator;
 use LSNepomuceno\LaravelA1PdfSign\Validation\TrustStore;
 use SensitiveParameter;
 
@@ -147,6 +151,44 @@ final readonly class A1PdfSignManager implements A1PdfSign
             Files::read($pdfPath),
             basename($pdfPath),
         );
+    }
+
+    public function icpBrasil(
+        string $pfxPath,
+        #[SensitiveParameter]
+        string $password = '',
+    ): IcpBrasilReport {
+        $bytes = Files::read($pfxPath);
+
+        // PEM needs no reader and no password: the identity is a public field
+        // of the certificate, and demanding a private key to read one would be
+        // asking for the wrong thing. Gated on content rather than on the
+        // extension, since PEM ships as .pem and .crt alike.
+        $bundle = Pem::hasCertificate($bytes)
+            ? $bytes
+            : $this->container->make(CertificateReader::class)->read($bytes, $password)->original;
+
+        $certificate = Pem::certificates($bundle)[0] ?? '';
+
+        return $this->container->make(IcpBrasilValidator::class)->validate(
+            $certificate,
+            $this->commonName($certificate),
+        );
+    }
+
+    /**
+     * The subject common name, for the cross-check against the CPF in the
+     * extension.
+     */
+    private function commonName(string $certificate): ?string
+    {
+        $parsed = openssl_x509_parse($certificate, false);
+
+        $name = is_array($parsed) && is_array($parsed['subject'] ?? null)
+            ? ($parsed['subject']['commonName'] ?? null)
+            : null;
+
+        return is_string($name) ? $name : null;
     }
 
     public function tempPath(bool $tempFile = false, string $fileExt = '.pfx'): string

--- a/src/Certificates/IcpBrasilReader.php
+++ b/src/Certificates/IcpBrasilReader.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Certificates;
+
+use LSNepomuceno\LaravelA1PdfSign\Data\IcpBrasilIdentity;
+use LSNepomuceno\LaravelA1PdfSign\Enums\IcpBrasilCertificateType;
+use LSNepomuceno\LaravelA1PdfSign\Enums\IcpBrasilOtherName;
+
+/**
+ * Reads the identity an ICP-Brasil certificate carries.
+ *
+ * The fields are fixed-width strings with no separators, so every value is a
+ * slice at a documented offset. There is one exception, and the specification
+ * makes it: the RG's issuing authority occupies "the positions needed, left to
+ * right" of six, so it is read as whatever remains rather than by its width.
+ *
+ * Nothing here decides whether the certificate is well formed. Slicing is a
+ * different job from judging, and mixing them would leave a caller unable to
+ * read a field this package disapproved of
+ * (docs/decisions/0029-the-identity-a-brazilian-signer-is-known-by.md).
+ *
+ * @internal
+ */
+final readonly class IcpBrasilReader
+{
+    public function __construct(private SubjectAlternativeNameReader $names = new SubjectAlternativeNameReader()) {}
+
+    /**
+     * @param  string  $certificate  PEM or DER.
+     */
+    public function read(string $certificate): IcpBrasilIdentity
+    {
+        $found = $this->names->otherNames($certificate);
+        $fields = $this->fields($found);
+        $type = $this->type($found);
+
+        if ($type === IcpBrasilCertificateType::None) {
+            return IcpBrasilIdentity::none();
+        }
+
+        return new IcpBrasilIdentity(
+            type: $type,
+            cpf: $this->digits($fields['cpf'] ?? null, 11),
+            cnpj: $this->digits($fields['cnpj'] ?? null, 14),
+            birthDate: $this->birthDate($fields['birthDate'] ?? null),
+            socialIdentity: $this->digits($fields['socialIdentity'] ?? null, 11),
+            nationalId: $this->unpadded($fields['nationalId'] ?? null),
+            nationalIdIssuer: $this->text($fields['nationalIdIssuer'] ?? null),
+            socialSecurity: $this->digits($fields['socialSecurity'] ?? null, 12),
+            responsibleName: $this->text($found[IcpBrasilOtherName::ResponsibleName->value] ?? null),
+            voterRegistration: $this->unpadded($fields['voterRegistration'] ?? null),
+            voterZone: $this->unpadded($fields['voterZone'] ?? null),
+            voterSection: $this->unpadded($fields['voterSection'] ?? null),
+            voterMunicipality: $this->text($fields['voterMunicipality'] ?? null),
+            raw: $found,
+        );
+    }
+
+    /**
+     * Every field of every known otherName, sliced by its layout.
+     *
+     * Exposed so the validator can judge what was written rather than what this
+     * class made of it: a CPF the reader rejected as malformed would otherwise
+     * be indistinguishable from one that was absent.
+     *
+     * @param  array<string, string>  $found
+     * @return array<string, string>
+     */
+    public function fields(array $found): array
+    {
+        $fields = [];
+
+        foreach ($found as $oid => $value) {
+            $name = IcpBrasilOtherName::tryFrom($oid);
+            $layout = $name?->layout();
+
+            if ($layout === null) {
+                continue;
+            }
+
+            $offset = 0;
+            $last = array_key_last($layout);
+
+            foreach ($layout as $field => $width) {
+                // The last slice takes the remainder. Only one field is allowed
+                // to be short, and it is always the last one in its layout.
+                $fields[$field] = $field === $last
+                    ? substr($value, $offset)
+                    : substr($value, $offset, $width);
+
+                $offset += $width;
+            }
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Which profile this is, from the fields that only one of them carries.
+     *
+     * A CNPJ decides it: an e-CNPJ carries a CPF too, for whoever answers for
+     * the company, so testing for a CPF first would read every company
+     * certificate as a person.
+     *
+     * @param  array<string, string>  $found
+     */
+    private function type(array $found): IcpBrasilCertificateType
+    {
+        return match (true) {
+            isset($found[IcpBrasilOtherName::CompanyRegistry->value]) => IcpBrasilCertificateType::LegalEntity,
+            isset($found[IcpBrasilOtherName::HolderData->value]) => IcpBrasilCertificateType::Individual,
+            default => IcpBrasilCertificateType::None,
+        };
+    }
+
+    /**
+     * A number of exactly $length digits, or null.
+     *
+     * "Unavailable" is written as every character being zero, which the
+     * specification requires, so it comes back as null rather than as a string
+     * of zeros a caller would have to know to test for.
+     */
+    private function digits(?string $value, int $length): ?string
+    {
+        if ($value === null || preg_match('/^\d{' . $length . '}$/', $value) !== 1) {
+            return null;
+        }
+
+        return trim($value, '0') === '' ? null : $value;
+    }
+
+    /**
+     * A number padded with leading zeros to its maximum width, with the padding
+     * removed. Null when nothing was written.
+     */
+    private function unpadded(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = ltrim(trim($value), '0');
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    private function text(?string $value): ?string
+    {
+        $trimmed = $value === null ? '' : trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    /**
+     * `ddmmyyyy`, as the layout fixes it, rendered the way it is written.
+     *
+     * Kept as a string rather than a date: an unparseable one still tells a
+     * caller what the certificate said, and a null date does not.
+     */
+    private function birthDate(?string $value): ?string
+    {
+        if ($value === null || preg_match('/^(\d{2})(\d{2})(\d{4})$/', $value, $parts) !== 1) {
+            return null;
+        }
+
+        return checkdate((int) $parts[2], (int) $parts[1], (int) $parts[3])
+            ? "{$parts[1]}/{$parts[2]}/{$parts[3]}"
+            : null;
+    }
+}

--- a/src/Certificates/SubjectAlternativeNameReader.php
+++ b/src/Certificates/SubjectAlternativeNameReader.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Certificates;
+
+use LSNepomuceno\LaravelA1PdfSign\Enums\Asn1Tag;
+use LSNepomuceno\LaravelA1PdfSign\Support\Pem;
+use LSNepomuceno\LaravelA1PdfSign\Validation\Asn1Node;
+use LSNepomuceno\LaravelA1PdfSign\Validation\Asn1Reader;
+
+/**
+ * The `otherName` entries in a certificate's subjectAlternativeName.
+ *
+ * **`openssl_x509_parse()` cannot answer this.** It renders the extension as
+ * text, and an `otherName` under an OID it does not know comes back as
+ * `othername:<unsupported>`, which is where every ICP-Brasil field lives. So
+ * the extension is walked here, in the DER, with the reader
+ * [0019](../../docs/decisions/0019-validation-reads-what-it-writes.md) built
+ * for the CMS.
+ *
+ * RFC 5280 §4.2.1.6:
+ *
+ * ```
+ * GeneralName ::= CHOICE { otherName [0] OtherName, ... }
+ * OtherName   ::= SEQUENCE { type-id OBJECT IDENTIFIER, value [0] EXPLICIT ANY }
+ * ```
+ *
+ * @internal
+ */
+final readonly class SubjectAlternativeNameReader
+{
+    /** RFC 5280 §4.2.1.6. */
+    private const string EXTENSION_OID = '2.5.29.17';
+
+    public function __construct(private Asn1Reader $reader = new Asn1Reader()) {}
+
+    /**
+     * Every otherName the certificate carries, as OID to written value.
+     *
+     * @return array<string, string>
+     */
+    public function otherNames(string $certificate): array
+    {
+        // A PEM bundle carries the private key too, and often first, so the
+        // certificate is taken by kind rather than by position. Handing the
+        // whole bundle to a DER decoder reads the key and finds no extensions,
+        // which looks exactly like a certificate that has none.
+        $der = Pem::hasCertificate($certificate)
+            ? Pem::toDer(Pem::certificates($certificate)[0] ?? '')
+            : $certificate;
+
+        if ($der === null || $der === '') {
+            return [];
+        }
+
+        $names = $this->generalNames($der);
+
+        if ($names === null) {
+            return [];
+        }
+
+        $found = [];
+
+        foreach ($this->reader->childrenOf($der, $names) as $entry) {
+            // Context tag [0], constructed: the otherName arm of the CHOICE.
+            // Every other arm is a name shape this does not read.
+            if (! $entry->is(Asn1Tag::Context0)) {
+                continue;
+            }
+
+            $parts = $this->reader->childrenOf($der, $entry);
+            $oid = $this->reader->oid($der, $parts[0] ?? null);
+
+            if ($oid === null || ! isset($parts[1])) {
+                continue;
+            }
+
+            $value = $this->value($der, $parts[1]);
+
+            if ($value !== null) {
+                $found[$oid] = $value;
+            }
+        }
+
+        return $found;
+    }
+
+    /**
+     * The GeneralNames sequence inside the extension, or null when the
+     * certificate carries no subjectAlternativeName.
+     */
+    private function generalNames(string $der): ?Asn1Node
+    {
+        $certificate = $this->reader->at($der);
+
+        if ($certificate === null) {
+            return null;
+        }
+
+        // Certificate ::= SEQUENCE { tbsCertificate, ... }, and the extensions
+        // are tbsCertificate's [3], which is the last field and optional.
+        $tbs = $this->reader->path($der, $certificate, [0]);
+
+        if ($tbs === null) {
+            return null;
+        }
+
+        foreach ($this->reader->childrenOf($der, $tbs) as $field) {
+            if (! $field->is(Asn1Tag::Context3)) {
+                continue;
+            }
+
+            return $this->extensionValue($der, $field);
+        }
+
+        return null;
+    }
+
+    /**
+     * Walks the extension list for the subjectAlternativeName and opens the
+     * OCTET STRING that wraps its value.
+     */
+    private function extensionValue(string $der, Asn1Node $extensions): ?Asn1Node
+    {
+        $list = $this->reader->path($der, $extensions, [0]);
+
+        if ($list === null) {
+            return null;
+        }
+
+        foreach ($this->reader->childrenOf($der, $list) as $extension) {
+            $parts = $this->reader->childrenOf($der, $extension);
+
+            if ($this->reader->oid($der, $parts[0] ?? null) !== self::EXTENSION_OID) {
+                continue;
+            }
+
+            // The critical flag is optional and shifts the value along by one,
+            // so the wrapper is the last child rather than the second.
+            $wrapper = end($parts);
+
+            if ($wrapper === false || ! $wrapper->is(Asn1Tag::OctetString)) {
+                return null;
+            }
+
+            return $this->reader->at($der, $wrapper->contentOffset());
+        }
+
+        return null;
+    }
+
+    /**
+     * The string inside `value [0] EXPLICIT ANY`.
+     *
+     * The specification says OCTET STRING, and real certificates also use
+     * UTF8String, PrintableString and IA5String. The tag is not the point: the
+     * content is a fixed-width string either way, so whatever primitive the
+     * wrapper holds is read as one.
+     */
+    private function value(string $der, Asn1Node $wrapper): ?string
+    {
+        $inner = $this->reader->at($der, $wrapper->contentOffset());
+
+        if ($inner === null || $inner->end() > $wrapper->end() || $inner->isConstructed()) {
+            return null;
+        }
+
+        return $inner->content($der);
+    }
+}

--- a/src/Contracts/A1PdfSign.php
+++ b/src/Contracts/A1PdfSign.php
@@ -133,6 +133,32 @@ interface A1PdfSign
     public function extendArchive(string $pdfPath): SignedPdf;
 
     /**
+     * Reads the ICP-Brasil identity out of a certificate and checks it against
+     * the rules the specification states about its own bytes.
+     *
+     * **Structural only, and never a substitute for trust.** Every rule checked
+     * is decidable from the certificate alone, so a self-signed certificate
+     * built to satisfy them all will conform. Whether the chain reaches an
+     * ICP-Brasil root is a different question, answered by
+     * `Validation\TrustStore`.
+     *
+     * Useful before signing rather than after being rejected: it says which
+     * field is wrong, from the file, instead of leaving that to whatever
+     * receives the document.
+     *
+     * @param  string  $pfxPath  A PKCS#12 file, or a PEM certificate.
+     *
+     * @throws \Throwable
+     *
+     * @see docs/decisions/0029-the-identity-a-brazilian-signer-is-known-by.md
+     */
+    public function icpBrasil(
+        string $pfxPath,
+        #[\SensitiveParameter]
+        string $password = '',
+    ): \LSNepomuceno\LaravelA1PdfSign\Data\IcpBrasilReport;
+
+    /**
      * Starts a fluent signature. Nothing happens until sign() is called.
      */
     public function newSignature(): \LSNepomuceno\LaravelA1PdfSign\Signing\PendingSignature;

--- a/src/Data/IcpBrasilIdentity.php
+++ b/src/Data/IcpBrasilIdentity.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Data;
+
+use LSNepomuceno\LaravelA1PdfSign\Enums\IcpBrasilCertificateType;
+
+/**
+ * Who an ICP-Brasil certificate says its holder is.
+ *
+ * Every value here is **what the certificate carries**, parsed rather than
+ * verified against any registry. A CPF that passes its check digits is a
+ * well-formed CPF, not a CPF that exists, and neither is evidence that the
+ * person it names controls the key: that is the trust question, answered by
+ * `Validation\TrustStore` and by nothing here
+ * (docs/decisions/0029-the-identity-a-brazilian-signer-is-known-by.md).
+ *
+ * A field the certificate fills with zeros, which the specification requires
+ * when a number is unavailable, is reported as null. "Absent" and "eleven
+ * zeros" are the same fact and only one of them is worth handing to a caller.
+ */
+final readonly class IcpBrasilIdentity extends BaseData
+{
+    /**
+     * @param  ?string  $cpf  The holder's, for an e-CPF; the responsible
+     *                        person's, for an e-CNPJ. Eleven digits, unpunctuated.
+     * @param  ?string  $cnpj  Fourteen digits, unpunctuated. Null for an e-CPF.
+     * @param  ?string  $birthDate  The holder's, as `dd/mm/yyyy`, or null when
+     *                              the field is not a date.
+     * @param  ?string  $socialIdentity  NIS, which is PIS, PASEP or CI.
+     * @param  ?string  $nationalId  RG, with the leading zeros the layout pads
+     *                               it to removed.
+     * @param  ?string  $nationalIdIssuer  The RG's issuing authority and state,
+     *                                     as written.
+     * @param  ?string  $socialSecurity  CEI, the INSS specific registry.
+     * @param  ?string  $responsibleName  For an e-CNPJ, who answers for the
+     *                                    company. Null for an e-CPF.
+     * @param  array<string, string>  $raw  Every otherName found, by OID, as it
+     *                                      was written. The escape hatch for a
+     *                                      field this package does not model.
+     */
+    public function __construct(
+        public IcpBrasilCertificateType $type,
+        public ?string $cpf = null,
+        public ?string $cnpj = null,
+        public ?string $birthDate = null,
+        public ?string $socialIdentity = null,
+        public ?string $nationalId = null,
+        public ?string $nationalIdIssuer = null,
+        public ?string $socialSecurity = null,
+        public ?string $responsibleName = null,
+        public ?string $voterRegistration = null,
+        public ?string $voterZone = null,
+        public ?string $voterSection = null,
+        public ?string $voterMunicipality = null,
+        public array $raw = [],
+    ) {}
+
+    /**
+     * Nothing ICP-Brasil was found, which is the ordinary case for a
+     * certificate from anywhere else.
+     */
+    public static function none(): self
+    {
+        return new self(IcpBrasilCertificateType::None);
+    }
+
+    /**
+     * The document that identifies the holder: the company's CNPJ when there is
+     * one, and the person's CPF otherwise.
+     *
+     * An e-CNPJ carries both, and they name different parties: the CNPJ is the
+     * holder, the CPF is whoever answers for it.
+     */
+    public function registry(): ?string
+    {
+        return $this->cnpj ?? $this->cpf;
+    }
+
+    /**
+     * The registry punctuated the way it is written in Brazil.
+     */
+    public function formattedRegistry(): ?string
+    {
+        return match (true) {
+            $this->cnpj !== null => preg_replace('/^(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})$/', '$1.$2.$3/$4-$5', $this->cnpj),
+            $this->cpf !== null => preg_replace('/^(\d{3})(\d{3})(\d{3})(\d{2})$/', '$1.$2.$3-$4', $this->cpf),
+            default => null,
+        };
+    }
+}

--- a/src/Data/IcpBrasilReport.php
+++ b/src/Data/IcpBrasilReport.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Data;
+
+use LSNepomuceno\LaravelA1PdfSign\Enums\IcpBrasilFinding;
+
+/**
+ * What a structural check of an ICP-Brasil certificate found.
+ *
+ * **`conforms()` is not `isTrusted()`, and confusing the two is the whole risk
+ * this class carries.** Every rule behind it is decidable from the certificate
+ * alone, so a self-signed certificate built to satisfy them all conforms. What
+ * it does not do is chain to an ICP-Brasil root, which is the question
+ * `Validation\TrustStore` answers and this one deliberately does not
+ * (docs/decisions/0029-the-identity-a-brazilian-signer-is-known-by.md).
+ *
+ * Useful before trust, not instead of it: a certificate that fails here will
+ * not be read correctly by anything, and finding that out from the bytes beats
+ * finding it out from a rejected filing.
+ */
+final readonly class IcpBrasilReport extends BaseData
+{
+    /**
+     * @param  list<array{finding: IcpBrasilFinding, field: string, detail: ?string}>  $findings
+     */
+    public function __construct(
+        public IcpBrasilIdentity $identity,
+        public array $findings = [],
+    ) {}
+
+    /**
+     * Whether the certificate satisfies every structural rule checked.
+     *
+     * A certificate that is not ICP-Brasil at all does not conform, since there
+     * was nothing to conform to. `identity->type` is what separates that from a
+     * malformed one.
+     */
+    public function conforms(): bool
+    {
+        return $this->identity->type->isIcpBrasil() && $this->findings === [];
+    }
+
+    /**
+     * Whether anything was found of this kind.
+     */
+    public function has(IcpBrasilFinding $finding): bool
+    {
+        foreach ($this->findings as $entry) {
+            if ($entry['finding'] === $finding) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * One line per finding, for a log or a message to whoever sent the file.
+     *
+     * @return list<string>
+     */
+    public function messages(): array
+    {
+        return array_map(
+            static fn(array $entry): string => $entry['detail'] === null
+                ? "{$entry['field']}: {$entry['finding']->description()}"
+                : "{$entry['field']}: {$entry['finding']->description()} ({$entry['detail']})",
+            $this->findings,
+        );
+    }
+}

--- a/src/Data/Signer.php
+++ b/src/Data/Signer.php
@@ -2,6 +2,8 @@
 
 namespace LSNepomuceno\LaravelA1PdfSign\Data;
 
+use LSNepomuceno\LaravelA1PdfSign\Certificates\IcpBrasilReader;
+
 /**
  * Who signed, as read from the certificate embedded in the signature.
  */
@@ -10,6 +12,12 @@ final readonly class Signer extends BaseData
     /**
      * @param  array<string, mixed>  $subject
      * @param  array<string, mixed>  $issuer
+     * @param  ?IcpBrasilIdentity  $icpBrasil  Who this is under ICP-Brasil, when
+     *                                         the certificate was read from
+     *                                         bytes rather than only from a
+     *                                         parse. Null means "not looked
+     *                                         for"; a type of `None` means
+     *                                         "looked for and not there".
      */
     public function __construct(
         public ?string $commonName,
@@ -21,12 +29,34 @@ final readonly class Signer extends BaseData
         public ?int $validTo,
         public array $subject = [],
         public array $issuer = [],
+        public ?IcpBrasilIdentity $icpBrasil = null,
     ) {}
 
     /**
-     * @param  array<string, mixed>  $parsed  Output of openssl_x509_parse() with long names.
+     * The name without the CPF an ICP-Brasil common name carries after a colon.
+     *
+     * `JOAO DA SILVA:01672780838` is the format the Receita Federal fixes for
+     * an e-CPF, and a caller wanting to show a name should not have to know
+     * that. The whole value is returned unchanged for any other certificate.
      */
-    public static function fromParsedCertificate(array $parsed): self
+    public function name(): ?string
+    {
+        if ($this->commonName === null) {
+            return null;
+        }
+
+        return (string) preg_replace('/:\d{11,14}$/', '', $this->commonName);
+    }
+
+    /**
+     * @param  array<string, mixed>  $parsed  Output of openssl_x509_parse() with long names.
+     * @param  ?string  $pem  The certificate the parse came from, when the
+     *                        caller still has it. Without it the ICP-Brasil
+     *                        identity cannot be read, because
+     *                        openssl_x509_parse() renders those fields as
+     *                        `othername:<unsupported>`.
+     */
+    public static function fromParsedCertificate(array $parsed, ?string $pem = null): self
     {
         /** @var array<string, mixed> $subject */
         $subject = is_array($parsed['subject'] ?? null) ? $parsed['subject'] : [];
@@ -43,6 +73,7 @@ final readonly class Signer extends BaseData
             validTo: is_int($parsed['validTo_time_t'] ?? null) ? $parsed['validTo_time_t'] : null,
             subject: $subject,
             issuer: $issuer,
+            icpBrasil: $pem === null ? null : new IcpBrasilReader()->read($pem),
         );
     }
 

--- a/src/Enums/Asn1Tag.php
+++ b/src/Enums/Asn1Tag.php
@@ -39,4 +39,7 @@ enum Asn1Tag: int
 
     /** Context-specific [1], constructed: unsignedAttrs in a SignerInfo. */
     case Context1 = 0xA1;
+
+    /** Context-specific [3], constructed: the extensions of a certificate. */
+    case Context3 = 0xA3;
 }

--- a/src/Enums/IcpBrasilCertificateType.php
+++ b/src/Enums/IcpBrasilCertificateType.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Enums;
+
+/**
+ * Which ICP-Brasil certificate this is, decided by the fields it carries.
+ *
+ * Read from the subjectAlternativeName rather than from the organizational
+ * unit: the OU text varies by certification authority, and a document number
+ * either is there or is not.
+ */
+enum IcpBrasilCertificateType: string
+{
+    /** e-CPF: a natural person, identified by CPF. */
+    case Individual = 'individual';
+
+    /** e-CNPJ: a company, identified by CNPJ, with a responsible person. */
+    case LegalEntity = 'legal-entity';
+
+    /**
+     * Not an ICP-Brasil certificate, or not one of these two profiles.
+     *
+     * The third answer, on the same reasoning as
+     * [0016](../../docs/decisions/0016-trust-is-the-applications-policy.md):
+     * a self-signed certificate carrying no ICP-Brasil field is not a malformed
+     * ICP-Brasil certificate, it is a certificate that never claimed to be one.
+     */
+    case None = 'none';
+
+    public function isIcpBrasil(): bool
+    {
+        return $this !== self::None;
+    }
+}

--- a/src/Enums/IcpBrasilFinding.php
+++ b/src/Enums/IcpBrasilFinding.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Enums;
+
+/**
+ * What a structural check of an ICP-Brasil certificate can find wrong.
+ *
+ * **Structural means decidable from the certificate alone.** Every case here is
+ * a rule the specification states about the bytes: a field that must be
+ * present, a width, an alphabet, a check digit, two places that must agree.
+ *
+ * None of it says the certificate is trustworthy. A self-signed certificate can
+ * be built to satisfy every one of these, which is exactly why the trust
+ * question stays where it was
+ * ([0016](../../docs/decisions/0016-trust-is-the-applications-policy.md)).
+ */
+enum IcpBrasilFinding: string
+{
+    case MissingRequiredField = 'missing-required-field';
+
+    case UnexpectedFieldLength = 'unexpected-field-length';
+
+    case IllegalCharacter = 'illegal-character';
+
+    case InvalidCpfCheckDigits = 'invalid-cpf-check-digits';
+
+    case InvalidCnpjCheckDigits = 'invalid-cnpj-check-digits';
+
+    case ImplausibleBirthDate = 'implausible-birth-date';
+
+    case CommonNameDisagreesWithCpf = 'common-name-disagrees-with-cpf';
+
+    case IssuerNamedWithoutNationalId = 'issuer-named-without-national-id';
+
+    /**
+     * What the rule says, for a message a caller can show without writing one.
+     */
+    public function description(): string
+    {
+        return match ($this) {
+            self::MissingRequiredField => 'a field the profile requires is absent from the subject alternative name',
+            self::UnexpectedFieldLength => 'the field is not the width its layout fixes',
+            self::IllegalCharacter => 'only A to Z and 0 to 9 are allowed in an otherName field',
+            self::InvalidCpfCheckDigits => 'the CPF does not satisfy its own check digits',
+            self::InvalidCnpjCheckDigits => 'the CNPJ does not satisfy its own check digits',
+            self::ImplausibleBirthDate => 'the birth date is not a date in the ddmmyyyy form the layout fixes',
+            self::CommonNameDisagreesWithCpf => 'the CPF in the common name is not the CPF in the subject alternative name',
+            self::IssuerNamedWithoutNationalId => 'an issuing authority is named for a national identity number that is absent',
+        };
+    }
+}

--- a/src/Enums/IcpBrasilOtherName.php
+++ b/src/Enums/IcpBrasilOtherName.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Enums;
+
+/**
+ * The `otherName` fields an ICP-Brasil certificate carries in its
+ * subjectAlternativeName, under the 2.16.76.1.3 arc.
+ *
+ * The identity a Brazilian signer is known by does not live in the subject. The
+ * CPF is glued onto the end of the common name as `NAME:00000000000`, and
+ * everything structured (the registry numbers, the birth date, the company)
+ * lives here, in fixed-width strings inside an OCTET STRING.
+ *
+ * Layouts are from the Receita Federal's certificate specification, §2.2.5 for
+ * e-CPF and §3.2.5 for e-CNPJ, which restates DOC-ICP-04.
+ *
+ * See docs/decisions/0029-the-identity-a-brazilian-signer-is-known-by.md.
+ */
+enum IcpBrasilOtherName: string
+{
+    /** e-CPF, mandatory: birth date, CPF, NIS, RG and the RG's issuer. */
+    case HolderData = '2.16.76.1.3.1';
+
+    /** e-CNPJ, mandatory: the name of the person responsible for the company. */
+    case ResponsibleName = '2.16.76.1.3.2';
+
+    /** e-CNPJ, mandatory: the company's CNPJ. */
+    case CompanyRegistry = '2.16.76.1.3.3';
+
+    /** e-CNPJ, mandatory: the same layout as HolderData, for that person. */
+    case ResponsibleData = '2.16.76.1.3.4';
+
+    /** e-CPF, mandatory: voter registration, its zone, section and municipality. */
+    case VoterRegistration = '2.16.76.1.3.5';
+
+    /** e-CPF, mandatory: the holder's INSS specific registry. */
+    case HolderSocialSecurity = '2.16.76.1.3.6';
+
+    /** e-CNPJ, mandatory: the company's INSS specific registry. */
+    case CompanySocialSecurity = '2.16.76.1.3.7';
+
+    /**
+     * The widths this field is made of, in order, or null when it is free text.
+     *
+     * Fixed width is the whole grammar: there are no separators, so a field
+     * read one character short reads the next one wrong rather than failing.
+     *
+     * @return array<string, int>|null
+     */
+    public function layout(): ?array
+    {
+        return match ($this) {
+            self::HolderData, self::ResponsibleData => [
+                'birthDate' => 8,
+                'cpf' => 11,
+                'socialIdentity' => 11,
+                'nationalId' => 15,
+                // "The 6 positions for the issuer and state refer to the maximum
+                // size, and only the positions needed are used, left to right",
+                // so this one is short in real certificates and is read as the
+                // remainder rather than by its width.
+                'nationalIdIssuer' => 6,
+            ],
+            self::VoterRegistration => [
+                'voterRegistration' => 12,
+                'voterZone' => 3,
+                'voterSection' => 4,
+                'voterMunicipality' => 22,
+            ],
+            self::CompanyRegistry => ['cnpj' => 14],
+            self::HolderSocialSecurity, self::CompanySocialSecurity => ['socialSecurity' => 12],
+            self::ResponsibleName => null,
+        };
+    }
+
+    /**
+     * Whether an e-CPF is required to carry this field.
+     */
+    public function requiredForIndividual(): bool
+    {
+        return in_array($this, [self::HolderData, self::VoterRegistration, self::HolderSocialSecurity], true);
+    }
+
+    /**
+     * Whether an e-CNPJ is required to carry this field.
+     */
+    public function requiredForLegalEntity(): bool
+    {
+        return in_array(
+            $this,
+            [self::ResponsibleName, self::CompanyRegistry, self::ResponsibleData, self::CompanySocialSecurity],
+            true,
+        );
+    }
+}

--- a/src/Facades/A1PdfSign.php
+++ b/src/Facades/A1PdfSign.php
@@ -14,6 +14,7 @@ use LSNepomuceno\LaravelA1PdfSign\Contracts\A1PdfSign as A1PdfSignContract;
  * @method static \LSNepomuceno\LaravelA1PdfSign\Data\SignatureReport validate(string $pdfPath, ?\LSNepomuceno\LaravelA1PdfSign\Validation\TrustStore $trust = null)
  * @method static list<\LSNepomuceno\LaravelA1PdfSign\Data\SignatureField> signatureFields(string $pdfPath)
  * @method static \LSNepomuceno\LaravelA1PdfSign\Data\SignedPdf extendArchive(string $pdfPath)
+ * @method static \LSNepomuceno\LaravelA1PdfSign\Data\IcpBrasilReport icpBrasil(string $pfxPath, string $password = '')
  * @method static \LSNepomuceno\LaravelA1PdfSign\Signing\PendingSignature newSignature()
  * @method static string tempPath(bool $tempFile = false, string $fileExt = '.pfx')
  *

--- a/src/Support/NationalRegistry.php
+++ b/src/Support/NationalRegistry.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Support;
+
+/**
+ * The check digits a CPF and a CNPJ carry.
+ *
+ * Laravel has no rule for either, and neither does any dependency this package
+ * already has, so it is written here rather than pulled in
+ * (docs/spec/conventions.md). It is one algorithm, modulus eleven over
+ * positional weights, applied twice with different weights.
+ *
+ * **This says a number is well formed, never that it exists.** A CPF that
+ * passes has the internal consistency the digits promise; whether the Receita
+ * Federal ever issued it is a question only the Receita Federal answers.
+ *
+ * @internal
+ */
+final readonly class NationalRegistry
+{
+    /**
+     * Whether eleven digits satisfy a CPF's two check digits.
+     */
+    public function isCpf(string $digits): bool
+    {
+        if (preg_match('/^\d{11}$/', $digits) !== 1) {
+            return false;
+        }
+
+        // 00000000000, 11111111111 and the rest satisfy the arithmetic and are
+        // rejected everywhere in Brazil, so the arithmetic is not the whole rule.
+        if (preg_match('/^(\d)\1{10}$/', $digits) === 1) {
+            return false;
+        }
+
+        // Weights count down from the length of the part being checked plus one.
+        return $this->digit($digits, range(10, 2)) === (int) $digits[9]
+            && $this->digit($digits, range(11, 2)) === (int) $digits[10];
+    }
+
+    /**
+     * Whether fourteen digits satisfy a CNPJ's two check digits.
+     */
+    public function isCnpj(string $digits): bool
+    {
+        if (preg_match('/^\d{14}$/', $digits) !== 1) {
+            return false;
+        }
+
+        if (preg_match('/^(\d)\1{13}$/', $digits) === 1) {
+            return false;
+        }
+
+        // Unlike the CPF's, these weights cycle from 2 to 9 rather than counting
+        // down, which is the only difference between the two.
+        $first = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+
+        return $this->digit($digits, $first) === (int) $digits[12]
+            && $this->digit($digits, [6, ...$first]) === (int) $digits[13];
+    }
+
+    /**
+     * One check digit: the weighted sum, modulus eleven, with the two remainders
+     * below two both meaning zero.
+     *
+     * @param  list<int>  $weights  One per digit read, from the left.
+     */
+    private function digit(string $digits, array $weights): int
+    {
+        $sum = 0;
+
+        foreach ($weights as $position => $weight) {
+            $sum += (int) $digits[$position] * $weight;
+        }
+
+        $remainder = $sum % 11;
+
+        return $remainder < 2 ? 0 : 11 - $remainder;
+    }
+}

--- a/src/Testing/DebugCertificate.php
+++ b/src/Testing/DebugCertificate.php
@@ -2,7 +2,10 @@
 
 namespace LSNepomuceno\LaravelA1PdfSign\Testing;
 
+use LSNepomuceno\LaravelA1PdfSign\Enums\IcpBrasilCertificateType;
+use LSNepomuceno\LaravelA1PdfSign\Enums\IcpBrasilOtherName;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\CertificateOutputNotFoundException;
+use LSNepomuceno\LaravelA1PdfSign\Support\TemporaryFile;
 use OpenSSLAsymmetricKey;
 use OpenSSLCertificate;
 use OpenSSLCertificateSigningRequest;
@@ -134,6 +137,137 @@ final class DebugCertificate
         /** @var string $pfx */
         /** @var string $rootPem */
         return [$pfx, self::PASSWORD, $rootPem];
+    }
+
+    /**
+     * A certificate shaped like an ICP-Brasil one, for reading the fields back.
+     *
+     * **It is self-signed, and that is the point of saying so here.** It
+     * carries the `otherName` fields the Receita Federal's layout fixes, so a
+     * parser can be tested against something with the right shape, and it
+     * chains to nothing: no trust store will accept it, and none should
+     * (docs/decisions/0029-the-identity-a-brazilian-signer-is-known-by.md).
+     *
+     * @param  array<string, string>  $otherNames  OID to written value,
+     *                                             replacing the defaults. Pass a
+     *                                             malformed one to exercise a
+     *                                             finding.
+     * @return array{0: string, 1: string} The PFX bytes and its password.
+     *
+     * @throws CertificateOutputNotFoundException
+     */
+    public static function icpBrasil(
+        IcpBrasilCertificateType $type = IcpBrasilCertificateType::Individual,
+        array $otherNames = [],
+        string $commonName = 'JOAO DA SILVA:11144477735',
+        int $daysValid = 600,
+    ): array {
+        // An empty override leaves the field out entirely, which is how a test
+        // expresses "this certificate does not carry it". An empty otherName is
+        // a different thing, and not the one anybody wants to check.
+        $fields = array_filter([...self::icpBrasilFields($type), ...$otherNames], static fn(string $value): bool => $value !== '');
+
+        $key = self::key();
+
+        $x509 = TemporaryFile::with(
+            sys_get_temp_dir(),
+            '.cnf',
+            self::openSslConfiguration($fields),
+            static function (TemporaryFile $configuration) use ($key, $commonName, $daysValid): OpenSSLCertificate {
+                $options = ['digest_alg' => 'sha256', 'config' => $configuration->path, 'x509_extensions' => 'icp'];
+
+                // openssl_csr_new takes the key by reference, so it is handed a
+                // copy: the analyser widens anything that function touches to
+                // mixed, and the signing call below needs the type intact.
+                $request = $key;
+                $csr = openssl_csr_new(['commonName' => $commonName, 'countryName' => 'BR'], $request, $options);
+
+                if (! $csr instanceof OpenSSLCertificateSigningRequest) {
+                    throw new RuntimeException('Unable to generate the ICP-Brasil test CSR: ' . openssl_error_string());
+                }
+
+                $signed = openssl_csr_sign($csr, null, $key, $daysValid, $options);
+
+                if ($signed === false) {
+                    throw new RuntimeException('Unable to sign the ICP-Brasil test certificate: ' . openssl_error_string());
+                }
+
+                return $signed;
+            },
+        );
+
+        $pfx = '';
+
+        if (! openssl_pkcs12_export($x509, $pfx, $key, self::PASSWORD)) {
+            throw new CertificateOutputNotFoundException();
+        }
+
+        /** @var string $pfx */
+        return [$pfx, self::PASSWORD];
+    }
+
+    /**
+     * The fields each profile is required to carry, filled with values that
+     * satisfy the check digits.
+     *
+     * @return array<string, string>
+     */
+    private static function icpBrasilFields(IcpBrasilCertificateType $type): array
+    {
+        // 8 birth + 11 CPF + 11 NIS + 15 RG + 6 issuer, and "unavailable" is
+        // written as zeros rather than left out.
+        $holder = '11081985' . '11144477735' . '12345678901' . '000000012345678' . 'SSPSP';
+
+        if ($type === IcpBrasilCertificateType::LegalEntity) {
+            return [
+                IcpBrasilOtherName::ResponsibleName->value => 'JOAO DA SILVA',
+                IcpBrasilOtherName::CompanyRegistry->value => '11222333000181',
+                IcpBrasilOtherName::ResponsibleData->value => $holder,
+                IcpBrasilOtherName::CompanySocialSecurity->value => '000000000000',
+            ];
+        }
+
+        return [
+            IcpBrasilOtherName::HolderData->value => $holder,
+            // 12 registration + 3 zone + 4 section + 22 municipality.
+            IcpBrasilOtherName::VoterRegistration->value => '465555610469' . '001' . '0477' . 'SAOPAULOSP',
+            IcpBrasilOtherName::HolderSocialSecurity->value => '000000000000',
+        ];
+    }
+
+    /**
+     * An openssl configuration carrying the fields as `otherName` entries.
+     *
+     * OCTET STRING because the specification says so, in as many words: "the
+     * information in each OtherName field shall be stored as an ASN.1 OCTET
+     * STRING character string". Real certificates also use UTF8String, and the
+     * reader accepts both, so this generates the one the rule names.
+     *
+     * @param  array<string, string>  $fields
+     */
+    private static function openSslConfiguration(array $fields): string
+    {
+        $entries = [];
+        $index = 0;
+
+        foreach ($fields as $oid => $value) {
+            $index++;
+            $entries[] = "otherName.{$index} = {$oid};FORMAT:ASCII,OCTETSTRING:{$value}";
+        }
+
+        return implode("\n", [
+            '[req]',
+            'distinguished_name = dn',
+            '[dn]',
+            '[icp]',
+            'subjectAltName = @alt',
+            'basicConstraints = CA:FALSE',
+            'keyUsage = critical, digitalSignature, nonRepudiation, keyEncipherment',
+            '[alt]',
+            ...$entries,
+            'email = signer@example.test',
+            '',
+        ]);
     }
 
     /**

--- a/src/Validation/IcpBrasilValidator.php
+++ b/src/Validation/IcpBrasilValidator.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Validation;
+
+use LSNepomuceno\LaravelA1PdfSign\Certificates\IcpBrasilReader;
+use LSNepomuceno\LaravelA1PdfSign\Certificates\SubjectAlternativeNameReader;
+use LSNepomuceno\LaravelA1PdfSign\Data\IcpBrasilReport;
+use LSNepomuceno\LaravelA1PdfSign\Enums\IcpBrasilCertificateType;
+use LSNepomuceno\LaravelA1PdfSign\Enums\IcpBrasilFinding;
+use LSNepomuceno\LaravelA1PdfSign\Enums\IcpBrasilOtherName;
+use LSNepomuceno\LaravelA1PdfSign\Support\NationalRegistry;
+
+/**
+ * Checks an ICP-Brasil certificate against the rules its own specification
+ * states about its bytes.
+ *
+ * **Structural, and that word is doing real work.** Everything checked here is
+ * decidable from the certificate alone: a required field is present, a width is
+ * the width the layout fixes, the alphabet is the one allowed, the check digits
+ * hold, and the CPF in the common name is the CPF in the extension. None of it
+ * is evidence that the certificate is genuine, and a self-signed one can be
+ * built to satisfy every rule.
+ *
+ * What it is good for is the thing that goes wrong in practice: a file arrives,
+ * something downstream rejects it, and nobody can say which field was wrong.
+ * This says which field, from the certificate, before anything is signed
+ * (docs/decisions/0029-the-identity-a-brazilian-signer-is-known-by.md).
+ */
+final readonly class IcpBrasilValidator
+{
+    /** Receita Federal §3.2.5: only A to Z and 0 to 9 in an otherName field. */
+    private const string ALPHABET = '/^[A-Z0-9]*$/';
+
+    public function __construct(
+        private IcpBrasilReader $reader = new IcpBrasilReader(),
+        private SubjectAlternativeNameReader $names = new SubjectAlternativeNameReader(),
+        private NationalRegistry $registry = new NationalRegistry(),
+    ) {}
+
+    /**
+     * @param  string  $certificate  PEM or DER.
+     * @param  ?string  $commonName  The subject's CN, when the caller has it
+     *                               parsed. Without it the cross-check between
+     *                               the two places a CPF appears cannot run,
+     *                               which is reported by not running rather
+     *                               than by failing.
+     */
+    public function validate(string $certificate, ?string $commonName = null): IcpBrasilReport
+    {
+        $found = $this->names->otherNames($certificate);
+        $identity = $this->reader->read($certificate);
+
+        if (! $identity->type->isIcpBrasil()) {
+            return new IcpBrasilReport($identity);
+        }
+
+        $fields = $this->reader->fields($found);
+
+        return new IcpBrasilReport($identity, [
+            ...$this->requiredFields($identity->type, $found),
+            ...$this->alphabet($found),
+            ...$this->widths($found),
+            ...$this->checkDigits($fields),
+            ...$this->birthDate($fields),
+            ...$this->nationalId($fields),
+            ...$this->commonName($commonName, $fields),
+        ]);
+    }
+
+    /**
+     * @param  array<string, string>  $found
+     * @return list<array{finding: IcpBrasilFinding, field: string, detail: ?string}>
+     */
+    private function requiredFields(IcpBrasilCertificateType $type, array $found): array
+    {
+        $findings = [];
+
+        foreach (IcpBrasilOtherName::cases() as $name) {
+            $required = $type === IcpBrasilCertificateType::Individual
+                ? $name->requiredForIndividual()
+                : $name->requiredForLegalEntity();
+
+            if ($required && ! isset($found[$name->value])) {
+                $findings[] = [
+                    'finding' => IcpBrasilFinding::MissingRequiredField,
+                    'field' => $name->name,
+                    'detail' => $name->value,
+                ];
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @param  array<string, string>  $found
+     * @return list<array{finding: IcpBrasilFinding, field: string, detail: ?string}>
+     */
+    private function alphabet(array $found): array
+    {
+        $findings = [];
+
+        foreach ($found as $oid => $value) {
+            $name = IcpBrasilOtherName::tryFrom($oid);
+
+            // A name is free text and still restricted to the same alphabet,
+            // which is why accented characters are stripped before issue.
+            if ($name !== null && preg_match(self::ALPHABET, str_replace(' ', '', $value)) !== 1) {
+                $findings[] = [
+                    'finding' => IcpBrasilFinding::IllegalCharacter,
+                    'field' => $name->name,
+                    'detail' => null,
+                ];
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @param  array<string, string>  $found
+     * @return list<array{finding: IcpBrasilFinding, field: string, detail: ?string}>
+     */
+    private function widths(array $found): array
+    {
+        $findings = [];
+
+        foreach ($found as $oid => $value) {
+            $layout = IcpBrasilOtherName::tryFrom($oid)?->layout();
+
+            if ($layout === null) {
+                continue;
+            }
+
+            $expected = array_sum($layout);
+            $last = (int) end($layout);
+            $actual = strlen($value);
+
+            // Only the final field may be short, and only that one, so the
+            // acceptable range is the full width down to the full width minus
+            // that field.
+            if ($actual > $expected || $actual < $expected - $last) {
+                $findings[] = [
+                    'finding' => IcpBrasilFinding::UnexpectedFieldLength,
+                    'field' => (string) IcpBrasilOtherName::from($oid)->name,
+                    'detail' => "{$actual} characters, expected {$expected}",
+                ];
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @param  array<string, string>  $fields
+     * @return list<array{finding: IcpBrasilFinding, field: string, detail: ?string}>
+     */
+    private function checkDigits(array $fields): array
+    {
+        $findings = [];
+
+        // A field of zeros means "not available", which the specification allows
+        // and which no check digit can be asked about.
+        if (isset($fields['cpf']) && trim($fields['cpf'], '0') !== '' && ! $this->registry->isCpf($fields['cpf'])) {
+            $findings[] = [
+                'finding' => IcpBrasilFinding::InvalidCpfCheckDigits,
+                'field' => 'cpf',
+                'detail' => $fields['cpf'],
+            ];
+        }
+
+        if (isset($fields['cnpj']) && trim($fields['cnpj'], '0') !== '' && ! $this->registry->isCnpj($fields['cnpj'])) {
+            $findings[] = [
+                'finding' => IcpBrasilFinding::InvalidCnpjCheckDigits,
+                'field' => 'cnpj',
+                'detail' => $fields['cnpj'],
+            ];
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @param  array<string, string>  $fields
+     * @return list<array{finding: IcpBrasilFinding, field: string, detail: ?string}>
+     */
+    private function birthDate(array $fields): array
+    {
+        $written = $fields['birthDate'] ?? null;
+
+        if ($written === null || preg_match('/^(\d{2})(\d{2})(\d{4})$/', $written, $parts) !== 1) {
+            return $written === null ? [] : [[
+                'finding' => IcpBrasilFinding::ImplausibleBirthDate,
+                'field' => 'birthDate',
+                'detail' => $written,
+            ]];
+        }
+
+        return checkdate((int) $parts[2], (int) $parts[1], (int) $parts[3]) ? [] : [[
+            'finding' => IcpBrasilFinding::ImplausibleBirthDate,
+            'field' => 'birthDate',
+            'detail' => $written,
+        ]];
+    }
+
+    /**
+     * Receita Federal §3.2.5: "if the RG is unavailable, the issuer and state
+     * fields shall not be filled in".
+     *
+     * @param  array<string, string>  $fields
+     * @return list<array{finding: IcpBrasilFinding, field: string, detail: ?string}>
+     */
+    private function nationalId(array $fields): array
+    {
+        $number = trim($fields['nationalId'] ?? '', '0 ');
+        $issuer = trim($fields['nationalIdIssuer'] ?? '');
+
+        return $number === '' && $issuer !== '' ? [[
+            'finding' => IcpBrasilFinding::IssuerNamedWithoutNationalId,
+            'field' => 'nationalIdIssuer',
+            'detail' => $issuer,
+        ]] : [];
+    }
+
+    /**
+     * The CPF appears twice, in the common name as `NAME:00000000000` and in the
+     * extension, and nothing in the format makes them agree.
+     *
+     * @param  array<string, string>  $fields
+     * @return list<array{finding: IcpBrasilFinding, field: string, detail: ?string}>
+     */
+    private function commonName(?string $commonName, array $fields): array
+    {
+        $cpf = $fields['cpf'] ?? null;
+
+        if ($commonName === null || $cpf === null || preg_match('/:(\d{11})$/', $commonName, $parts) !== 1) {
+            return [];
+        }
+
+        return $parts[1] === $cpf ? [] : [[
+            'finding' => IcpBrasilFinding::CommonNameDisagreesWithCpf,
+            'field' => 'commonName',
+            'detail' => "{$parts[1]} against {$cpf}",
+        ]];
+    }
+}

--- a/src/Validation/Pkcs7Reader.php
+++ b/src/Validation/Pkcs7Reader.php
@@ -26,10 +26,10 @@ final class Pkcs7Reader
      */
     public function signers(string $der): array
     {
-        return array_map(
-            static fn(array $parsed): Signer => Signer::fromParsedCertificate($parsed),
-            $this->parsedCertificates($der),
-        );
+        // Through the PEM rather than through parsedCertificates(), because a
+        // Signer now carries what only the bytes can answer: openssl_x509_parse()
+        // renders every ICP-Brasil otherName as `othername:<unsupported>`.
+        return $this->signersFromPem($this->certificates($der));
     }
 
     /**
@@ -47,7 +47,7 @@ final class Pkcs7Reader
 
             if ($parsed !== false) {
                 /** @var array<string, mixed> $parsed */
-                $signers[] = Signer::fromParsedCertificate($parsed);
+                $signers[] = Signer::fromParsedCertificate($parsed, $one);
             }
         }
 

--- a/tests/IcpBrasilTest.php
+++ b/tests/IcpBrasilTest.php
@@ -1,0 +1,306 @@
+<?php
+
+use LSNepomuceno\LaravelA1PdfSign\Certificates\IcpBrasilReader;
+use LSNepomuceno\LaravelA1PdfSign\Certificates\NativeCertificateReader;
+use LSNepomuceno\LaravelA1PdfSign\Certificates\SubjectAlternativeNameReader;
+use LSNepomuceno\LaravelA1PdfSign\Enums\IcpBrasilCertificateType;
+use LSNepomuceno\LaravelA1PdfSign\Enums\IcpBrasilFinding;
+use LSNepomuceno\LaravelA1PdfSign\Enums\IcpBrasilOtherName;
+use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
+use LSNepomuceno\LaravelA1PdfSign\Support\Files;
+use LSNepomuceno\LaravelA1PdfSign\Support\NationalRegistry;
+use LSNepomuceno\LaravelA1PdfSign\Testing\DebugCertificate;
+use LSNepomuceno\LaravelA1PdfSign\Validation\IcpBrasilValidator;
+
+/**
+ * Reading who a Brazilian signer is, and checking the certificate says it
+ * consistently.
+ *
+ * Everything here runs against certificates this suite generates, which are
+ * self-signed and carry the ICP-Brasil fields. That is the whole shape of the
+ * claim being tested: the fields can be read and judged from the bytes, and no
+ * amount of judging them makes a certificate trustworthy
+ * (docs/decisions/0029-the-identity-a-brazilian-signer-is-known-by.md).
+ */
+
+/**
+ * The leaf certificate of a throwaway ICP-Brasil bundle, as PEM.
+ *
+ * @param  array<string, string>  $otherNames
+ */
+function icpCertificate(
+    IcpBrasilCertificateType $type = IcpBrasilCertificateType::Individual,
+    array $otherNames = [],
+    string $commonName = 'JOAO DA SILVA:11144477735',
+): string {
+    [$pfx, $password] = DebugCertificate::icpBrasil($type, $otherNames, $commonName);
+
+    return app(NativeCertificateReader::class)->read($pfx, $password)->original;
+}
+
+it('finds the otherName fields openssl_x509_parse cannot render', function () {
+    // The reason this reader exists at all: PHP renders every one of these as
+    // `othername:<unsupported>`, so the identity was unreachable through the
+    // parse the rest of the package uses.
+    $certificate = icpCertificate();
+
+    $parsed = openssl_x509_parse($certificate);
+    $extensions = is_array($parsed) && is_array($parsed['extensions'] ?? null) ? $parsed['extensions'] : [];
+    $rendered = is_string($extensions['subjectAltName'] ?? null) ? $extensions['subjectAltName'] : '';
+
+    $names = app(SubjectAlternativeNameReader::class)->otherNames($certificate);
+
+    expect($rendered)->toContain('othername')
+        ->and($names)->toHaveKeys([
+            IcpBrasilOtherName::HolderData->value,
+            IcpBrasilOtherName::VoterRegistration->value,
+            IcpBrasilOtherName::HolderSocialSecurity->value,
+        ]);
+});
+
+it('reads an e-CPF holder', function () {
+    $identity = app(IcpBrasilReader::class)->read(icpCertificate());
+
+    expect($identity->type)->toBe(IcpBrasilCertificateType::Individual)
+        ->and($identity->cpf)->toBe('11144477735')
+        ->and($identity->cnpj)->toBeNull()
+        ->and($identity->birthDate)->toBe('11/08/1985')
+        ->and($identity->socialIdentity)->toBe('12345678901')
+        // Written padded to fifteen characters, handed back as the number.
+        ->and($identity->nationalId)->toBe('12345678')
+        ->and($identity->nationalIdIssuer)->toBe('SSPSP')
+        ->and($identity->voterRegistration)->toBe('465555610469')
+        ->and($identity->voterMunicipality)->toBe('SAOPAULOSP');
+});
+
+it('reads an e-CNPJ as the company rather than as the person answering for it', function () {
+    // An e-CNPJ carries a CPF too. Reading the CPF first would report every
+    // company certificate as a person, which is the trap in the layout.
+    $identity = app(IcpBrasilReader::class)->read(icpCertificate(IcpBrasilCertificateType::LegalEntity));
+
+    expect($identity->type)->toBe(IcpBrasilCertificateType::LegalEntity)
+        ->and($identity->cnpj)->toBe('11222333000181')
+        ->and($identity->cpf)->toBe('11144477735')
+        ->and($identity->responsibleName)->toBe('JOAO DA SILVA')
+        ->and($identity->registry())->toBe('11222333000181')
+        ->and($identity->formattedRegistry())->toBe('11.222.333/0001-81');
+});
+
+it('reports a field written as zeros as absent rather than as zeros', function () {
+    // The specification requires an unavailable number to be filled with zeros,
+    // so "000000000000" and "not there" are the same fact, and only one of them
+    // is worth handing to a caller.
+    $identity = app(IcpBrasilReader::class)->read(icpCertificate());
+
+    expect($identity->socialSecurity)->toBeNull();
+});
+
+it('answers None for a certificate that never claimed to be ICP-Brasil', function () {
+    [$pfx, $password] = debugCertificate();
+
+    $identity = app(IcpBrasilReader::class)
+        ->read(app(NativeCertificateReader::class)->read(Files::read($pfx), $password)->original);
+
+    expect($identity->type)->toBe(IcpBrasilCertificateType::None)
+        ->and($identity->cpf)->toBeNull();
+});
+
+it('carries the identity on the signer a validated document reports', function () {
+    // The point of the whole feature: validate a document and know who signed
+    // it, by the number they are known by in Brazil.
+    [$pfx, $password] = DebugCertificate::icpBrasil();
+
+    $path = A1PdfSign::tempPath(true, '.pfx');
+    file_put_contents($path, $pfx);
+
+    $signed = A1PdfSign::newSignature()
+        ->certificate($path, $password)
+        ->pdf(resource('test.pdf'))
+        ->sign()
+        ->save(A1PdfSign::tempPath(true, '.pdf'));
+
+    $signer = A1PdfSign::validate($path = $signed)->signers()[0];
+
+    expect($signer->icpBrasil?->cpf)->toBe('11144477735')
+        // The name without the CPF glued to it, which is what a caller wants to
+        // show and would otherwise have to strip themselves.
+        ->and($signer->name())->toBe('JOAO DA SILVA')
+        ->and($signer->commonName)->toBe('JOAO DA SILVA:11144477735');
+
+    unlink($path);
+});
+
+/*
+|--------------------------------------------------------------------------
+| The structural check
+|--------------------------------------------------------------------------
+*/
+
+it('conforms when every rule the specification states is satisfied', function () {
+    $report = app(IcpBrasilValidator::class)->validate(icpCertificate(), 'JOAO DA SILVA:11144477735');
+
+    expect($report->conforms())->toBeTrue()
+        ->and($report->findings)->toBe([])
+        ->and($report->identity->cpf)->toBe('11144477735');
+});
+
+it('does not conform when the certificate is not ICP-Brasil at all', function () {
+    // Not a malformed ICP-Brasil certificate: one that never claimed to be one.
+    // The type is what separates those, and conforms() is false either way
+    // because there was nothing to conform to.
+    [$pfx, $password] = debugCertificate();
+
+    $report = app(IcpBrasilValidator::class)->validate(
+        app(NativeCertificateReader::class)->read(Files::read($pfx), $password)->original,
+    );
+
+    expect($report->conforms())->toBeFalse()
+        ->and($report->findings)->toBe([])
+        ->and($report->identity->type)->toBe(IcpBrasilCertificateType::None);
+});
+
+it('catches a CPF that does not satisfy its own check digits', function () {
+    $broken = '11081985' . '11144477736' . '12345678901' . '000000012345678' . 'SSPSP';
+
+    $report = app(IcpBrasilValidator::class)->validate(
+        icpCertificate(otherNames: [IcpBrasilOtherName::HolderData->value => $broken]),
+    );
+
+    expect($report->has(IcpBrasilFinding::InvalidCpfCheckDigits))->toBeTrue()
+        ->and($report->conforms())->toBeFalse();
+});
+
+it('catches a CNPJ that does not satisfy its own check digits', function () {
+    $report = app(IcpBrasilValidator::class)->validate(
+        icpCertificate(
+            IcpBrasilCertificateType::LegalEntity,
+            [IcpBrasilOtherName::CompanyRegistry->value => '11222333000182'],
+        ),
+    );
+
+    expect($report->has(IcpBrasilFinding::InvalidCnpjCheckDigits))->toBeTrue();
+});
+
+it('catches a required field the profile does not carry', function () {
+    // An e-CPF must carry all three. Removing the voter registration leaves a
+    // certificate that reads as an e-CPF and is not a complete one.
+    $report = app(IcpBrasilValidator::class)->validate(
+        icpCertificate(otherNames: [IcpBrasilOtherName::VoterRegistration->value => '']),
+    );
+
+    expect($report->has(IcpBrasilFinding::MissingRequiredField))->toBeTrue();
+});
+
+it('catches a field that is not the width its layout fixes', function () {
+    $report = app(IcpBrasilValidator::class)->validate(
+        icpCertificate(otherNames: [IcpBrasilOtherName::HolderData->value => '1108198511144477735']),
+    );
+
+    expect($report->has(IcpBrasilFinding::UnexpectedFieldLength))->toBeTrue();
+});
+
+it('accepts the one short field the specification allows', function () {
+    // "The 6 positions for the RG issuer refer to the maximum size, and only the
+    // positions needed are used", so the last field of a layout is allowed to
+    // run short and only that one.
+    $short = '11081985' . '11144477735' . '12345678901' . '000000012345678' . 'DIC';
+
+    $report = app(IcpBrasilValidator::class)->validate(
+        icpCertificate(otherNames: [IcpBrasilOtherName::HolderData->value => $short]),
+    );
+
+    expect($report->has(IcpBrasilFinding::UnexpectedFieldLength))->toBeFalse()
+        ->and($report->identity->nationalIdIssuer)->toBe('DIC');
+});
+
+it('catches characters the alphabet does not allow', function () {
+    // Only A to Z and 0 to 9. Accents are stripped before issue precisely
+    // because of this rule, so one appearing is a certificate built by hand.
+    $report = app(IcpBrasilValidator::class)->validate(
+        icpCertificate(
+            IcpBrasilCertificateType::LegalEntity,
+            [IcpBrasilOtherName::ResponsibleName->value => 'JOAO DA SILVA JUNIOR-ME'],
+        ),
+    );
+
+    expect($report->has(IcpBrasilFinding::IllegalCharacter))->toBeTrue();
+});
+
+it('catches a birth date that is not a date', function () {
+    $report = app(IcpBrasilValidator::class)->validate(
+        icpCertificate(otherNames: [
+            IcpBrasilOtherName::HolderData->value => '32131985' . '11144477735' . '12345678901' . '000000012345678' . 'SSPSP',
+        ]),
+    );
+
+    expect($report->has(IcpBrasilFinding::ImplausibleBirthDate))->toBeTrue()
+        ->and($report->identity->birthDate)->toBeNull();
+});
+
+it('catches an issuing authority named for an identity number that is absent', function () {
+    // §3.2.5, stated outright: if the RG is unavailable, the issuer and state
+    // fields shall not be filled in.
+    $report = app(IcpBrasilValidator::class)->validate(
+        icpCertificate(otherNames: [
+            IcpBrasilOtherName::HolderData->value => '11081985' . '11144477735' . '12345678901' . '000000000000000' . 'SSPSP',
+        ]),
+    );
+
+    expect($report->has(IcpBrasilFinding::IssuerNamedWithoutNationalId))->toBeTrue();
+});
+
+it('catches the two places a CPF appears disagreeing', function () {
+    // Nothing in the format makes the common name and the extension agree, and
+    // a document filed under the wrong number is filed under the wrong person.
+    $report = app(IcpBrasilValidator::class)->validate(
+        icpCertificate(commonName: 'JOAO DA SILVA:12345678909'),
+        'JOAO DA SILVA:12345678909',
+    );
+
+    expect($report->has(IcpBrasilFinding::CommonNameDisagreesWithCpf))->toBeTrue()
+        ->and($report->messages())->toContain('commonName: the CPF in the common name is not the CPF in the subject alternative name (12345678909 against 11144477735)');
+});
+
+it('checks a certificate through the facade, from the PFX a signer already has', function () {
+    [$pfx, $password] = DebugCertificate::icpBrasil();
+
+    $path = A1PdfSign::tempPath(true, '.pfx');
+    file_put_contents($path, $pfx);
+
+    $report = A1PdfSign::icpBrasil($path, $password);
+
+    expect($report->conforms())->toBeTrue()
+        ->and($report->identity->cpf)->toBe('11144477735');
+
+    unlink($path);
+});
+
+/*
+|--------------------------------------------------------------------------
+| The arithmetic underneath
+|--------------------------------------------------------------------------
+*/
+
+it('agrees with the check digits every Brazilian document carries', function (string $number, bool $valid) {
+    expect(app(NationalRegistry::class)->isCpf($number))->toBe($valid);
+})->with([
+    ['11144477735', true],
+    ['12345678909', true],
+    // One digit changed, which is the error the check digits exist to catch.
+    ['11144477736', false],
+    // Arithmetically consistent and rejected everywhere in Brazil.
+    ['11111111111', false],
+    ['00000000000', false],
+    ['1114447773', false],
+    ['abcdefghijk', false],
+]);
+
+it('agrees with the check digits a CNPJ carries', function (string $number, bool $valid) {
+    expect(app(NationalRegistry::class)->isCnpj($number))->toBe($valid);
+})->with([
+    ['11222333000181', true],
+    ['33989214000191', true],
+    ['11222333000182', false],
+    ['11111111111111', false],
+    ['1122233300018', false],
+]);

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -125,6 +125,13 @@ it('lets the container swap the implementation', function () {
             return new \LSNepomuceno\LaravelA1PdfSign\Data\SignedPdf('faked');
         }
 
+        public function icpBrasil(string $pfxPath, string $password = ''): \LSNepomuceno\LaravelA1PdfSign\Data\IcpBrasilReport
+        {
+            return new \LSNepomuceno\LaravelA1PdfSign\Data\IcpBrasilReport(
+                \LSNepomuceno\LaravelA1PdfSign\Data\IcpBrasilIdentity::none(),
+            );
+        }
+
         public function newSignature(): \LSNepomuceno\LaravelA1PdfSign\Signing\PendingSignature
         {
             return app(\LSNepomuceno\LaravelA1PdfSign\Signing\PendingSignature::class);


### PR DESCRIPTION
This package exists for Brazilian signing and could not answer the first question anyone asks of a signed document: **who signed it.**

In Brazil that answer is a CPF or a CNPJ. The package handed back this:

```php
$signer->commonName;   // "JOAO DA SILVA:11144477735"
```

So every consumer wrote `explode(':', $commonName)`. That breaks on a name containing a colon, and it is **simply wrong for an e-CNPJ**: its common name carries the company, while the CPF in the extension belongs to whoever answers for it.

## Now

```php
$signer = A1PdfSign::validate($path)->signers()[0];

$signer->icpBrasil?->cpf;                 // '11144477735'
$signer->icpBrasil?->cnpj;                // the company, for an e-CNPJ
$signer->icpBrasil?->formattedRegistry(); // '11.222.333/0001-81'
$signer->name();                          // 'JOAO DA SILVA', without the number
```

## Why it was not read before

`openssl_x509_parse()` cannot do it. Every ICP-Brasil field is an `otherName` under 2.16.76.1.3, and PHP renders each one as `othername:<unsupported>`. The `Asn1Reader` that [0019](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/blob/main/docs/decisions/0019-validation-reads-what-it-writes.md) built for the CMS goes where it cannot.

## Three ways to read the layout wrong, from the specification itself

Verified against the Receita Federal's certificate layout, §2.2.5 for e-CPF and §3.2.5 for e-CNPJ, not from memory:

- **There are no separators.** A field read one character short reads the *next* one wrong rather than failing.
- **The last field of a layout may run short.** The six positions for the RG's issuing authority "refer to the maximum size, and only the positions needed are used". It is read as the remainder, and the width check allows exactly that one field to be short.
- **"Unavailable" is written as zeros.** Eleven zeros and an absent field are the same fact, so callers get null rather than a string they would have to know to test for.

## The structural check

`A1PdfSign::icpBrasil($pfxPath, $password)` says which field is wrong, from the file, before anything is signed.

| | |
|---|---|
| Required fields | three `otherName` entries for e-CPF, four for e-CNPJ |
| Widths | the layout's, with the last allowed short |
| Alphabet | "only A to Z and 0 to 9" |
| Check digits | modulus eleven, both numbers |
| Birth date | a real date in `ddmmyyyy` |
| RG | an issuer named for a number that is absent, which the specification calls out |
| The CPF twice | common name against extension, which nothing in the format makes agree |

### ⚠️ `conforms()` is not `isTrusted()`

**A self-signed certificate can be built to satisfy every rule above, and this PR builds one**: `DebugCertificate::icpBrasil()` is what the tests run against. It chains to nothing and no trust store will accept it.

The value is upstream of trust rather than instead of it. A certificate that fails here will be read wrong by everything downstream, and finding that out from the bytes beats finding it out from a rejected filing. Stated in the class docblock, the report docblock, the contract and [0029](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/blob/main/docs/decisions/0029-the-identity-a-brazilian-signer-is-known-by.md), because it is the one thing about this feature that is dangerous to get wrong.

## Surface

- `Contracts\A1PdfSign` gained `icpBrasil()`: a break for implementers, which Roave reports.
- `Data\Signer` gained `$icpBrasil` and `name()`, appended with defaults.
- `Pkcs7Reader::signers()` goes through the PEM rather than through a parse, because the identity is only in the bytes.
- `Support\NationalRegistry` is bespoke by necessity: neither Laravel nor any dependency here validates a CPF.

**It says a number is well formed, never that it exists.** Whether the Receita Federal issued it is a question only they answer, and asking would mean a network call from validation, which nothing here does.

`composer check` green: **473 passing**, 30 of them new, PHPStan level max, Pint clean.