### PR TITLE
Stop reporting an unusable environment as an invalid signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,12 @@ composer require lsnepomuceno/laravel-a1-pdf-sign
 ```
 
 Nothing else to register: the service provider is discovered, and the `A1PdfSign` facade is available immediately.
+
 `openssl` on `PATH` is **not** required to sign; it is used only for verifying a signature and for reading a legacy
-PFX file.
+PFX file. Where it is needed it is needed properly: **`ext-openssl` being loaded is a different thing from the binary
+being installed**, and a minimal container commonly has the first without the second. Validating without it raises
+`MissingBinaryException`, and an environment where `proc_open` is disabled raises `ProcessUnavailableException`.
+Neither is reported as a signature that failed to verify.
 
 ```bash
 php artisan vendor:publish --tag=a1-pdf-sign-config

--- a/src/Exceptions/MissingBinaryException.php
+++ b/src/Exceptions/MissingBinaryException.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Exceptions;
+
+use Exception;
+
+/**
+ * A binary the package needs is not on the PATH.
+ *
+ * In practice this is `openssl`, and the distinction that matters is that
+ * `ext-openssl` being loaded says nothing about the binary being installed:
+ * they are different things, and a minimal container commonly has the first
+ * without the second.
+ *
+ * Raised rather than absorbed for the reason in ProcessUnavailableException:
+ * absorbing it made a valid signature report as invalid.
+ */
+final class MissingBinaryException extends Exception
+{
+    public function __construct(public readonly string $binary)
+    {
+        parent::__construct(
+            "The '{$binary}' binary was not found on the PATH. Signature validation shells out to it, so "
+            . 'it has to be installed even where ext-openssl is already loaded: the extension and the '
+            . 'command-line tool are separate things.',
+        );
+    }
+}

--- a/src/Exceptions/ProcessUnavailableException.php
+++ b/src/Exceptions/ProcessUnavailableException.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Exceptions;
+
+use Exception;
+
+/**
+ * PHP cannot spawn a child process at all.
+ *
+ * `proc_open` is routinely listed in `disable_functions` on shared hosting, and
+ * is absent or restricted on some serverless runtimes. Validation needs it,
+ * because the CMS verdict comes from the `openssl` binary
+ * (docs/decisions/0001-openssl-native-with-cli-fallback.md).
+ *
+ * It is raised rather than absorbed because the alternative was worse than an
+ * error: `Validation\SignatureVerifier` caught everything and returned false,
+ * so a perfectly valid signature was reported as **invalid**, with no exception
+ * and nothing in a log. A caller cannot tell that apart from a tampered
+ * document, and the natural response is to reject something legitimate.
+ */
+final class ProcessUnavailableException extends Exception
+{
+    public function __construct(string $function = 'proc_open')
+    {
+        parent::__construct(
+            "PHP cannot start a child process: {$function}() is unavailable, which usually means it is "
+            . 'listed in disable_functions. Signature validation needs the openssl binary, so it cannot '
+            . 'run in this environment.',
+        );
+    }
+}

--- a/src/Support/ProcessRunner.php
+++ b/src/Support/ProcessRunner.php
@@ -3,7 +3,10 @@
 namespace LSNepomuceno\LaravelA1PdfSign\Support;
 
 use Illuminate\Process\Factory;
