### PR TITLE
docs(2.x): document 2.5, and give ICP-Brasil a page of its own

### DIFF
--- a/public/docs/2.x/home.md
+++ b/public/docs/2.x/home.md
@@ -22,4 +22,5 @@ $signed->save('path/to/signed.pdf');
 * [Installation](/docs/2.x/installation)
 * [Usage](/docs/2.x/usage)
 * [Signature profiles](/docs/2.x/signature-profiles)
+* [ICP-Brasil](/docs/2.x/icp-brasil)
 * [Tests](/docs/2.x/tests)

--- a/public/docs/2.x/icp-brasil.md
+++ b/public/docs/2.x/icp-brasil.md
@@ -1,0 +1,79 @@
+#### 1 - Who signed, in the number Brazil knows them by. <small>(since 2.5)</small>
+
+An ICP-Brasil certificate carries its holder's identity in `subjectAlternativeName`, not in the subject. The common name is the person's name with their CPF glued to the end after a colon, and everything structured lives in `otherName` entries under the 2.16.76.1.3 arc.
+
+```PHP
+<?php
+
+use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
+
+$signer = A1PdfSign::validate('path/to/signed.pdf')->signers()[0];
+
+$signer->icpBrasil?->cpf;                 // '11144477735'
+$signer->icpBrasil?->cnpj;                // the company, for an e-CNPJ
+$signer->icpBrasil?->formattedRegistry(); // '11.222.333/0001-81'
+$signer->icpBrasil?->registry();          // the CNPJ when there is one, the CPF otherwise
+
+$signer->name();                          // 'JOAO DA SILVA', without the number
+$signer->commonName;                      // 'JOAO DA SILVA:11144477735', as written
+```
+
+**Before 2.5 the only way to get a CPF out of a certificate was `explode(':', $commonName)`.** That breaks on a name containing a colon, and it is simply wrong for an e-CNPJ: its common name carries the company, while the CPF in the extension belongs to whoever answers for it.
+
+<hr>
+
+#### 2 - Everything the certificate carries.
+
+```PHP
+$identity = $signer->icpBrasil;
+
+$identity?->type;               // IcpBrasilCertificateType: Individual, LegalEntity or None
+$identity?->birthDate;          // '11/08/1985'
+$identity?->socialIdentity;     // NIS: PIS, PASEP or CI
+$identity?->nationalId;         // RG, without the zeros it is padded with
+$identity?->nationalIdIssuer;   // 'SSPSP'
+$identity?->socialSecurity;     // CEI
+$identity?->responsibleName;    // for an e-CNPJ, who answers for the company
+$identity?->voterRegistration;
+$identity?->raw;                // every otherName found, by OID, as written
+```
+
+A field the certificate fills with zeros, which the specification requires when a number is unavailable, comes back as `null`. "Absent" and "eleven zeros" are the same fact, and only one of them is worth handing to a caller.
+
+`type` answers `None` for a certificate that is not ICP-Brasil at all, which is not the same as a malformed one: it never claimed to be.
+
+<hr>
+
+#### 3 - Checking a certificate before you sign with it.
+
+```PHP
+$report = A1PdfSign::icpBrasil('path/to/certificate.pfx', 'password');
+
+$report->conforms();   // bool
+$report->messages();   // list<string>, one line per finding, naming the field
+$report->identity;     // the same IcpBrasilIdentity, parsed
+```
+
+What it checks, all of it stated by the specification about the certificate's own bytes:
+
+| | |
+|---|---|
+| Required fields | three `otherName` entries for an e-CPF, four for an e-CNPJ |
+| Widths | the layout's, with the last field of each allowed to run short |
+| Alphabet | only A to Z and 0 to 9 |
+| Check digits | modulus eleven, for both CPF and CNPJ |
+| Birth date | a real date in `ddmmyyyy` |
+| RG | an issuing authority named for a number that is absent, which the specification calls out |
+| The CPF twice | the common name and the extension carry it separately, and nothing makes them agree |
+
+The value is upstream of a rejection rather than after one: a certificate that fails here will be read wrong by everything downstream, and finding that out from the file beats finding it out from a filing that came back.
+
+> **`conforms()` is not `isTrusted()`.** Every rule above is decidable from the certificate alone, so a self-signed certificate built to satisfy them all will conform. Whether the chain reaches an ICP-Brasil root is a different question, answered by [`TrustStore`](/docs/2.x/validating-signature), and neither answer implies the other.
+
+<hr>
+
+#### 4 - What this does not do.
+
+**It never asks the Receita Federal anything.** A CPF that satisfies its check digits is a well-formed CPF, not a CPF that exists, and whether one was ever issued is a question only the Receita Federal answers. Asking would mean a network request during validation, which nothing in this package makes.
+
+**It does not read the certificate policy.** The OID that says whether a certificate is A1, A3 or A4 is not checked, because that says which *kind* of certificate it is rather than whether it is well formed. It was left out rather than half done.

