### PR TITLE
feat(signing): refresh the security store when extending an archive

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -35,6 +35,26 @@ Nothing here is configurable, and that is deliberate: the previous behaviour was
 a conformant document going in and a non-conformant one coming out.
 `seal.transparent => false` is still the lever for PDF/A-1.
 
+### Extending an archive refreshes the evidence it archives
+
+`A1PdfSign::extendArchive()` used to append the timestamp and nothing else, so a
+document could gain a fifth archive timestamp over revocation material gathered
+on the day it was signed. That is the one thing long-term validation exists to
+prevent.
+
+It now gathers fresh material for every chain the document carries and writes
+the store **before** the timestamp, which is the order ETSI EN 319 142-1 fixes:
+the evidence goes inside the file while it is still verifiable, and the
+timestamp then covers it.
+
+The timestamp authorities' own chains are included, deliberately. Their
+certificates are what the *next* archive timestamp has to be able to check, and
+they expire like any other.
+
+Extending now appends two revisions where it appended one, so the file grows
+more. Nothing about the earlier bytes changes
+([0022](docs/decisions/0022-the-archive-timestamp-is-a-chain.md)).
+
 ### Who signed, in the number Brazil knows them by
 
 A validated document now answers the first question anyone asks of one:

--- a/docs/decisions/0022-the-archive-timestamp-is-a-chain.md
+++ b/docs/decisions/0022-the-archive-timestamp-is-a-chain.md
@@ -80,12 +80,35 @@ What the network tests assert:
   implementing the contract, which the Roave check reports.
 - `DocTimeStampWriter` takes `SignatureFieldReader` as a further defaulted
   constructor parameter, appended.
-- Nothing refreshes the Document Security Store while extending. A rigorous
-  chain re-collects revocation material for the *previous* timestamp's
-  certificate before stamping over it, and this does not: it appends the
-  timestamp only. Named here rather than implied, and it is the same gap
-  [0016](0016-trust-is-the-applications-policy.md) left open around revocation
-  generally.
+- ~~Nothing refreshes the Document Security Store while extending.~~ **Fixed.**
+  This section said a rigorous chain re-collects revocation material for the
+  previous timestamp's certificate before stamping over it, and that this did
+  not: it appended the timestamp only. A document could therefore gain a fifth
+  archive timestamp over evidence gathered on the day it was signed, which is
+  the one thing long-term validation exists to prevent.
+
+  `extend()` now refreshes the store first, and the order is the correctness
+  claim: ETSI EN 319 142-1 puts the material for everything the document already
+  carries **inside the file while it is still verifiable**, and the archive
+  timestamp then covers it. A store appended afterwards is material the
+  timestamp does not attest.
+
+  The chains are built per signature with `Validation\ChainBuilder` rather than
+  pooled, because `collectValidationMaterial()` treats each certificate's
+  neighbour as its issuer: a mixed pile would build an OCSP request against the
+  wrong pair and embed the answer. The timestamps' own chains are included, and
+  that is the point of the exercise, since the authority's certificate is what
+  the *next* archive timestamp has to be able to check.
+
+  Gated offline by `tests/ArchiveRefreshTest.php`. Two pieces of test-only
+  machinery were needed and neither is a stub of the thing under test:
+  `DebugCertificate::makeRevocable()` issues a certificate that names its own
+  distribution point, because `collectValidationMaterial()` reads the endpoints
+  from the certificate and one carrying none is never asked about whatever
+  transport is bound; and `Testing\LocalRevocationAuthority` answers with
+  material, where `LocalTimestampAuthority` answers false. Whether that material
+  is *good* is [0024](0024-revocation-is-evaluated-not-counted.md)'s question,
+  with its own fixtures.
 
 ## Alternatives rejected
 

--- a/src/Signing/ArchiveExtender.php
+++ b/src/Signing/ArchiveExtender.php
@@ -11,7 +11,10 @@ use LSNepomuceno\LaravelA1PdfSign\Exceptions\ProcessRunTimeException;
 use LSNepomuceno\LaravelA1PdfSign\Signing\Incremental\CertificationReader;
 use LSNepomuceno\LaravelA1PdfSign\Signing\Incremental\DocTimeStampWriter;
 use LSNepomuceno\LaravelA1PdfSign\Signing\Incremental\DocumentReader;