-use LSNepomuceno\LaravelA1PdfSign\Exceptions\ProcessRunTimeException;
+use LogicException;
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\{MissingBinaryException,
+    ProcessRunTimeException,
+    ProcessUnavailableException};
 
 /**
  * The package's single point of shell-out.
@@ -17,27 +20,126 @@ use LSNepomuceno\LaravelA1PdfSign\Exceptions\ProcessRunTimeException;
  * directly: the behaviour is identical (the factory builds the same object)
  * but a host application can fake it in its own tests, which is impossible
  * when the class is instantiated inline.
+ *
+ * **Being unable to run is not the same as running and failing**, and this is
+ * the only place that can tell them apart. Downstream, `SignatureVerifier`
+ * reads a non-zero exit as "this signature does not verify", which is correct
+ * for a real verdict and catastrophic for an environment problem: a missing
+ * binary used to make every signature report as invalid, silently. So the two
+ * conditions that mean "no verdict was reached" raise their own exceptions
+ * before the command is ever built.
  */
 final readonly class ProcessRunner
 {
     public function __construct(private Factory $factory) {}
 
     /**
-     * @throws ProcessRunTimeException
+     * @throws ProcessRunTimeException When the command ran and failed, which is
+     *                                 a result.
+     * @throws ProcessUnavailableException When PHP cannot start a process.
+     * @throws MissingBinaryException When the command's binary is not on PATH.
      */
     public function run(string $command, bool $usePathEnv = false): string
     {
-        // newPendingProcess() rather than the factory's __call proxy, which
-        // static analysis cannot follow.
-        $result = $this->factory
-            ->newPendingProcess()
-            ->env($usePathEnv ? ['PATH' => (string) getenv('PATH')] : [])
-            ->run($command);
+        $this->guardProcessesAreAvailable();
+        $this->guardBinaryExists($command);
+
+        try {
+            // newPendingProcess() rather than the factory's __call proxy, which
+            // static analysis cannot follow.
+            $result = $this->factory
+                ->newPendingProcess()
+                ->env($usePathEnv ? ['PATH' => (string) getenv('PATH')] : [])
+                ->run($command);
+        } catch (LogicException $exception) {
+            // Symfony's Process raises a bare LogicException when proc_open is
+            // missing. The guard above catches the common form of that; this
+            // catches the platforms where the function exists and the process
+            // layer still refuses, and stops it arriving as an exception from
+            // somebody else's namespace.
+            if (str_contains($exception->getMessage(), 'proc_open')) {
+                throw new ProcessUnavailableException();
+            }
+
+            throw $exception;
+        }
 
         if ($result->failed()) {
             throw new ProcessRunTimeException($result->errorOutput());
         }
 
         return $result->output();
+    }
+
+    /**
+     * @throws ProcessUnavailableException
+     */
+    private function guardProcessesAreAvailable(): void
+    {
+        // function_exists() returns false for a function in disable_functions,
+        // which is exactly the case worth naming.
+        if (! function_exists('proc_open')) {
+            throw new ProcessUnavailableException();
+        }
+    }
+
+    /**
+     * @throws MissingBinaryException
+     */
+    private function guardBinaryExists(string $command): void
+    {
+        // A faked factory runs nothing, so whether the binary exists is not a
+        // question about the host and asking it would defeat Process::fake(),
+        // which this class exists to keep working.
+        if ($this->factory->isRecording()) {
+            return;
+        }
+
+        $binary = $this->binaryOf($command);
+
+        // A command built by this package always begins with a bare program
+        // name. Anything else, a path or an empty string, is left to the
+        // process layer rather than guessed at here.
+        if ($binary === null) {
+            return;
+        }
+
+        foreach (explode(PATH_SEPARATOR, $this->searchPath()) as $directory) {
+            if ($directory !== '' && is_executable(rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $binary)) {
+                return;
+            }
+        }
+
+        throw new MissingBinaryException($binary);
+    }
+
+    /**
+     * The program a command invokes, or null when it is not a bare name.
+     */
+    private function binaryOf(string $command): ?string
+    {
+        $first = strtok(trim($command), " \t");
+
+        if ($first === false || str_contains($first, DIRECTORY_SEPARATOR)) {
+            return null;
+        }
+
+        return $first;
+    }
+
+    /**
+     * Where to look for a program.
+     *
+     * $usePathEnv changes what the child process is given, not where the
+     * program is found, so both cases search the same list.
+     */
+    private function searchPath(): string
+    {
+        $path = (string) getenv('PATH');
+
+        // A PATH-less environment is not a missing binary, and treating it as
+        // one would raise on a host where the process layer would have found
+        // the program anyway.
+        return $path === '' ? '/usr/local/bin' . PATH_SEPARATOR . '/usr/bin' . PATH_SEPARATOR . '/bin' : $path;
     }
 }