--- a/public/docs/2.x/release-notes.md
+++ b/public/docs/2.x/release-notes.md
@@ -1,3 +1,83 @@
+# 2.5.0
+
+## A visible seal no longer costs PDF/A conformance
+
+The seal was embedded as `/DeviceRGB`, which PDF/A allows only where the file declares an OutputIntent, so a conformant document came back non-conformant. It now carries its own `/ICCBased` profile and asks the document for nothing.
+
+| | 2.4 | 2.5 |
+|---|---|---|
+| PDF/A-1b, opaque seal | FAIL | **PASS** |
+| PDF/A-1b, transparent seal | FAIL | FAIL, and always will: §6.4 forbids `/SMask` |
+| PDF/A-2b, opaque seal | FAIL | **PASS** |
+| PDF/A-2b, transparent seal | FAIL | **PASS** |
+
+The profile is **built rather than vendored**, from the numbers IEC 61966-2-1 publishes, so no third party's binary and no third party's licence enters an MIT package. Its computed colorants match the published sRGB profile to four decimal places, which is asserted rather than assumed: veraPDF validates the container, not the colours, so a structurally valid profile with the wrong primaries would pass every conformance check and render the seal in the wrong colour.
+
+**A sealed document grows by about 2.4 KB.** An invisible signature embeds nothing and is unchanged.
+
+<hr>
+
+## Who signed, in the number Brazil knows them by
+
+```PHP
+$signer = A1PdfSign::validate($path)->signers()[0];
+
+$signer->icpBrasil?->cpf;                 // '11144477735'
+$signer->icpBrasil?->cnpj;                // the company, for an e-CNPJ
+$signer->icpBrasil?->formattedRegistry(); // '11.222.333/0001-81'
+$signer->name();                          // 'JOAO DA SILVA', without the number
+```
+
+The identity lives in `subjectAlternativeName`, and PHP renders every one of those fields as `othername:<unsupported>`, so until now the only way to get a CPF was `explode(':', $commonName)`. That breaks on a name containing a colon and is wrong for an e-CNPJ, whose common name carries the company while the CPF belongs to whoever answers for it.
+
+`A1PdfSign::icpBrasil()` also checks a certificate against the rules its own specification states, and says which field is wrong before anything is signed. **`conforms()` is not `isTrusted()`**: every rule is decidable from the certificate alone, so a self-signed certificate built to satisfy them will conform.
+
+[ICP-Brasil →](/docs/2.x/icp-brasil)
+
+<hr>
+
+## A document protected by a password can be signed
+
+```PHP
+A1PdfSign::newSignature()
+    ->certificate($pfxPath, $certificatePassword)
+    ->pdf($path, 'the document password')
+    ->sign();
+```
+
+Encrypted documents used to be refused outright, which was correct rather than good: the cross-reference table is not encrypted, so reading gets far enough to look successful while everything around it is unreadable, and a plaintext revision beside it produces a file whose new objects no reader can decrypt.
+
+The standard security handler is implemented for **AES-128 and AES-256**. The document's password and the certificate's are different things and are passed separately: one opens the file, the other unlocks the key that signs it.
+
+**RC4 is refused**, because signing an RC4 document means writing RC4 back into it, and this package will not weaken a file in order to sign it. Also refused, each with a message naming why: a non-standard security handler, an encrypted document packed into object streams, and `pades-b-lt` and above while encrypted.
+
+Verified against qpdf in both directions: the fixtures are qpdf's output, and qpdf reads the signed result back.
+
+<hr>
+
+## Extending an archive refreshes the evidence it archives
+
+`extendArchive()` used to append the timestamp and nothing else, so a document could gain a fifth archive timestamp over revocation material gathered on the day it was signed. That is the one thing long-term validation exists to prevent.
+
+It now gathers fresh material for every chain the document carries and writes the store **before** the timestamp, which is the order ETSI EN 319 142-1 fixes: the evidence goes inside the file while it is still verifiable, and the timestamp then covers it. The timestamp authorities' own certificates are included, because they are what the next archive timestamp has to be able to check.
+
+<hr>
+
+## Also
+
+- **`SECURITY.md`**, saying what counts as a vulnerability and, more usefully, what looks like one and is a documented decision.
+- The README was rewritten. It had never mentioned reading a CPF, signing an encrypted document, field locks or extending an archive.
+- Two docblock rules are now executable, after four stacked docblocks turned up across the package, one of them describing `latest()` while sitting above `timestamps()`.
+- `main` is built after a merge. A pull request is tested against its own branch, not against main with it merged, and two branches that are each green can produce a main that is not.
+
+<hr>
+
+## Upgrading
+
+No public class was removed and no signature was narrowed. `Contracts\A1PdfSign` gained `icpBrasil()` and `Contracts\PdfSigner::sign()` gained a document password argument, both of which matter only to someone implementing those interfaces. `Data\Signer` gained `$icpBrasil` and `name()`, appended with defaults.
+
+**The bytes of every sealed document change**, because the seal's colour space did.
+
 # 2.4.0
 
 ## Validation reads what signing writes