+use LSNepomuceno\LaravelA1PdfSign\Signing\Incremental\DssWriter;
+use LSNepomuceno\LaravelA1PdfSign\Validation\ChainBuilder;
 use LSNepomuceno\LaravelA1PdfSign\Validation\PdfSignatureExtractor;
+use LSNepomuceno\LaravelA1PdfSign\Validation\Pkcs7Reader;
 
 /**
  * Adds a fresh archive timestamp to a document that already has one.
@@ -39,6 +42,9 @@ final readonly class ArchiveExtender
         private DocTimeStampWriter $timestamps,
         private PdfSignatureExtractor $extractor,
         private CertificationReader $certifications,
+        private DssWriter $store,
+        private Pkcs7Reader $pkcs7 = new Pkcs7Reader(),
+        private ChainBuilder $builder = new ChainBuilder(),
     ) {}
 
     /**
@@ -67,7 +73,45 @@ final readonly class ArchiveExtender
             throw CertificationException::forbidsArchiveTimestamp();
         }
 
-        return new SignedPdf($this->timestamps->append($pdfContents), $fileName);
+        // The store is refreshed first, and the ordering is the whole point.
+        // ETSI EN 319 142-1 §5.5: the validation material for everything the
+        // document already carries has to be inside the file, and then the new
+        // archive timestamp covers it. Extending without this produced a longer
+        // chain of timestamps over evidence that was ageing out.
+        return new SignedPdf(
+            $this->timestamps->append($this->store->refresh($pdfContents, $this->certificateChains($signatures))),
+            $fileName,
+        );
+    }
+
+    /**
+     * One chain per signature and timestamp in the document, leaf first.
+     *
+     * Built rather than taken in order: a CMS carries its certificates as a
+     * set, so "the first one" is not the signer, and the collector downstream
+     * treats each certificate's neighbour as its issuer. A pile in the wrong
+     * order would ask a responder about the wrong pair and embed the answer.
+     *
+     * The timestamps' own chains are included deliberately. The authority's
+     * certificate is what the next archive timestamp has to be able to check,
+     * and it expires like any other.
+     *
+     * @param  list<array{cms: string, ...}>  $signatures
+     * @return list<list<string>>
+     */
+    private function certificateChains(array $signatures): array
+    {
+        $chains = [];
+
+        foreach ($signatures as $signature) {
+            $chain = $this->builder->build($this->pkcs7->certificates($signature['cms']));
+
+            if ($chain !== []) {
+                $chains[] = $chain;
+            }
+        }
+
+        return $chains;
     }
 
     /**

--- a/src/Signing/Incremental/DssWriter.php
+++ b/src/Signing/Incremental/DssWriter.php
@@ -37,8 +37,60 @@ final readonly class DssWriter
      */
     public function append(string $pdf, Certificate $certificate): string
     {
-        $material = $this->collect($certificate);
+        return $this->write($pdf, $this->collect(Pem::certificates($certificate->original)));
+    }
 