--- a/src/Validation/SignatureVerifier.php
+++ b/src/Validation/SignatureVerifier.php
@@ -3,9 +3,9 @@
 namespace LSNepomuceno\LaravelA1PdfSign\Validation;
 
 use LSNepomuceno\LaravelA1PdfSign\Contracts\A1PdfSign;
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\ProcessRunTimeException;
 use LSNepomuceno\LaravelA1PdfSign\Support\ProcessRunner;
 use LSNepomuceno\LaravelA1PdfSign\Support\TemporaryFile;
-use Throwable;
 
 /**
  * Decides whether a detached CMS matches the bytes it covers.
@@ -46,9 +46,17 @@ final readonly class SignatureVerifier
                     return true;
                 });
             });
-        } catch (Throwable) {
+        } catch (ProcessRunTimeException) {
             // A non-zero exit is the expected outcome for a signature that does
             // not match; it is a verdict, not a failure to report.
+            //
+            // Narrowed from catch (Throwable), which swallowed the difference
+            // between "this signature does not verify" and "nothing verified
+            // it". A missing openssl binary, proc_open disabled, an unwritable
+            // temporary directory: every one of those used to arrive here and
+            // leave as `false`, so a valid document was reported as invalid
+            // with nothing to read anywhere. ProcessUnavailableException and
+            // MissingBinaryException now travel past this catch on purpose.
             return false;
         }
     }
@@ -92,8 +100,10 @@ final readonly class SignatureVerifier
     {
         try {
             $tstInfo = $this->tstInfo($this->paths->tempPath(), $token);
-        } catch (Throwable) {
+        } catch (ProcessRunTimeException) {
             // A token whose own CMS does not verify writes nothing out.
+            // Narrowed for the reason above: an environment that cannot run
+            // openssl must not read as a token that failed to verify.
             return null;
         }
 

--- a/tests/ProcessEnvironmentTest.php
+++ b/tests/ProcessEnvironmentTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use Illuminate\Process\Factory;
+use Illuminate\Support\Facades\Process;
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\MissingBinaryException;
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\ProcessRunTimeException;
+use LSNepomuceno\LaravelA1PdfSign\Support\ProcessRunner;
+
+/**
+ * Being unable to run a command, against running one that fails.
+ *
+ * The two used to be the same thing. `Validation\SignatureVerifier` caught
+ * every throwable and returned false, on the correct reasoning that a non-zero
+ * exit from `openssl smime -verify` means the signature does not verify. The
+ * catch was wider than the reasoning, so a missing binary, `proc_open` in
+ * `disable_functions`, and an unwritable temporary directory all arrived at the
+ * same place and left as "invalid".
+ *
+ * Measured before it was fixed, on `samples/pades-b-b.pdf`, changing nothing
+ * but the environment:
+ *
+ * | openssl present            | isValid=true  |
+ * | openssl binary removed     | isValid=false |
+ * | proc_open disabled         | isValid=false |
+ *
+ * A wrong answer, not a degraded one: the caller cannot tell it from a tampered
+ * document, and the natural response is to reject something legitimate.
+ */
+it('raises rather than reporting a verdict when the binary is not there', function () {
+    expect(fn() => app(ProcessRunner::class)->run('a1-pdf-sign-no-such-binary --version'))
+        ->toThrow(MissingBinaryException::class);
+});
+
+it('names the binary it could not find, since that is the whole point', function () {
+    try {
+        app(ProcessRunner::class)->run('a1-pdf-sign-no-such-binary --version');
+    } catch (MissingBinaryException $exception) {
+        expect($exception->binary)->toBe('a1-pdf-sign-no-such-binary')
+            ->and($exception->getMessage())->toContain('was not found on the PATH');
+
+        return;
+    }
+
+    // Reached only if nothing was thrown, which is the regression this file
+    // exists for.
+    expect(false)->toBeTrue();
+});
+
+it('still reports a command that ran and failed as a failure, not as an environment problem', function () {
+    // The distinction the whole change turns on. `false` exits non-zero and is
+    // on every PATH, so this is a command that ran.
+    expect(fn() => app(ProcessRunner::class)->run('false'))
+        ->toThrow(ProcessRunTimeException::class);
+});
+
+it('runs a command that exists, unchanged', function () {
+    expect(app(ProcessRunner::class)->run('openssl version'))->toContain('OpenSSL');
+});
+
+it('does not check the PATH when the factory is faked, which would defeat the fake', function () {
+    // Support\ProcessRunner is built on Illuminate\Process\Factory precisely so
+    // a host application can Process::fake() it, and its docblock says so. A
+    // guard that inspected the real PATH would make that promise false for
+    // every command the host does not happen to have installed.
+    Process::fake([
+        '*' => Process::result(output: 'faked'),
+    ]);
+
+    // The assertion that matters is that nothing was thrown; the fake's output
+    // carries a trailing newline, as a real process would.
+    expect(trim(app(ProcessRunner::class)->run('a1-pdf-sign-no-such-binary --version')))
+        ->toBe('faked');
+});
+
+it('translates the process layer refusing to spawn into an exception of its own', function () {
+    // Symfony's Process raises a bare LogicException when proc_open is missing.
+    // Reaching the caller as somebody else's exception class is the thing
+    // docs/decisions/0008-exceptions-name-the-real-fault.md rules out.
+    //
+    // proc_open cannot be disabled from inside a running process, so the
+    // condition is produced at the factory rather than in php.ini.
+    $factory = new class extends Factory {
+        #[Override]
+        public function newPendingProcess(): never
+        {
+            throw new LogicException(
+                'The Process class relies on proc_open, which is not available on your PHP installation.',
+            );
+        }
+    };
+
+    expect(fn() => new ProcessRunner($factory)->run('openssl version'))
+        ->toThrow(LSNepomuceno\LaravelA1PdfSign\Exceptions\ProcessUnavailableException::class);
+});


