### PR TITLE
Set the mutation floors from what the nightly actually measured

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -104,25 +104,34 @@ jobs:
         # scores 64.71% with 8 uncovered, while shard 1/2 reports 61.76% with
         # 26 uncovered and shard 2/2 reports 69.12%. Faster, and wrong.
         #
-        # Each floor sits below the lowest of two consecutive measurements of
-        # that namespace, because the score is not reproducible to the point:
-        # it tracks how many mutations time out, which tracks machine load.
-        # Certificates swings the most (~20 timeouts out of 68); Validation
-        # does not move at all (2 timeouts), so its floor can sit close.
+        # Each floor sits a few points below the lowest measurement of that
+        # namespace, because the score is not reproducible to the point: it
+        # tracks how many mutations time out, which tracks machine load.
+        #
+        # Measurements below are the nightly runs of 2026-08-09 through
+        # 2026-08-12, read from the logs rather than remembered. Every one of
+        # them is higher than the pair each floor was originally set from, so
+        # the floors were sitting six to twelve points low and had stopped
+        # being able to fail.
         include:
-          - namespace: Certificates   # measured 64.71% / 61.76%
-            min: 58
-          - namespace: Signing        # measured 66.02% / 67.50%
-            min: 62
-          - namespace: Validation     # measured 77.68% / 77.68% / 78.95%
+          - namespace: Certificates   # 68.13 / 68.13 / 68.13 / 73.48
+            min: 64
+          - namespace: Signing        # 70.05 / 70.02 / 72.75 / 73.98
+            min: 66
+          # Left where it is. The lowest observation, 75.19, clears this floor
+          # by 0.19, which is the tightest margin here by an order of
+          # magnitude. Raising it would be indefensible and lowering it is what
+          # the rule in docs/spec/quality-policy.md forbids, so it stays and
+          # the margin is written down instead of discovered on a red night.
+          - namespace: Validation     # 75.19 / 76.74 / 78.95 / 79.50
             min: 75
           # Added when two helpers moved here out of Signing and Validation,
           # which quietly took them out of the gate they had been under. The
-          # floor is provisional: one measurement, not the two the rule above
-          # asks for, so it sits well below rather than close. Tighten it after
-          # the second nightly run, not before.
-          - namespace: Support        # measured 83.44%, one run only
-            min: 65
+          # floor was provisional at 65, from a single measurement of 83.44%.
+          # Two consecutive runs have since scored lower than that one, which
+          # is exactly why the rule asks for two.
+          - namespace: Support        # 78.26 / 79.26
+            min: 74
 
     steps:
       - name: Checkout

--- a/docs/spec/quality-policy.md
+++ b/docs/spec/quality-policy.md
@@ -43,27 +43,42 @@ defects.
 
 ## Mutation testing
 
-Covers `src/Certificates`, `src/Signing` and `src/Validation`, the three
-namespaces where a test that only asserts "it did not throw" would keep passing
-with broken cryptography.
+Covers `src/Certificates`, `src/Signing`, `src/Validation` and `src/Support`,
+the namespaces where a test that only asserts "it did not throw" would keep
+passing with broken cryptography.
 
 **It runs nightly, not on pull requests** (`.github/workflows/mutation.yml`),
-one runner per namespace, each with its own floor:
+one runner per namespace, each with its own floor. Measured on the nightly runs
+of 2026-08-09 through 2026-08-12, read from the job logs:
 
-| Namespace | Measured | Floor |
-|---|---|---|
-| `src/Certificates` | 64.71% / 61.76% | 58 |
-| `src/Signing` | 66.02% / 67.50% | 62 |
-| `src/Validation` | 77.68% / 77.68% | 75 |
+| Namespace | Measured | Lowest | Floor | Margin |
+|---|---|---|---|---|
+| `src/Certificates` | 68.13 / 68.13 / 68.13 / 73.48 | 68.13 | 64 | 4.13 |
+| `src/Signing` | 70.05 / 70.02 / 72.75 / 73.98 | 70.02 | 66 | 4.02 |
+| `src/Validation` | 75.19 / 76.74 / 78.95 / 79.50 | 75.19 | 75 | **0.19** |
+| `src/Support` | 78.26 / 79.26 | 78.26 | 74 | 4.26 |
+
+`src/Validation` is the one to watch. Its floor was set when the namespace was
+believed not to move, and the run of 2026-08-09 cleared it by less than a fifth
+of a point. It is not raised, because nothing here justifies raising it, and it
+is not lowered, because that is what the second rule below forbids. It is
+written down so the night it fires is not the night somebody first learns the
+margin was that thin.
 
 Three rules govern this, and each cost something to learn:
 
 **The score is not reproducible.** It tracks how many mutations time out, which
 tracks machine load. A mutation that breaks a loop condition burns the full
 timeout, which the plugin derives from the suite duration and does not expose as
