### PR TITLE
Write the signature metadata as a PDF text string

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -10,12 +10,18 @@ return (new Configuration())
 
     /*
      * Extensions are used through the libraries that wrap them: gd by
-     * Intervention, fileinfo by UploadedFile, mbstring by Laravel's string
-     * handling, so no direct symbol reference exists to detect. They stay
-     * declared because a host missing them fails at runtime.
+     * Intervention, fileinfo by UploadedFile, so no direct symbol reference
+     * exists to detect. They stay declared because a host missing them fails at
+     * runtime.
+     *
+     * ext-mbstring is no longer among them. It used to be here for the same
+     * reason, Laravel's string handling, and Signing\Encryption\ObjectCipher
+     * now calls mb_convert_encoding() directly to write a text string as
+     * UTF-16BE, so the reference is real and the ignore was reported as never
+     * applied. Which is the analyser doing its job in the other direction.
      */
     ->ignoreErrorsOnExtensions(
-        ['ext-fileinfo', 'ext-gd', 'ext-mbstring'],
+        ['ext-fileinfo', 'ext-gd'],
         [ErrorType::UNUSED_DEPENDENCY],
     )
 

--- a/src/Signing/Encryption/ObjectCipher.php
+++ b/src/Signing/Encryption/ObjectCipher.php
@@ -44,11 +44,45 @@ final readonly class ObjectCipher
      */
     public function text(string $value, int $object): string
     {
+        $encoded = self::textString($value);
+
         if ($this->security === null) {
-            return '(' . str_replace(['\\', '(', ')'], ['\\\\', '\\(', '\\)'], $value) . ')';
+            // Hex for anything that had to be re-encoded, for the same reason
+            // ciphertext is written in hex: UTF-16BE produces 0x28 and 0x29 in
+            // the middle of characters, and escaping them would be escaping
+            // half a character.
+            return $encoded === $value
+                ? '(' . str_replace(['\\', '(', ')'], ['\\\\', '\\(', '\\)'], $value) . ')'
+                : '<' . bin2hex($encoded) . '>';
         }
 
-        return '<' . bin2hex($this->security->encrypt($value, $object)) . '>';
+        // Encoded before encryption, not after. A reader decrypts and then
+        // interprets the plaintext as a text string, so the byte order mark has
+        // to be inside the ciphertext.
+        return '<' . bin2hex($this->security->encrypt($encoded, $object)) . '>';
+    }
+
+    /**
+     * The bytes of a PDF text string.
+     *
+     * *ISO 32000-1 §7.9.2.2, Table 35: a text string is PDFDocEncoding, or
+     * UTF-16BE with a leading byte order mark.* Raw UTF-8 is neither, and it
+     * was what this package wrote. A conforming reader finds no mark, decodes
+     * as PDFDocEncoding, and shows the two bytes of `ã` as two characters:
+     * `João` displayed as `JoÃ£o` for anybody signing in Portuguese, in a file
+     * that verified perfectly.
+     *
+     * ASCII is PDFDocEncoding byte for byte, so it stays a literal and the
+     * output for a document with an unaccented signer is unchanged. Everything
+     * else is converted, which is the only branch that costs anything.
+     */
+    private static function textString(string $value): string
+    {
+        if (preg_match('/^[\x09\x0A\x0D\x20-\x7E]*$/', $value) === 1) {
+            return $value;
+        }
+
+        return "\xFE\xFF" . mb_convert_encoding($value, 'UTF-16BE', 'UTF-8');
     }
 
     /**

--- a/tests/SignatureMetadataTest.php
+++ b/tests/SignatureMetadataTest.php
@@ -1,0 +1,144 @@
+<?php
+
+use LSNepomuceno\LaravelA1PdfSign\Contracts\SignatureValidator;
+use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
+
+/**
+ * What the signature dictionary says about the signer, and how it says it.
+ *
+ * *ISO 32000-1 §7.9.2.2, Table 35: a text string is PDFDocEncoding, or UTF-16BE
+ * with a leading byte order mark.* Raw UTF-8 is neither, and it was what this
+ * package wrote: the file verified, and a conforming reader displayed `João` as
+ * `JoÃ£o` because it decoded the two bytes of `ã` as two PDFDocEncoding
+ * characters.
+ *
+ * Nothing caught it because every assertion here used to be about the
+ * signature verifying, and it did. The metadata was wrong in a document that
+ * was correct.
+ */
+
+/**
+ * Signs `test.pdf` with the given metadata and hands back the bytes.
+ */
+function signedWithInfo(string $name, string $reason = 'Contract'): string
+{
+    [$pfxPath, $password] = debugCertificate();
+
+    return A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdf(resource('test.pdf'))
+        ->info(name: $name, reason: $reason)
+        ->sign()
+        ->contents;
+}
+
+/**
+ * The value of a key in the signature dictionary, decoded from whichever of the
+ * two forms it was written in.
+ */
+function metadataValue(string $pdf, string $key): ?string
+{
+    if (preg_match('/\/' . $key . '\s*<([0-9A-Fa-f]+)>/', $pdf, $hex) === 1) {
+        $raw = (string) hex2bin($hex[1]);
+
+        return str_starts_with($raw, "\xFE\xFF")
+            ? (string) mb_convert_encoding(substr($raw, 2), 'UTF-8', 'UTF-16BE')
+            : $raw;
+    }
+
+    if (preg_match('/\/' . $key . '\s*\((.*?)(?<!\\\\)\)/s', $pdf, $literal) === 1) {
+        return str_replace(['\\(', '\\)', '\\\\'], ['(', ')', '\\'], $literal[1]);
+    }
+
+    return null;
+}
+
+it('writes an ASCII name as a literal, unchanged', function () {
+    // The output for an unaccented signer must not move. Every committed
+    // sample, and every PDF/A verdict measured against them, was produced this
+    // way.
+    $signed = signedWithInfo('Lucas Nepomuceno');
+
+    expect($signed)->toContain('/Name (Lucas Nepomuceno)')
+        ->and(metadataValue($signed, 'Name'))->toBe('Lucas Nepomuceno');
+});
+
+it('still escapes the characters that would end the string early', function () {
+    // The escaping was already right, and is the part this class of bug is
+    // usually reported as. It has to survive the encoding change.
+    $signed = signedWithInfo('Silva (Jr) \\ Co');
+
+    expect($signed)->toContain('/Name (Silva \(Jr\) \\\\ Co)')
+        ->and(metadataValue($signed, 'Name'))->toBe('Silva (Jr) \\ Co');
+});
+
+it('writes a name outside PDFDocEncoding as UTF-16BE with a byte order mark', function (string $name) {
+    $signed = signedWithInfo($name);
+
+    // Case-insensitive: a PDF hex string is, and bin2hex() writes lowercase.
+    expect($signed)->toMatch('/\/Name\s*<feff[0-9a-f]+>/i')
+        ->and(metadataValue($signed, 'Name'))->toBe($name);
+})->with([
+    'accents' => 'João da Silva Áureo',
+    'emoji' => 'Lucas 🎉',
+    'cyrillic' => 'Лукас Непомусено',
+    'both, with the characters that need escaping' => 'João (Jr) \\ 🎉',
+]);
+
+it('encodes before escaping, so a character whose bytes look like a delimiter survives', function () {
+    // U+0128 is 01 28 in UTF-16BE, and 0x28 is '('. Escaping the encoded bytes
+    // as if they were text would split the character in half. Writing the whole
+    // string in hex is what makes the question not arise.
+    $signed = signedWithInfo("Ĩ");
+
+    expect(metadataValue($signed, 'Name'))->toBe("Ĩ");
+});
+
+it('applies the same encoding to every metadata key, not only the name', function () {
+    [$pfxPath, $password] = debugCertificate();
+
+    $signed = A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdf(resource('test.pdf'))
+        ->info(
+            name: 'João',
+            location: 'São Paulo',
+            reason: 'Aprovação do contrato',
+            contactInfo: 'joão@example.com',
+        )
+        ->sign()
+        ->contents;
+
+    expect(metadataValue($signed, 'Name'))->toBe('João')
+        ->and(metadataValue($signed, 'Location'))->toBe('São Paulo')
+        ->and(metadataValue($signed, 'Reason'))->toBe('Aprovação do contrato')
+        ->and(metadataValue($signed, 'ContactInfo'))->toBe('joão@example.com');
+});
+
+it('keeps the signature valid whatever the metadata says', function () {
+    // The metadata sits inside the range the signature covers, so an encoding
+    // change is a change to signed bytes: getting it wrong breaks verification
+    // rather than only display.
+    $signed = signedWithInfo('João da Silva 🎉', "Contrato (importante)");
+
+    expect(app(SignatureValidator::class)->validate($signed)->isValid())->toBeTrue();
+});
+
+it('encodes before encrypting, so the mark ends up inside the ciphertext', function () {
+    // A reader decrypts and then interprets the plaintext as a text string. A
+    // byte order mark added after encryption would be a mark over ciphertext,
+    // which decodes to nothing anybody can read.
+    [$pfxPath, $password] = debugCertificate();
+
+    $signed = A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdf(resource('encrypted-aes256.pdf'), 'secret')
+        ->info(name: 'João da Silva')
+        ->sign()
+        ->contents;
+
+    // Encrypted strings are hex either way, so the assertion is that the
+    // document still verifies and that no raw UTF-8 leaked out beside it.
+    expect(app(SignatureValidator::class)->validate($signed)->isValid())->toBeTrue()
+        ->and($signed)->not->toContain('/Name (João');
+});