### PR DESCRIPTION
Closes #269.

## The defect, measured

`samples/pades-b-b.pdf` validated in the development image, changing nothing but the environment:

| Environment | Result |
|---|---|
| `openssl` on `PATH` | `isValid=true verified=true` |
| binary removed | `isValid=false verified=false` |
| `disable_functions=proc_open,exec,…` | `isValid=false verified=false` |

**A valid signature reported as invalid.** No exception, no warning, nothing in a log.

For a package whose job is to answer that question, a wrong answer is worse than a crash: the caller cannot tell it from a tampered document, and the natural response to "invalid" is to reject something legitimate.

## Why it happened

```php
} catch (Throwable) {
    // A non-zero exit is the expected outcome for a signature that does
    // not match; it is a verdict, not a failure to report.
    return false;
}
```

The comment is right about the case it names. The catch was wider than the reasoning, so `openssl: not found`, `proc_open() has been disabled` and an unwritable temporary directory all arrived through it and left as `false`.

## The fix

**`ProcessRunner` is the only place that can tell "could not run" from "ran and failed"**, so the two conditions that mean no verdict was reached raise before the command is built:

- `ProcessUnavailableException` when PHP cannot spawn a process at all
- `MissingBinaryException`, carrying the program name, when it is not on the `PATH`

It also translates the bare `LogicException` Symfony raises when `proc_open` is missing, so that case cannot reach a caller from somebody else's namespace ([0008](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/blob/main/docs/decisions/0008-exceptions-name-the-real-fault.md)).

`SignatureVerifier` now catches `ProcessRunTimeException` alone. A genuine mismatch still returns `false`, unchanged.

## Two things it deliberately does not do

**It does not check in `boot()`.** That would probe the environment on every request of every consuming application, including the ones that only sign and never validate. Signing spawns no process at all except for a legacy PFX.

**It does not defeat `Process::fake()`.** The binary check is skipped when the factory is recording. This class is built on `Illuminate\Process\Factory` precisely so a host can fake it, and its docblock has said so since 2.0; a guard inspecting the real `PATH` would make that promise false for every command the host does not happen to have installed. There is a test for exactly this.

## After

Without the `openssl` binary, the same call now raises `MissingBinaryException` with:

> The 'openssl' binary was not found on the PATH. Signature validation shells out to it, so it has to be installed even where ext-openssl is already loaded: the extension and the command-line tool are separate things.

That distinction is the one people lose an afternoon to.

## Checks

`composer check` passes in the 8.4 image: 516 tests, 3398 assertions. Six new tests in `tests/ProcessEnvironmentTest.php` covering a missing binary, a command that ran and failed, a faked factory, and the process layer refusing to spawn.