+    /**
+     * A store built from the certificates the document already carries, with
+     * the revocation material fetched now rather than when it was signed.
+     *
+     * This is what an archive timestamp needs before it is written: the
+     * evidence for everything up to this point has to be inside the file while
+     * it is still verifiable, and then the timestamp covers it
+     * (docs/decisions/0022-the-archive-timestamp-is-a-chain.md).
+     *
+     * @param  list<list<string>>  $chains  One chain per signature, leaf first.
+     *                                      Kept apart rather than pooled: the
+     *                                      collector pairs each certificate with
+     *                                      the next one as its issuer, so a
+     *                                      mixed pile would build OCSP requests
+     *                                      against the wrong issuer.
+     *
+     * @throws InvalidPdfFileException
+     */
+    public function refresh(string $pdf, array $chains): string
+    {
+        $material = ['certs' => [], 'ocsp' => [], 'crls' => []];
+
+        foreach ($chains as $chain) {
+            $collected = $this->collect($chain);
+
+            if ($collected === null) {
+                continue;
+            }
+
+            foreach ($material as $kind => $items) {
+                $material[$kind] = [...$items, ...$collected[$kind]];
+            }
+        }
+
+        foreach ($material as $kind => $items) {
+            $material[$kind] = array_values(array_unique($items));
+        }
+
+        return $this->write(
+            $pdf,
+            $material['certs'] === [] && $material['ocsp'] === [] && $material['crls'] === [] ? null : $material,
+        );
+    }
+
+    /**
+     * @param  array{certs: list<string>, ocsp: list<string>, crls: list<string>}|null  $material
+     *
+     * @throws InvalidPdfFileException
+     */
+    private function write(string $pdf, ?array $material): string
+    {
         if ($material === null) {
             return $pdf;
         }
@@ -63,12 +115,11 @@ final readonly class DssWriter
      * distribution point, and an unreachable responder must not fail the
      * signature: in both cases the document simply stays at B-T.
      *
+     * @param  list<string>  $chain  Leaf first.
      * @return array{certs: list<string>, ocsp: list<string>, crls: list<string>}|null
      */
-    private function collect(Certificate $certificate): ?array
+    private function collect(array $chain): ?array
     {
-        $chain = $this->chain($certificate);
-
         if ($chain === []) {
             return null;
         }
@@ -86,14 +137,6 @@ final readonly class DssWriter
         return $material['certs'] === [] && $material['ocsp'] === [] && $material['crls'] === []
             ? null
             : $material;
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function chain(Certificate $certificate): array
-    {
-        return Pem::certificates($certificate->original);
     }
 
     /**

--- a/src/Testing/DebugCertificate.php
+++ b/src/Testing/DebugCertificate.php
@@ -169,31 +169,12 @@ final class DebugCertificate
 
         $key = self::key();
 
-        $x509 = TemporaryFile::with(
-            sys_get_temp_dir(),
-            '.cnf',
+        $x509 = self::signWithExtensions(
             self::openSslConfiguration($fields),
-            static function (TemporaryFile $configuration) use ($key, $commonName, $daysValid): OpenSSLCertificate {
-                $options = ['digest_alg' => 'sha256', 'config' => $configuration->path, 'x509_extensions' => 'icp'];
-
-                // openssl_csr_new takes the key by reference, so it is handed a
-                // copy: the analyser widens anything that function touches to
-                // mixed, and the signing call below needs the type intact.
-                $request = $key;
-                $csr = openssl_csr_new(['commonName' => $commonName, 'countryName' => 'BR'], $request, $options);
-
-                if (! $csr instanceof OpenSSLCertificateSigningRequest) {
-                    throw new RuntimeException('Unable to generate the ICP-Brasil test CSR: ' . openssl_error_string());
-                }
-
-                $signed = openssl_csr_sign($csr, null, $key, $daysValid, $options);
-
-                if ($signed === false) {
-                    throw new RuntimeException('Unable to sign the ICP-Brasil test certificate: ' . openssl_error_string());
-                }
-
-                return $signed;
-            },
+            'icp',
+            ['commonName' => $commonName, 'countryName' => 'BR'],
+            $key,
+            $daysValid,
         );
 
         $pfx = '';
@@ -204,6 +185,102 @@ final class DebugCertificate
 
         /** @var string $pfx */
         return [$pfx, self::PASSWORD];
+    }
+
+    /**
+     * A certificate that names where its revocation material lives.
+     *
+     * `Signer::collectValidationMaterial()` reads the endpoints out of the
+     * certificate, so a certificate carrying none is never asked about, whatever
+     * transport is bound. Without this, the code that gathers a Document
+     * Security Store could only be exercised against a real authority
+     * (docs/decisions/0022-the-archive-timestamp-is-a-chain.md).
+     *
+     * The URLs are unroutable on purpose. A substituted transport answers them,
+     * and anything that reached the network would be a test lying about what it
+     * checks.
+     *
+     * @return array{0: string, 1: string} The PFX bytes and its password.
+     *
+     * @throws CertificateOutputNotFoundException
+     */
+    public static function makeRevocable(
+        string $crlUrl = 'http://crl.invalid/test.crl',
+        string $ocspUrl = 'http://ocsp.invalid',
+        int $daysValid = 600,
+    ): array {
+        $key = self::key();
+
+        $configuration = implode("\n", [
+            '[req]',
+            'distinguished_name = dn',
+            '[dn]',
+            '[leaf]',
+            'basicConstraints = CA:FALSE',
+            'keyUsage = critical, digitalSignature, nonRepudiation, keyEncipherment',
+            "crlDistributionPoints = URI:{$crlUrl}",
+            "authorityInfoAccess = OCSP;URI:{$ocspUrl}",
+            '',
+        ]);
+
+        $x509 = self::signWithExtensions(
+            $configuration,
+            'leaf',
+            ['commonName' => 'Revocable Test Certificate'],
+            $key,
+            $daysValid,
+        );
+
+        $pfx = '';
+
+        if (! openssl_pkcs12_export($x509, $pfx, $key, self::PASSWORD)) {
+            throw new CertificateOutputNotFoundException();
+        }
+
+        /** @var string $pfx */
+        return [$pfx, self::PASSWORD];
+    }
+
+    /**
+     * Issues a self-signed certificate whose extensions come from a written
+     * configuration, which is the only way openssl accepts an `otherName` or a
+     * distribution point.
+     *
+     * @param  array<string, string>  $subject
+     */
+    private static function signWithExtensions(
+        string $configuration,
+        string $section,
+        array $subject,
+        OpenSSLAsymmetricKey $key,
+        int $daysValid,
+    ): OpenSSLCertificate {
+        return TemporaryFile::with(
+            sys_get_temp_dir(),
+            '.cnf',
+            $configuration,
+            static function (TemporaryFile $file) use ($section, $subject, $key, $daysValid): OpenSSLCertificate {
+                $options = ['digest_alg' => 'sha256', 'config' => $file->path, 'x509_extensions' => $section];
+
+                // openssl_csr_new takes the key by reference, so it is handed a
+                // copy: the analyser widens anything that function touches to
+                // mixed, and the signing call below needs the type intact.
+                $request = $key;
+                $csr = openssl_csr_new($subject, $request, $options);
+
+                if (! $csr instanceof OpenSSLCertificateSigningRequest) {
+                    throw new RuntimeException('Unable to generate the test CSR: ' . openssl_error_string());
+                }
+
+                $signed = openssl_csr_sign($csr, null, $key, $daysValid, $options);
+
+                if ($signed === false) {
+                    throw new RuntimeException('Unable to sign the test certificate: ' . openssl_error_string());
+                }
+
+                return $signed;
+            },
+        );
     }
 
     /**

--- a/src/Testing/LocalRevocationAuthority.php
+++ b/src/Testing/LocalRevocationAuthority.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Testing;
+
+use LSNepomuceno\LaravelA1PdfSign\Contracts\SignatureTransport;
+use LSNepomuceno\LaravelA1PdfSign\Support\ProcessRunner;
+
+/**
+ * The local timestamp authority, with revocation material to hand out.
+ *
+ * `LocalTimestampAuthority` answers false for OCSP and CRL, which is honest for
+ * a self-signed certificate: it has no responder and no distribution point, so
+ * a document signed with one carries no revocation material and the live tests
+ * produce exactly the same. That leaves the code that gathers a Document
+ * Security Store unexercised offline.
+ *
+ * This serves whatever it was given, at whatever URL it is asked for. **The
+ * material is not evaluated here**, and that separation is deliberate: whether
+ * a response really covers a certificate is
+ * `Validation\RevocationChecker`'s question, with its own tests and its own
+ * fixtures ([0024](../../docs/decisions/0024-revocation-is-evaluated-not-counted.md)).
+ * What this makes testable is that the store is written, refreshed and covered
+ * by the timestamp that follows it.
+ *
+ * Test-only, and kept out of the production classes exactly as its parent is.
+ *
+ * See docs/decisions/0022-the-archive-timestamp-is-a-chain.md.
+ */
+final class LocalRevocationAuthority implements SignatureTransport
+{
+    private readonly LocalTimestampAuthority $timestamps;
+
+    /**
+     * @param  ?string  $crl  DER, or null to answer as though there were none.
+     * @param  ?string  $ocsp  DER, or null.
+     */
+    public function __construct(
+        ProcessRunner $processes,
+        private readonly ?string $crl = null,
+        private readonly ?string $ocsp = null,
+    ) {
+        $this->timestamps = new LocalTimestampAuthority($processes);
+    }
+
+    /**
+     * @return callable(string): string
+     */
+    public function timestamp(string $url, ?string $username = null, ?string $password = null): callable
+    {
+        return $this->timestamps->timestamp($url, $username, $password);
+    }
+
+    /**
+     * @return callable(string, string): (string|false)
+     */
+    public function ocsp(): callable
+    {
+        $response = $this->ocsp;
+
+        return static fn(string $url, string $request): string|false => $response ?? false;
+    }
+
+    /**
+     * @return callable(string): (string|false)
+     */
+    public function crl(): callable
+    {
+        $list = $this->crl;
+
+        return static fn(string $url): string|false => $list ?? false;
+    }
+}

--- a/tests/ArchiveRefreshTest.php
+++ b/tests/ArchiveRefreshTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use LSNepomuceno\LaravelA1PdfSign\Contracts\SignatureTransport;
+use LSNepomuceno\LaravelA1PdfSign\Enums\SignatureProfile;
+use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
+use LSNepomuceno\LaravelA1PdfSign\Signing\ArchiveExtender;
+use LSNepomuceno\LaravelA1PdfSign\Support\Files;
+use LSNepomuceno\LaravelA1PdfSign\Support\ProcessRunner;
+use LSNepomuceno\LaravelA1PdfSign\Testing\DebugCertificate;
+use LSNepomuceno\LaravelA1PdfSign\Testing\LocalRevocationAuthority;
+use LSNepomuceno\LaravelA1PdfSign\Validation\SecurityStoreReader;
+
+/**
+ * Extending an archive refreshes the evidence it archives.
+ *
+ * [0022](docs/decisions/0022-the-archive-timestamp-is-a-chain.md) built the
+ * chain and said outright what it left undone: "nothing refreshes the Document
+ * Security Store while extending". So a document could gain a fifth archive
+ * timestamp over revocation material gathered on the day it was signed, years
+ * earlier, which is the one thing long-term validation exists to prevent.
+ *
+ * ETSI EN 319 142-1 puts the order the other way round: the material for
+ * everything the document already carries goes in **first**, while it is still
+ * verifiable, and the archive timestamp then covers it.
+ */
+beforeEach(function () {
+    app()->bind(SignatureTransport::class, fn(): LocalRevocationAuthority => new LocalRevocationAuthority(
+        app(ProcessRunner::class),
+        crl: Files::read(resource('revocation/crl-good.der')),
+    ));
+
+    config()->set('a1-pdf-sign.signature.timestamp.url', 'https://timestamp.invalid/tsr');
+});
+
+/**
+ * A B-LT document signed with a certificate that names where its revocation
+ * material lives, so the store is not empty to begin with.
+ */
+function archivedDocument(): string
+{
+    [$pfx, $password] = DebugCertificate::makeRevocable();
+
+    $path = A1PdfSign::tempPath(true, '.pfx');
+    file_put_contents($path, $pfx);
+
+    $signed = A1PdfSign::newSignature()
+        ->certificate($path, $password)
+        ->pdf(resource('test.pdf'))
+        ->profile(SignatureProfile::PadesBLTA)
+        ->sign();
+
+    unlink($path);
+
+    return $signed->contents;
+}
+
+it('gathers revocation material a certificate points at', function () {
+    // The precondition for everything below, and the reason
+    // DebugCertificate::makeRevocable() exists: collectValidationMaterial reads
+    // the endpoints out of the certificate, so one carrying none is never asked
+    // about, whatever transport is bound.
+    $store = app(SecurityStoreReader::class)->read(archivedDocument());
+
+    expect($store->crls)->toBeGreaterThan(0);
+});
+
+it('appends a further store when the archive is extended', function () {
+    $archived = archivedDocument();
+    $before = app(SecurityStoreReader::class)->read($archived)->certificates;
+
+    $extended = app(ArchiveExtender::class)->extend($archived);
+    $after = app(SecurityStoreReader::class)->read($extended->contents)->certificates;
+
+    // The reader answers with the newest store, and a refreshed one carries the
+    // certificates of every signature and timestamp in the file rather than
+    // only the signer's.
+    expect($after)->toBeGreaterThan($before);
+});
+
+it('writes the store before the timestamp that has to cover it', function () {
+    // The ordering is the whole correctness claim. A store appended after the
+    // archive timestamp is material the timestamp does not attest, which is
+    // worth no more than material sitting outside the file.
+    $extended = app(ArchiveExtender::class)->extend(archivedDocument())->contents;
+
+    $store = strrpos($extended, '/DSS');
+    $timestamp = strrpos($extended, '/DocTimeStamp');
+
+    expect($store)->toBeInt()
+        ->and($timestamp)->toBeInt()
+        ->and((int) $store)->toBeLessThan((int) $timestamp);
+});
+
+it('keeps every signature valid through the refresh', function () {
+    // Two revisions are appended where one used to be, and the invariant is
+    // unchanged: the original bytes survive and nothing already signed moves.
+    $archived = archivedDocument();
+    $extended = app(ArchiveExtender::class)->extend($archived)->contents;
+
+    expect(substr($extended, 0, strlen($archived)))->toBe($archived);
+
+    $report = A1PdfSign::validate($path = tap(A1PdfSign::tempPath(true, '.pdf'), function (string $to) use ($extended) {
+        file_put_contents($to, $extended);
+    }));
+
+    expect($report->isValid())->toBeTrue()
+        ->and($report->timestamps())->toHaveCount(2);
+
+    unlink($path);
+});
+
+it('carries the timestamp authority chain the signer store never had', function () {
+    // Worth having even for a certificate with no responder and no distribution
+    // point, which is what a self-signed one is. The store written at signing
+    // time holds the signer's chain; the authority that stamped the document has
+    // a certificate of its own, and it is the one the *next* archive timestamp
+    // has to be able to check.
+    app()->bind(
+        SignatureTransport::class,
+        fn(): LocalRevocationAuthority => new LocalRevocationAuthority(app(ProcessRunner::class)),
+    );
+
+    [$pfxPath, $password] = debugCertificate();
+
+    $signed = A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdf(resource('test.pdf'))
+        ->profile(SignatureProfile::PadesBLTA)
+        ->sign();
+
+    $before = app(SecurityStoreReader::class)->read($signed->contents)->certificates;
+    $extended = app(ArchiveExtender::class)->extend($signed->contents)->contents;
+    $after = app(SecurityStoreReader::class)->read($extended)->certificates;
+
+    expect($after)->toBeGreaterThan($before);
+});


### PR DESCRIPTION
[0022](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/blob/main/docs/decisions/0022-the-archive-timestamp-is-a-chain.md) built the archive timestamp chain and wrote down what it left undone:

> Nothing refreshes the Document Security Store while extending.

So a document could gain a fifth archive timestamp **over revocation material gathered on the day it was signed**, years earlier. That is the one thing long-term validation exists to prevent.

## The order is the correctness claim

`extend()` now gathers fresh material for every chain the document carries and writes the store **before** the timestamp. ETSI EN 319 142-1 puts the evidence inside the file while it is still verifiable, and has the archive timestamp cover it.

A store appended *after* the timestamp is material the timestamp does not attest, which is worth no more than material sitting outside the file. That ordering is asserted, not assumed.

## Chains, not a pile of certificates

Built per signature with `Validation\ChainBuilder`, because `collectValidationMaterial()` treats each certificate's neighbour as its issuer. **A mixed pile would build an OCSP request against the wrong pair and embed the answer**, which is worse than embedding nothing.

The timestamps' own chains are included deliberately: the authority's certificate is what the *next* archive timestamp has to be able to check, and it expires like any other.

## Two pieces of test machinery, neither a stub of what is under test

- **`DebugCertificate::makeRevocable()`** issues a certificate that names its own distribution point. Without it none of this is reachable offline: `collectValidationMaterial()` reads the endpoints out of the certificate, so one carrying none is never asked about, whatever transport is bound. That is asserted first, as the precondition for everything else.
- **`Testing\LocalRevocationAuthority`** answers with material where `LocalTimestampAuthority` answers false.

Whether that material is *good* stays [0024](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/blob/main/docs/decisions/0024-revocation-is-evaluated-not-counted.md)'s question, with its own fixtures. This gates that the store is written, refreshed and covered.

## Gated

| | |
|---|---|
| material is gathered from the endpoints a certificate names | ✓ |
| extending appends a further store | ✓ |
| the store is written before the timestamp | ✓ |
| every signature survives, byte for byte | ✓ |
| the authority's own chain arrives, even for a signer with no responder | ✓ |

Offline, in the ordinary suite.

## Cost

Extending appends two revisions where it appended one, so the file grows more. Nothing about the earlier bytes changes.

`composer check` green: **478 passing**, PHPStan level max, Pint clean.