### PR DESCRIPTION
Closes #277.

## The defect

`/Name`, `/Reason`, `/Location` and `/ContactInfo` are **text strings** (ISO 32000-1 §7.9.2.2, Table 35), and a text string is PDFDocEncoding or UTF-16BE with a byte order mark. The package wrote raw UTF-8, which is neither.

A conforming reader finds no mark, decodes as PDFDocEncoding, and the two bytes of `ã` become two characters. **`João` displays as `JoÃ£o`**, in a document that verifies perfectly.

Anyone signing in Portuguese hit this on the first accented name.

## Why nothing caught it

Every assertion about metadata was ultimately "the signature verifies", and it did. The bytes were signed, covered, and wrong. This is the same shape as the `/ByteRange` defect in #262: the suite only ever saw output it had produced itself, and agreed with it.

## What changed

| Input | Before | After |
|---|---|---|
| `Lucas Nepomuceno` | `/Name (Lucas Nepomuceno)` | unchanged |
| `Silva (Jr) \ Co` | `/Name (Silva \(Jr\) \\ Co)` | unchanged |
| `João da Silva 🎉` | `/Name (João da Silva 🎉)`, raw UTF-8 | `/Name <feff004a006f00e30…>` |

**ASCII output does not move**, which matters more than it sounds: every committed sample, and every PDF/A verdict measured against them, was produced through this path.

The escaping was already correct and is untouched. That is the part this class of bug is usually reported as, and it was never broken here.

## The trap, avoided rather than handled

UTF-16BE produces `0x28` and `0x29`, `(` and `)`, **inside** characters: `Ĩ` is `01 28`. Escaping encoded bytes as if they were text splits a character in half. Writing the whole string in hex is what makes the question not arise, which is the same reasoning already used for encrypted strings.

For an encrypted document the encoding happens **before** encryption, since a reader decrypts and then interprets the plaintext as a text string.

## Where the fix lives

`Signing\Encryption\ObjectCipher::text()`, the single place a text string is written, so every key is covered by one change rather than four.

## Also

`ext-mbstring` leaves the dependency analyser's ignore list. It was ignored as "used by Laravel's string handling, no direct reference to detect", and `mb_convert_encoding()` is now a direct reference. The analyser reported the stale ignore, which is it working in the other direction.

## Checks

`composer check` passes in the 8.4 image: 520 tests, 3411 assertions. Ten new tests in `tests/SignatureMetadataTest.php`, including accents, emoji, Cyrillic, a character whose UTF-16BE bytes look like a delimiter, and the encrypted path.