### PR TITLE
Reach the network through the framework's client

### DIFF
--- a/config/a1-pdf-sign.php
+++ b/config/a1-pdf-sign.php
@@ -56,10 +56,21 @@ return [
             'username' => env('A1_TSA_USERNAME'),
             'password' => env('A1_TSA_PASSWORD'),
             'timeout' => 20,
+
+            // A timestamp authority is a third party over the public internet,
+            // and a transient failure would otherwise fail the signature.
+            // Attempts, not retries: 1 means try once and do not retry.
+            'attempts' => 3,
+            'backoff' => 200,
         ],
 
         'ltv' => [
             'timeout' => 10,
+
+            // Revocation material degrades the profile rather than failing it,
+            // so this is deliberately less patient than the timestamp above.
+            'attempts' => 2,
+            'backoff' => 100,
         ],
     ],
 

--- a/src/Exceptions/SignatureTransportException.php
+++ b/src/Exceptions/SignatureTransportException.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Exceptions;
+
+use Exception;
+use Throwable;
+
+/**
+ * A request the signature needed did not come back.
+ *
+ * Timestamp authorities, OCSP responders and CRL distribution points are third
+ * parties over the public internet, and every profile above `pades-b-b` depends
+ * on one.
+ *
+ * It replaces ProcessRunTimeException on this path, which named a fault that
+ * did not occur: no process is run to fetch a timestamp, and a consumer
+ * catching it to handle a shell-out problem was catching a network problem
+ * instead (docs/decisions/0008-exceptions-name-the-real-fault.md).
+ */
+final class SignatureTransportException extends Exception
+{
+    public function __construct(public readonly string $url, string $detail, ?Throwable $previous = null)
+    {
+        parent::__construct("The request to {$url} failed: {$detail}", previous: $previous);
+    }
+}

--- a/src/Signing/Cades/HttpTransport.php
+++ b/src/Signing/Cades/HttpTransport.php
@@ -3,8 +3,11 @@
 namespace LSNepomuceno\LaravelA1PdfSign\Signing\Cades;
 
 use Illuminate\Contracts\Config\Repository as Config;
+use Illuminate\Http\Client\Factory as Http;
+use Illuminate\Http\Client\PendingRequest;
 use LSNepomuceno\LaravelA1PdfSign\Contracts\SignatureTransport;