--- a/public/docs/2.x/sign-pdf-file.md
+++ b/public/docs/2.x/sign-pdf-file.md
@@ -177,6 +177,8 @@ $signed = A1PdfSign::newSignature()
 
 **A seal with an alpha channel stays transparent since 2.4**, where before it was flattened onto white. It costs more bytes, because PDF has no PNG filter and the alpha travels as a separate `/SMask` image, and **it makes PDF/A-1 impossible**: §6.4 forbids `/SMask` outright. `'transparent' => false` in the config is the lever, and that is the whole reason the setting exists.
 
+**Since 2.5 a seal no longer costs PDF/A conformance otherwise.** It was embedded as `/DeviceRGB`, which PDF/A allows only where the file declares an OutputIntent, and it now carries its own `/ICCBased` sRGB profile instead, so it asks the document for nothing. A sealed document grows by about 2.4 KB; an invisible signature embeds nothing. PDF/A-1 with a *transparent* seal remains impossible, for the `/SMask` reason above.
+
 **The page is counted from one, in the order the page tree declares.** `SealPlacement::LAST_PAGE` is the default, so a placement that names no page puts the seal on the last one. A page the document does not have raises `SealPlacementException` rather than being clamped to the nearest one: a seal asked for on page 7 of a three-page contract is a mistake, and putting it on page 3 would look deliberate.
 
 > **Fixed in 2.3.1.** Before that release `page` and `onEveryPage` were both ignored and every seal landed on the first page. If you signed multi-page documents with 2.3.0 or earlier and want the seal to stay on page 1, pass `page: 1` explicitly.
@@ -361,3 +363,35 @@ $extended = A1PdfSign::extendArchive('path/to/archived.pdf');
 **No certificate, no key, no password.** A DocTimeStamp is signed by the timestamp authority rather than by the signer, so extending a `pades-b-lta` archive is something a scheduled job can do with no key material anywhere near it.
 
 An archive timestamp is a chain, not a state. Each new one covers the whole file including the previous timestamp, so the evidence can be renewed before the algorithms behind the older links weaken. It needs the same authority configured as `pades-b-t` and above.
+
+<hr>
+
+#### 12 - Signing a document protected by a password. <small>(since 2.5)</small>
+
+```PHP
+<?php
+
+use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
+
+A1PdfSign::newSignature()
+    ->certificate($pfxPath, $certificatePassword)
+    ->pdf('path/to/protected.pdf', 'the document password')
+    ->sign();
+```
+
+**The document's password and the certificate's are different things**, which is why they are passed separately: one opens the file, the other unlocks the key that signs it. Both are marked sensitive, so neither appears in a stack trace.
+
+The signed revision is encrypted under the document's own key, so the file stays consistent: everything written is encrypted except the signature's `/Contents`, which ISO 32000-1 §7.6.2 excludes because it is the signature over the bytes rather than content of the document.
+
+Encrypted documents were refused until 2.5, and the refusal was correct rather than good: the cross-reference table is not encrypted, so reading gets far enough to look successful while everything around it is unreadable, and a plaintext revision written beside it produces a file whose new objects no reader can decrypt.
+
+> **A wrong password is refused rather than used.** Deriving a key from it would produce noise, and noise appended beside a document is exactly the silent corruption the old refusal existed to prevent.
+
+**AES-128 and AES-256 only.** Four things are still refused, each saying why:
+
+| | |
+|---|---|
+| RC4 | Signing means writing RC4 back into the document, and this package will not weaken a file to sign it |
+| A non-standard security handler | Its key comes from somewhere this package cannot reach |
+| An encrypted document packed into object streams | Reachable, not implemented |
+| `pades-b-lt` and above, while encrypted | They append streams this does not encrypt |