-an option. `Certificates` shells out to `openssl` and swings three points
-between identical runs; `Validation` times out twice and does not move at all.
-Every floor therefore sits below the lowest observed value for its namespace.
+an option. Every floor therefore sits below the lowest observed value for its
+namespace.
+
+*Which namespace moves is not stable either.* This document used to say that
+`Certificates` swings three points between identical runs while `Validation`
+does not move at all. Four consecutive nights say the opposite: `Certificates`
+scored 68.13 three times running, and `Validation` covered a 4.31-point range.
+The claim was true when it was measured and was left standing after it stopped
+being true, which is the failure this table exists to prevent.
 
 **Raise a floor only after measuring it.** Never set a target ahead of the
 measurement, and never lower one to make a run pass.
@@ -309,10 +324,14 @@ came out of `Signing` the same way. Extracting them removed real duplication and
 **silently took the code out of the gate it had been under**, since the nightly
 matrix names namespaces rather than following the code.
 
-The floor is provisional. One measurement, 83.44%, where the rule above asks for
-two consecutive ones, so it sits at 65 rather than close. Tighten it after the
-second nightly run, and not before: a floor set from one measurement of a score
-that moves with machine load is a floor that fails a night when nothing changed.
+The floor was provisional at 65, set from a single measurement of 83.44% where
+the rule above asks for two consecutive ones. The runs since have measured
+78.26% and 79.26%, so the floor is now 74, four points below the lower of them.
+
+**Both of those are below the measurement the provisional floor was set from**,
+which is the case for asking for two. Had 65 been tightened to "close" against
+83.44% on the strength of one run, the nightly would have failed twice on code
+nobody had touched.
 
 ## Why the backward compatibility check reports rather than blocks
 


### PR DESCRIPTION
Closes #256.

## What changed

| Namespace | Measured, 2026-08-09 to 08-12 | Lowest | Floor was | Floor is |
|---|---|---|---|---|
| `Certificates` | 68.13 / 68.13 / 68.13 / 73.48 | 68.13 | 58 | **64** |
| `Signing` | 70.05 / 70.02 / 72.75 / 73.98 | 70.02 | 62 | **66** |
| `Validation` | 75.19 / 76.74 / 78.95 / 79.50 | 75.19 | 75 | 75 |
| `Support` | 78.26 / 79.26 | 78.26 | 65 | **74** |

Scores read from the job logs of runs 31567276553, 31460851557, 31359095027 and 31327720068, not from memory.

## The issue asked about Support, and the numbers said more

**Support** is what #256 was about, and the answer is 74. Worth noting why the rule was right: both new measurements, 78.26 and 79.26, are **below** the 83.44 the provisional floor was set from. A floor tightened to sit close against that single run would have failed twice on code nobody had touched.

**Certificates and Signing** were sitting six to twelve points below their lowest recent score. A floor that far under has stopped being able to fail, so they move up to four points below the lowest, which is how every floor here was set.

**Validation needs a decision that is not mine to make.** Its lowest observation, 75.19, clears the floor of 75 by **0.19**, the tightest margin here by an order of magnitude. I left it alone: raising it is unjustified, and lowering it is precisely what `quality-policy.md` forbids. The margin is now written into the table and into the workflow comment, so the night it fires is not the night somebody first discovers it was that thin. If you would rather move it to ~71 and record why, that is a one-line follow-up.

## One claim removed

The document said `Certificates` swings three points between identical runs while `Validation` does not move at all. Four consecutive nights say the opposite: `Certificates` scored 68.13 three times running, and `Validation` covered a 4.31-point range. It was true when it was measured and was left standing after it stopped being true, which is the failure the table exists to prevent.

## Checks

`composer check` passes in the 8.4 image: 493 tests, 3356 assertions.