-use LSNepomuceno\LaravelA1PdfSign\Exceptions\ProcessRunTimeException;
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\SignatureTransportException;
+use Throwable;
 
 /**
  * The HTTP the signature primitives deliberately do not do.
@@ -17,10 +20,18 @@ use LSNepomuceno\LaravelA1PdfSign\Exceptions\ProcessRunTimeException;
  * The interface behind it exists so a test can substitute a local authority
  * and gate the profiles that need one
  * (docs/decisions/0027-the-transport-is-a-seam.md).
+ *
+ * **It goes through the framework's client**, not through `file_get_contents()`
+ * with a stream context, which is what it used to do. That cost more than
+ * elegance: a host could not `Http::fake()` it, could not apply its own proxy,
+ * middleware or logging, and a timestamp authority having a bad minute failed
+ * the signature outright because nothing retried. `Support\ProcessRunner` is
+ * built on Laravel's process factory for exactly the same reason, and the
+ * network path had not been given the same treatment.
  */
 final readonly class HttpTransport implements SignatureTransport
 {
-    public function __construct(private Config $config) {}
+    public function __construct(private Config $config, private Http $http) {}
 
     /**
      * Posts a DER TimeStampReq and returns the DER TimeStampResp.
@@ -30,15 +41,17 @@ final readonly class HttpTransport implements SignatureTransport
     public function timestamp(string $url, ?string $username = null, ?string $password = null): callable
     {
         $timeout = $this->intConfig('signature.timestamp.timeout', 20);
+        $attempts = $this->intConfig('signature.timestamp.attempts', 3);
+        $backoff = $this->intConfig('signature.timestamp.backoff', 200);
 
-        return function (string $request) use ($url, $username, $password, $timeout): string {
-            $headers = ['Content-Type: application/timestamp-query'];
+        return function (string $request) use ($url, $username, $password, $timeout, $attempts, $backoff): string {
+            $headers = [];
 
             if ($username !== null && $username !== '') {
-                $headers[] = 'Authorization: Basic ' . base64_encode("{$username}:{$password}");
+                $headers['Authorization'] = 'Basic ' . base64_encode("{$username}:{$password}");
             }
 
-            return $this->post($url, $request, $headers, $timeout);
+            return $this->post($url, $request, 'application/timestamp-query', $headers, $timeout, $attempts, $backoff);
         };
     }
 
@@ -50,11 +63,13 @@ final readonly class HttpTransport implements SignatureTransport
     public function ocsp(): callable
     {
         $timeout = $this->intConfig('signature.ltv.timeout', 10);
+        $attempts = $this->intConfig('signature.ltv.attempts', 2);
+        $backoff = $this->intConfig('signature.ltv.backoff', 100);
 
-        return function (string $url, string $request) use ($timeout): string|false {
+        return function (string $url, string $request) use ($timeout, $attempts, $backoff): string|false {
             try {
-                return $this->post($url, $request, ['Content-Type: application/ocsp-request'], $timeout);
-            } catch (ProcessRunTimeException) {
+                return $this->post($url, $request, 'application/ocsp-request', [], $timeout, $attempts, $backoff);
+            } catch (SignatureTransportException) {
                 // A responder being unreachable degrades the profile; it must
                 // not fail the signature.
                 return false;
@@ -70,38 +85,72 @@ final readonly class HttpTransport implements SignatureTransport
     public function crl(): callable
     {
         $timeout = $this->intConfig('signature.ltv.timeout', 10);
+        $attempts = $this->intConfig('signature.ltv.attempts', 2);
+        $backoff = $this->intConfig('signature.ltv.backoff', 100);
 
-        return function (string $url) use ($timeout): string|false {
-            $context = stream_context_create(['http' => ['timeout' => $timeout], 'https' => ['timeout' => $timeout]]);
+        return function (string $url) use ($timeout, $attempts, $backoff): string|false {
+            try {
+                $response = $this->request($timeout, $attempts, $backoff)->get($url);
+            } catch (Throwable) {
+                return false;
+            }
 
-            return @file_get_contents($url, false, $context);
+            return $response->successful() ? $response->body() : false;
         };
     }
 
     /**
-     * @param  array<int, string>  $headers
+     * @param  array<string, string>  $headers
      *
-     * @throws ProcessRunTimeException
+     * @throws SignatureTransportException
      */
-    private function post(string $url, string $body, array $headers, int $timeout): string
-    {
-        $context = stream_context_create([
-            'http' => [
-                'method' => 'POST',
-                'header' => implode("\r\n", $headers),
-                'content' => $body,
-                'timeout' => $timeout,
-                'ignore_errors' => true,
-            ],
-        ]);
-
-        $response = @file_get_contents($url, false, $context);
-
-        if ($response === false || $response === '') {
-            throw new ProcessRunTimeException("no response from {$url}");
+    private function post(
+        string $url,
+        string $body,
+        string $contentType,
+        array $headers,
+        int $timeout,
+        int $attempts,
+        int $backoff,
+    ): string {
+        try {
+            $response = $this->request($timeout, $attempts, $backoff)
+                ->withHeaders($headers)
+                ->withBody($body, $contentType)
+                ->post($url);
+        } catch (Throwable $exception) {
+            throw new SignatureTransportException($url, $exception->getMessage(), $exception);
         }
 
-        return $response;
+        // The body is read whatever the status. RFC 3161 answers a rejection
+        // with a TimeStampResp carrying the reason, and an authority that says
+        // why it refused is more useful than a status code on its own. This is
+        // what `ignore_errors` was doing in the stream context.
+        $contents = $response->body();
+
+        if ($contents === '') {
+            throw new SignatureTransportException($url, "empty response, HTTP {$response->status()}");
+        }
+
+        return $contents;
+    }
+
+    /**
+     * A request that retries transient failures.
+     *
+     * `throw: false` because a non-2xx is not necessarily a failure here: the
+     * body still has to be read. Retrying is for connection problems and for
+     * the statuses Laravel's client treats as retryable.
+     */
+    private function request(int $timeout, int $attempts, int $backoff): PendingRequest
+    {
+        // createPendingRequest() rather than the factory's __call proxy, which
+        // static analysis cannot follow. Support\ProcessRunner uses
+        // newPendingProcess() for the same reason.
+        return $this->http
+            ->createPendingRequest()
+            ->timeout($timeout)
+            ->retry(max(1, $attempts), max(0, $backoff), throw: false);
     }
 
     private function intConfig(string $key, int $default): int

--- a/tests/TransportTest.php
+++ b/tests/TransportTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use LSNepomuceno\LaravelA1PdfSign\Contracts\SignatureTransport;
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\SignatureTransportException;
+
+/**
+ * The one place this package reaches the network.
+ *
+ * It used to be `file_get_contents()` with a stream context, which meant a host
+ * application could not `Http::fake()` it, could not apply its own proxy,
+ * middleware or logging, and had no retry when a timestamp authority had a bad
+ * minute. `Support\ProcessRunner` is built on Laravel's process factory so a
+ * host can fake that; the network path had not been given the same treatment.
+ *
+ * Every test here fakes the client, so nothing in this file touches a real
+ * authority. The live cross-check stays in the `network` group
+ * (docs/decisions/0027-the-transport-is-a-seam.md).
+ */
+it('is intercepted by Http::fake, which is the whole point', function () {
+    Http::fake(['tsa.example/*' => Http::response('a timestamp token')]);
+
+    $token = app(SignatureTransport::class)->timestamp('https://tsa.example/tsr')('a request');
+
+    expect($token)->toBe('a timestamp token');
+
+    Http::assertSent(fn($request) => $request->url() === 'https://tsa.example/tsr'
+        && $request->hasHeader('Content-Type', 'application/timestamp-query'));
+});
+
+it('sends basic credentials when the authority is configured with them', function () {
+    Http::fake(['tsa.example/*' => Http::response('token')]);
+
+    app(SignatureTransport::class)->timestamp('https://tsa.example/tsr', 'user', 'secret')('a request');
+
+    Http::assertSent(fn($request) => $request->hasHeader(
+        'Authorization',
+        'Basic ' . base64_encode('user:secret'),
+    ));
+});
+
+it('retries a transient failure rather than failing the signature', function () {
+    config()->set('a1-pdf-sign.signature.timestamp.attempts', 3);
+    config()->set('a1-pdf-sign.signature.timestamp.backoff', 0);
+
+    Http::fakeSequence()
+        ->push('', 500)
+        ->push('', 500)
+        ->push('a timestamp token', 200);
+
+    expect(app(SignatureTransport::class)->timestamp('https://tsa.example/tsr')('a request'))
+        ->toBe('a timestamp token');
+
+    Http::assertSentCount(3);
+});
+
+it('gives up after the configured number of attempts, naming the URL', function () {
+    config()->set('a1-pdf-sign.signature.timestamp.attempts', 2);
+    config()->set('a1-pdf-sign.signature.timestamp.backoff', 0);
+
+    Http::fake(['tsa.example/*' => Http::response('', 500)]);
+
+    try {
+        app(SignatureTransport::class)->timestamp('https://tsa.example/tsr')('a request');
+    } catch (SignatureTransportException $exception) {
+        // Named for the network. It used to be ProcessRunTimeException, which
+        // named a fault that did not occur: no process is run to fetch a
+        // timestamp.
+        expect($exception->url)->toBe('https://tsa.example/tsr')
+            ->and($exception->getMessage())->toContain('tsa.example');
+
+        Http::assertSentCount(2);
+
+        return;
+    }
+
+    expect(false)->toBeTrue();
+});
+
+it('keeps the body of a rejection, because RFC 3161 puts the reason in it', function () {
+    // A TimeStampResp carrying a rejection is more useful than a status code,
+    // and reading it is what `ignore_errors` was doing in the stream context.
+    config()->set('a1-pdf-sign.signature.timestamp.attempts', 1);
+
+    Http::fake(['tsa.example/*' => Http::response('a rejection with a reason', 400)]);
+
+    expect(app(SignatureTransport::class)->timestamp('https://tsa.example/tsr')('a request'))
+        ->toBe('a rejection with a reason');
+});
+
+it('degrades rather than failing when a revocation responder is unreachable', function () {
+    // Revocation material improves the profile; an unreachable responder must
+    // not fail the signature (docs/decisions/0024-revocation-is-evaluated-not-counted.md).
+    config()->set('a1-pdf-sign.signature.ltv.attempts', 1);
+
+    Http::fake(fn() => throw new ConnectionException('could not connect'));
+
+    expect(app(SignatureTransport::class)->ocsp()('https://ocsp.example', 'a request'))->toBeFalse()
+        ->and(app(SignatureTransport::class)->crl()('https://crl.example/list.crl'))->toBeFalse();
+});
+
+it('returns a CRL the distribution point answered with', function () {
+    Http::fake(['crl.example/*' => Http::response('DER bytes')]);
+
+    expect(app(SignatureTransport::class)->crl()('https://crl.example/list.crl'))->toBe('DER bytes');
+});
+
+it('treats a CRL the distribution point refused as absent', function () {
+    Http::fake(['crl.example/*' => Http::response('not found', 404)]);
+
+    expect(app(SignatureTransport::class)->crl()('https://crl.example/list.crl'))->toBeFalse();
+});


### PR DESCRIPTION
Closes #273.

## What it was

```php
$context = stream_context_create(['http' => [/* … */ 'ignore_errors' => true]]);
$response = @file_get_contents($url, false, $context);

if ($response === false || $response === '') {
    throw new ProcessRunTimeException("no response from {$url}");
}
```

Seven lines, four problems, in the only place this package touches the network.

| | |
|---|---|
| **No retry** | a timestamp authority is a third party over the public internet, and a transient failure failed the signature |
| **Not fakeable** | `Http::fake()` intercepts Laravel's client, and this was not Laravel's client |
| **Bypassed the host** | proxy, middleware, logging, TLS options. [Invariant 9](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/blob/main/docs/spec/invariants.md) says the host owns this SSRF surface, and it owned a seam it could not reach inside |
| **Misnamed failure** | a network error raised `ProcessRunTimeException`, where no process is run |

The second is the one that stings: `Support\ProcessRunner` is built on `Illuminate\Process\Factory` **specifically** so a host can `Process::fake()` it, and its docblock has said so since 2.0. The network path had not been given the same treatment.

## What it is now

`Illuminate\Http\Client`, with retries configurable per family and defaults that say what they are for:

```php
'timestamp' => [ 'attempts' => 3, 'backoff' => 200 ],  // failing this fails the signature
'ltv'       => [ 'attempts' => 2, 'backoff' => 100 ],  // this only degrades the profile
```

`SignatureTransportException` replaces `ProcessRunTimeException` on this path, carrying the URL. That is [0008](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/blob/main/docs/decisions/0008-exceptions-name-the-real-fault.md) applied to the one path that had been ignoring it.

## Two behaviours deliberately preserved

**A rejection body still comes back whatever the status.** RFC 3161 answers a refusal with a `TimeStampResp` carrying the reason, and an authority that says why is worth more than a status code. That is what `ignore_errors => true` was doing, and it is now `throw: false` plus reading the body.

**An unreachable revocation responder still degrades rather than fails.** OCSP and CRL return `false`, unchanged ([0024](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/blob/main/docs/decisions/0024-revocation-is-evaluated-not-counted.md)).

## Behaviour change worth calling out

A consumer catching `ProcessRunTimeException` around a timestamped signature will no longer catch it. That is the fix rather than a side effect, but it is a change, and it belongs in the release notes.

## Checks

`composer check` passes in the 8.4 image: 528 tests, 3424 assertions. Eight new tests in `tests/TransportTest.php`, all faked, covering interception, credentials, retry-then-succeed, give-up-and-name-the-URL, the rejection body, and both degrade paths. `tests/TimestampOfflineTest.php` and the `network` group are untouched and green.