--- a/public/docs/2.x/signature-profiles.md
+++ b/public/docs/2.x/signature-profiles.md
@@ -66,6 +66,8 @@ An archive timestamp is a **chain, not a state**. Each new one covers the whole 
 
 No certificate is involved: a DocTimeStamp is signed by the authority, not by the signer, so this is something a scheduled job can do to an archive with no key material anywhere near it.
 
+**Since 2.5 it refreshes the evidence as well as the chain.** Extending used to append the timestamp alone, so a document could gain a fifth archive timestamp over revocation material gathered on the day it was signed, which is the one thing long-term validation exists to prevent. Fresh material is now gathered for every chain the document carries and written **before** the timestamp, which is the order ETSI EN 319 142-1 fixes: the evidence goes inside the file while it is still verifiable, and the timestamp then covers it. The timestamp authorities' own certificates are included, since they are what the *next* archive timestamp has to be able to check.
+
 <hr>
 
 ## What happens when the material is unavailable

--- a/public/docs/2.x/validating-signature.md
+++ b/public/docs/2.x/validating-signature.md
@@ -227,7 +227,20 @@ OpenSSL does the path validation, so each intermediate's validity window, `basic
 
 <hr>
 
-#### 11 - What validation still does not do.
+#### 11 - Who signed, under ICP-Brasil. <small>(since 2.5)</small>
+
+```PHP
+$signer = $report->signers()[0];
+
+$signer->icpBrasil?->cpf;   // '11144477735'
+$signer->name();            // the name, without the number glued to it
+```
+
+A Brazilian certificate carries its holder's identity in `subjectAlternativeName` rather than in the subject, and it has its own page: [ICP-Brasil](/docs/2.x/icp-brasil).
+
+<hr>
+
+#### 12 - What validation still does not do.
 
 **It never goes to the network.** Revocation is evaluated since 2.4, but only from the material the document already carries. A signature whose certificate was revoked *after* signing, with no OCSP response in the file saying so, reports `Unknown`: the answer is somewhere on the internet, and fetching it is the host application's decision rather than the validator's.
 
@@ -235,7 +248,7 @@ That is the same rule as everywhere else here. Signing reaches an authority beca
 
 <hr>
 
-#### 12 - Verifying independently.
+#### 13 - Verifying independently.
 
 Our validator shares its assumptions with the code that produced the signature, so it is worth checking against something that does not. Poppler's `pdfsig` has caught bugs in this package that the whole test suite passed straight through:
 

--- a/src/documentationLinks/v2x.ts
+++ b/src/documentationLinks/v2x.ts
@@ -72,6 +72,14 @@ export default <Doc>{
                     url: "validating-signature",
                     footerActions: {
                         previousLink: "signature-profiles",
+                        nextLink: "icp-brasil",
+                    },
+                },
+                {
+                    title: "ICP-Brasil",
+                    url: "icp-brasil",
+                    footerActions: {
+                        previousLink: "validating-signature",
                         nextLink: "commands",
                     },
                 },
@@ -86,7 +94,7 @@ export default <Doc>{
             url: "commands",
             icon: "fa-terminal",
             footerActions: {
-                previousLink: "validating-signature",
+                previousLink: "icp-brasil",
                 nextLink: "not-laravel-or-lumen",
             },
         },


### PR DESCRIPTION
The 2.5.0 entry, plus the reference pages the release touches.

## A page of its own for ICP-Brasil

Rather than a section, for two reasons. It is the capability this package's audience needs most, and the thing that is dangerous to get wrong about it needs room:

> **`conforms()` is not `isTrusted()`.** Every rule is decidable from the certificate alone, so a self-signed certificate built to satisfy them all will conform.

That appears as a callout and again under "what this does not do", alongside the two other limits worth stating: it never asks the Receita Federal whether a CPF exists, and it does not read the certificate policy OID.

Added to the sidebar between "Validating signature" and "Commands", with the previous/next chain rewired on both neighbours, and to the home page's fast links.

## Updated pages

| | |
|---|---|
| `release-notes` | the 2.5.0 entry |
| `sign-pdf-file` | signing a password-protected document, and the correction that a seal no longer costs PDF/A conformance |
| `signature-profiles` | extending an archive now refreshes the evidence, with the ordering ETSI fixes and why it is the ordering rather than a detail |
| `validating-signature` | a short ICP-Brasil section pointing at the new page, sections renumbered |
| `home` | the new page in the fast links |

Markdown and one TypeScript nav file. **Nothing here describes unreleased behaviour**: this merges alongside the 2.5.0 tag, which is the rule the contributing guide now states, because the site describes what is installable.