### PR TITLE
Put the seal where the reader shows it on a rotated page

### DIFF
--- a/docs/decisions/0033-the-seal-honours-page-rotation.md
+++ b/docs/decisions/0033-the-seal-honours-page-rotation.md
@@ -1,0 +1,85 @@
+# 0033: The seal honours the page's rotation
+
+**Status:** implemented.
+
+## Context
+
+`/Rotate` turns a page clockwise for display and leaves its coordinate system
+alone (ISO 32000-1 §7.7.3.3). `SealPlacement` is documented in terms of where
+the seal appears, and the caller giving those coordinates is looking at the
+document in a reader, where it is already turned.
+
+The two were never reconciled. The placement went straight into `/Rect`, and
+`grep -rn "Rotate" src/` returned nothing at all: the key was read nowhere.
+
+Measured on a page carrying `/Rotate 90`, with a placement of (60, 400):
+
+```
+Rect[60 400 180 460]
+```
+
+The caller's numbers, untouched. On screen that is somewhere else entirely, the
+seal reads sideways, and on a page rotated 90 or 270 it can fall outside the
+visible area, since the displayed width and height have swapped.
+
+`/Rotate 90` is how most scanners and many generators express landscape. This
+was not an exotic input.
+
+## Decision
+
+**The placement is where the seal appears, and the file records where that is.**
+
+Two things follow, and only doing the first would be worse than doing neither:
+the seal would land correctly and read sideways.
+
+- `/Rect` is mapped from displayed coordinates into user space. For a quarter
+  turn clockwise the user-space origin, the bottom left, is displayed at the top
+  left, so a displayed point (x, y) sits at user (width − y, x).
+- The appearance carries a `/Matrix` turning it the other way, because a form
+  XObject is drawn in user space and the display rotation applies to it too. No
+  translation is needed: the reader maps the transformed bounding box onto
+  `/Rect` (§12.5.5).
+
+`/Rotate` and `/MediaBox` are read **with inheritance**, through `/Parent`. Both
+are inheritable (§7.7.3.4, Table 30), and one declaration on `/Pages` is the
+ordinary way to say "this document is landscape". Reading the page object alone
+would have missed the common case.
+
+**Geometry is per page**, not per document. A file can carry a landscape scan
+beside a portrait cover, and `SealPlacement` can put a stamp on both.
+
+## Verification
+
+The rectangle is asserted at every rotation, including 360 and −90, which
+normalise to no turn and to 270.
+
+The claim that matters is about what a reader shows, so it was checked with one.
+Both documents rendered with poppler's `pdftoppm` at 40 dpi, and the ink located:
+
+| | Asked for, as displayed | Rendered |
+|---|---|---|
+| No rotation | x 10-30%, y 45-52% | x 10-30%, y 45-51% |
+| `/Rotate 90` | x 7-21%, y 23-33% | x 7-21%, y 24-33% |
+
+The rotated page's ink also spans 120 pt across and 60 pt down, so the seal is
+neither distorted nor turned on screen.
+
+## Consequences
+
+- **A document with no rotation produces the bytes it did before.** The mapping
+  returns its input and no `/Matrix` is written, so every committed sample and
+  every conformance verdict measured against them is unaffected.
+- A page with no `/MediaBox` anywhere above it behaves as unrotated. The mapping
+  needs the page's size and inventing one would put the seal somewhere
+  arbitrary; landing where it used to is at least predictable.
+- `Signing\Incremental\PageGeometry` is where the mapping lives, so the
+  arithmetic is testable without signing anything.
+
+## Alternatives rejected
+
+| | Why not |
+|---|---|
+| Treat the placement as user space and let the caller compensate | The caller is looking at a reader. The package is the only party that knows the page is turned |
+| `/MK <</R 90>>` on the widget | Readers vary in whether they honour it. A matrix on the appearance is what the rendering algorithm is specified to apply |
+| Read `/Rotate` from the page only | Misses the document declared landscape once on `/Pages`, which is the common shape |
+| Fix the rectangle and leave the appearance | The seal lands correctly and reads sideways, which looks like a different bug |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -42,6 +42,7 @@ document drifts away from the code it describes.
 | [0030](0030-signing-a-document-that-is-encrypted.md) | Signing a document that is encrypted |
 | [0031](0031-certification-verified-by-a-reader.md) | Certification is verified by a reader that enforces it |
 | [0032](0032-what-signing-does-to-pdf-ua.md) | What signing does to PDF/UA, measured |
+| [0033](0033-the-seal-honours-page-rotation.md) | The seal honours the page's rotation |
 
 Nothing is currently proposed and unbuilt. The four that were, 0009, 0010, 0012
 and 0013, all shipped in 2.2, and each carries the measurement that decided its

--- a/src/Signing/Incremental/DocumentReader.php
+++ b/src/Signing/Incremental/DocumentReader.php
@@ -280,6 +280,59 @@ final class DocumentReader
     }
 
     /**
+     * How a page is displayed, against how its coordinates read.
+     *
+     * /Rotate and /MediaBox are both inheritable (ISO 32000-1 §7.7.3.4,
+     * Table 30), and a document declared landscape once on /Pages is the common
+     * case rather than the exotic one, so reading them from the page object
+     * alone would miss it.
+     *
+     * @throws InvalidPdfFileException
+     */
+    public function pageGeometry(string $pdf, DocumentInfo $document, int $pageNumber): PageGeometry
+    {
+        $rotate = $this->inherited($pdf, $document, $pageNumber, 'Rotate');
+        $mediaBox = $this->inherited($pdf, $document, $pageNumber, 'MediaBox');
+
+        $box = null;
+
+        if ($mediaBox !== null && preg_match_all('/-?[\d.]+/', $mediaBox, $numbers) === 4) {
+            $box = [(float) $numbers[0][0], (float) $numbers[0][1], (float) $numbers[0][2], (float) $numbers[0][3]];
+        }
+
+        return PageGeometry::of((int) ($rotate ?? 0), $box);
+    }
+
+    /**
+     * An inheritable page attribute, from the page or from the nearest ancestor
+     * that declares it.
+     *
+     * @throws InvalidPdfFileException
+     */
+    private function inherited(string $pdf, DocumentInfo $document, int $number, string $key): ?string
+    {
+        $seen = [];
+
+        while (! isset($seen[$number]) && $document->has($number)) {
+            $seen[$number] = true;
+
+            $node = $this->rawObject($pdf, $document, $number);
+
+            if (preg_match('#/' . $key . '\s*(\[[^\]]*\]|-?[\d.]+)#', $node, $found) === 1) {
+                return $found[1];
+            }
+
+            if (preg_match('/\/Parent\s+(\d+)\s+\d+\s+R/', $node, $parent) !== 1) {
+                return null;
+            }
+
+            $number = (int) $parent[1];
+        }
+
+        return null;
+    }
+
+    /**
      * @throws InvalidPdfFileException
      */
     public function findFirstPage(string $pdf, DocumentInfo $document): int

--- a/src/Signing/Incremental/PageGeometry.php
+++ b/src/Signing/Incremental/PageGeometry.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Signing\Incremental;
+
+/**
+ * A page as the reader displays it, against a page as its coordinates describe
+ * it.
+ *
+ * *ISO 32000-1 §7.7.3.3: /Rotate is the number of degrees by which the page
+ * shall be rotated clockwise when displayed.* The coordinate system does not
+ * turn with it, so on a page carrying `/Rotate 90` a rectangle at the bottom
+ * left of user space appears at the top left of the screen, and anything drawn
+ * in it reads sideways.
+ *
+ * That mattered here because `SealPlacement` is documented in terms of where
+ * the seal appears, and the caller is looking at the document in a reader.
+ * Before this existed the placement was written straight into `/Rect`, so a
+ * seal asked for at (60, 400) on a landscape scan, which is `/Rotate 90` in
+ * practice, landed somewhere else entirely and could fall outside the visible
+ * area, since the displayed width and height have swapped.
+ *
+ * A page with no rotation returns its input unchanged and needs no matrix, so
+ * every document that is not rotated produces exactly the bytes it did before.
+ */
+final readonly class PageGeometry
+{
+    public function __construct(
+        public int $rotation = 0,
+        public float $width = 0.0,
+        public float $height = 0.0,
+    ) {}
+
+    /**
+     * Reads the two keys, normalising the rotation.
+     *
+     * Values are multiples of 90 and may be negative or above 360, so 450 and
+     * -270 are both a quarter turn clockwise.
+     *
+     * @param  array{0: float, 1: float, 2: float, 3: float}|null  $mediaBox
+     */
+    public static function of(int $rotate, ?array $mediaBox): self
+    {
+        $rotation = ((int) round($rotate / 90) * 90 % 360 + 360) % 360;
+
+        if ($mediaBox === null) {
+            // Without a media box the mapping below cannot be computed, and
+            // guessing a page size would put the seal somewhere arbitrary.
+            // Behaving as an unrotated page is the honest failure: the seal
+            // lands where it used to, which is at least predictable.
+            return new self();
+        }
+
+        return new self(
+            $rotation,
+            abs($mediaBox[2] - $mediaBox[0]),
+            abs($mediaBox[3] - $mediaBox[1]),
+        );
+    }
+
+    public function isRotated(): bool
+    {
+        return $this->rotation !== 0 && $this->width > 0.0 && $this->height > 0.0;
+    }
+
+    /**
+     * The rectangle in user space for a box the caller placed on the screen.
+     *
+     * @return array{0: float, 1: float, 2: float, 3: float}
+     */
+    public function toUserSpace(float $x, float $y, float $width, float $height): array
+    {
+        if (! $this->isRotated()) {
+            return [$x, $y, $x + $width, $y + $height];
+        }
+
+        // Each case maps the two opposite corners and then normalises, because
+        // a rotation can put the "lower left" corner above the other one and a
+        // /Rect with its coordinates the wrong way round is a rectangle readers
+        // disagree about.
+        [$ax, $ay] = $this->corner($x, $y);
+        [$bx, $by] = $this->corner($x + $width, $y + $height);
+
+        return [min($ax, $bx), min($ay, $by), max($ax, $bx), max($ay, $by)];
+    }
+
+    /**
+     * The /Matrix a form XObject needs to render upright once the page is
+     * turned.
+     *
+     * The appearance is drawn in user space, so the display rotation applies to
+     * it as well. Rotating it the other way in advance is what leaves it
+     * readable. Null when there is nothing to correct.
+     *
+     * The reader maps the transformed bounding box onto /Rect (§12.5.5), so no
+     * translation is needed here: only the rotation.
+     */
+    public function appearanceMatrix(): ?string
+    {
+        if (! $this->isRotated()) {
+            return null;
+        }
+
+        return match ($this->rotation) {
+            90 => '/Matrix[0 1 -1 0 0 0]',
+            180 => '/Matrix[-1 0 0 -1 0 0]',
+            270 => '/Matrix[0 -1 1 0 0 0]',
+            default => null,
+        };
+    }
+
+    /**
+     * One corner, from what the viewer sees to what the file records.
+     *
+     * Derived rather than guessed. For a quarter turn clockwise the user-space
+     * origin, the bottom left of the page, is displayed at the top left, so a
+     * displayed point (dx, dy) is at user (width - dy, dx).
+     *
+     * @return array{0: float, 1: float}
+     */
+    private function corner(float $x, float $y): array
+    {
+        return match ($this->rotation) {
+            90 => [$this->width - $y, $x],
+            180 => [$this->width - $x, $this->height - $y],
+            270 => [$y, $this->height - $x],
+            default => [$x, $y],
+        };
+    }
+}

--- a/src/Signing/Incremental/RevisionWriter.php
+++ b/src/Signing/Incremental/RevisionWriter.php
@@ -104,6 +104,10 @@ final class RevisionWriter
             $stampNumbers[$page] = $number++;
         }
 
+        // Per page, because a document can carry a landscape scan beside a
+        // portrait cover and the seal may go on both.
+        $geometry = $this->reader->pageGeometry($pdf, $document, $pageNumber);
+
         $base = strlen($pdf);
         $body = "\n";
         $offsets = [];
@@ -119,7 +123,7 @@ final class RevisionWriter
                 $pageNumber,
                 $fieldName,
                 $appearanceNumber,
-                $visible ? $this->appearance->rectangle($placement, $seal) : null,
+                $visible ? $this->appearance->rectangle($placement, $seal, $geometry) : null,
                 $lock,
                 $cipher,
             )
@@ -138,13 +142,18 @@ final class RevisionWriter
             }
 
             $offsets[$formNumber] = $base + strlen($body);
-            $body .= $this->appearance->formObject($formNumber, $imageNumber, $placement, $seal, $cipher);
-
-            $rectangle = $this->appearance->rectangle($placement, $seal);
+            $body .= $this->appearance->formObject($formNumber, $imageNumber, $placement, $seal, $cipher, $geometry);
 
             foreach ($stampNumbers as $page => $stampNumber) {
                 $offsets[$stampNumber] = $base + strlen($body);
-                $body .= $this->stampObject($stampNumber, $formNumber, $page, $rectangle);
+                $body .= $this->stampObject(
+                    $stampNumber,
+                    $formNumber,
+                    $page,
+                    // Each stamp asks its own page, since /Rotate is a property
+                    // of the page rather than of the document.
+                    $this->appearance->rectangle($placement, $seal, $this->reader->pageGeometry($pdf, $document, $page)),
+                );
             }
         } else {
             $offsets[$formNumber] = $base + strlen($body);

--- a/src/Signing/Incremental/SealAppearance.php
+++ b/src/Signing/Incremental/SealAppearance.php
@@ -119,6 +119,7 @@ final class SealAppearance
         SealPlacement $placement,
         SealImage $seal,
         ?ObjectCipher $cipher = null,
+        ?PageGeometry $geometry = null,
     ): string {
         [$width, $height] = $this->size($placement, $seal);
 
@@ -129,6 +130,9 @@ final class SealAppearance
         return "{$number} 0 obj\n"
             . '<</Type/XObject/Subtype/Form'
             . "/BBox[0 0 {$width} {$height}]"
+            // Turned the other way, so the seal reads upright once the reader
+            // applies the page's own rotation to it.
+            . ($geometry ?? new PageGeometry())->appearanceMatrix()
             . "/Resources<</XObject<</Im0 {$imageNumber} 0 R>>>>"
             . '/Length ' . $length
             . ">>\nstream\n"
@@ -162,11 +166,14 @@ final class SealAppearance
      *
      * @return array{0: float, 1: float, 2: float, 3: float}
      */
-    public function rectangle(SealPlacement $placement, SealImage $seal): array
+    public function rectangle(SealPlacement $placement, SealImage $seal, ?PageGeometry $geometry = null): array
     {
         [$width, $height] = $this->size($placement, $seal);
 
-        return [$placement->x, $placement->y, $placement->x + $width, $placement->y + $height];
+        // The placement is where the seal appears, and on a rotated page that
+        // is not where its coordinates are (docs/decisions/0033-the-seal-honours-page-rotation.md).
+        return ($geometry ?? new PageGeometry())
+            ->toUserSpace($placement->x, $placement->y, $width, $height);
     }
 
     /**

--- a/tests/PageRotationTest.php
+++ b/tests/PageRotationTest.php
@@ -1,0 +1,153 @@
+<?php
+
+use LSNepomuceno\LaravelA1PdfSign\Data\SealPlacement;
+use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
+use LSNepomuceno\LaravelA1PdfSign\Signing\Incremental\PageGeometry;
+
+/**
+ * A page as the reader shows it, against a page as its coordinates describe it.
+ *
+ * ISO 32000-1 §7.7.3.3: `/Rotate` turns the page clockwise for display and
+ * leaves the coordinate system where it was. `/Rotate 90` is how most scanners
+ * and many generators express landscape, so this is not an exotic input.
+ *
+ * The placement went straight into `/Rect`, and `grep -rn Rotate src/` returned
+ * nothing at all. Measured before the fix, at `/Rotate 90` with a placement of
+ * (60, 400): `Rect[60 400 180 460]`, the caller's numbers untouched, which puts
+ * the seal somewhere else entirely on screen and draws it sideways.
+ *
+ * Confirmed afterwards with poppler, rendering both pages at 40 dpi and finding
+ * the ink: the rotated page carries the seal at 7-21% across and 24-33% down,
+ * which is where a placement of (60, 400) sits on a page displayed 842 wide and
+ * 595 tall.
+ */
+
+/**
+ * A one-page document with the given rotation, and nothing else on it.
+ */
+function pageRotated(?int $rotate, string $mediaBox = '[0 0 595 842]'): string
+{
+    return pdfWith([
+        1 => '<</Type/Catalog/Pages 2 0 R>>',
+        2 => '<</Type/Pages/Kids[3 0 R]/Count 1>>',
+        3 => '<</Type/Page/Parent 2 0 R/MediaBox' . $mediaBox
+            . ($rotate === null ? '' : "/Rotate {$rotate}") . '>>',
+    ]);
+}
+
+/**
+ * Signs a document with a seal at a known place and returns its /Rect.
+ *
+ * @return list<float>
+ */
+function sealedRectangle(string $pdf): array
+{
+    [$pfxPath, $password] = debugCertificate();
+
+    $path = A1PdfSign::tempPath(true, '.pdf');
+    file_put_contents($path, $pdf);
+
+    $signed = A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdf($path)
+        ->seal(placement: new SealPlacement(x: 60, y: 400, width: 120, height: 60))
+        ->sign()
+        ->contents;
+
+    preg_match('/\/Rect\[([^\]]+)\]/', $signed, $found);
+
+    $parts = preg_split('/\s+/', trim($found[1] ?? ''));
+
+    return array_map(floatval(...), $parts === false ? [] : $parts);
+}
+
+it('leaves an unrotated page exactly as it was', function () {
+    // The placement is already in user space, so nothing should move and no
+    // matrix should be written. Every document that is not rotated has to
+    // produce the bytes it produced before.
+    expect(sealedRectangle(pageRotated(null)))->toBe([60.0, 400.0, 180.0, 460.0]);
+});
+
+it('maps the placement onto the page the file describes', function (int $rotate, array $expected) {
+    expect(sealedRectangle(pageRotated($rotate)))->toBe($expected);
+})->with([
+    // Derived rather than guessed: for a quarter turn clockwise the user-space
+    // origin, the bottom left, is displayed at the top left, so a displayed
+    // point (x, y) sits at user (width - y, x).
+    'a quarter turn' => [90, [135.0, 60.0, 195.0, 180.0]],
+    'upside down' => [180, [415.0, 382.0, 535.0, 442.0]],
+    'three quarters' => [270, [400.0, 662.0, 460.0, 782.0]],
+    'a full turn is no turn' => [360, [60.0, 400.0, 180.0, 460.0]],
+    'expressed the other way round' => [-90, [400.0, 662.0, 460.0, 782.0]],
+]);
+
+it('swaps the sides, because the displayed page has', function () {
+    // The clearest single consequence: a box 120 wide and 60 tall on screen is
+    // 60 wide and 120 tall in the file.
+    [$x1, $y1, $x2, $y2] = sealedRectangle(pageRotated(90));
+
+    expect($x2 - $x1)->toBe(60.0)
+        ->and($y2 - $y1)->toBe(120.0);
+});
+
+it('inherits the rotation from the page tree, which is where a landscape document declares it', function () {
+    // /Rotate and /MediaBox are inheritable (ISO 32000-1 §7.7.3.4, Table 30),
+    // and one declaration on /Pages is the common way to say "this document is
+    // landscape". Reading the page object alone would miss it.
+    $pdf = pdfWith([
+        1 => '<</Type/Catalog/Pages 2 0 R>>',
+        2 => '<</Type/Pages/Kids[3 0 R]/Count 1/Rotate 90/MediaBox[0 0 595 842]>>',
+        3 => '<</Type/Page/Parent 2 0 R>>',
+    ]);
+
+    expect(sealedRectangle($pdf))->toBe([135.0, 60.0, 195.0, 180.0]);
+});
+
+it('turns the appearance the other way, so the seal reads upright', function () {
+    [$pfxPath, $password] = debugCertificate();
+
+    $path = A1PdfSign::tempPath(true, '.pdf');
+    file_put_contents($path, pageRotated(90));
+
+    $signed = A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdf($path)
+        ->seal(placement: new SealPlacement(x: 60, y: 400, width: 120, height: 60))
+        ->sign()
+        ->contents;
+
+    // The appearance is drawn in user space, so the display rotation applies to
+    // it too. Without this the seal lands correctly and reads sideways.
+    expect($signed)->toContain('/Matrix[0 1 -1 0 0 0]');
+});
+
+it('writes no matrix when there is nothing to correct', function () {
+    [$pfxPath, $password] = debugCertificate();
+
+    $path = A1PdfSign::tempPath(true, '.pdf');
+    file_put_contents($path, pageRotated(null));
+
+    $signed = A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdf($path)
+        ->seal(placement: new SealPlacement(x: 60, y: 400, width: 120, height: 60))
+        ->sign()
+        ->contents;
+
+    expect($signed)->not->toContain('/Matrix');
+});
+
+it('behaves as an unrotated page when the document declares no media box', function () {
+    // The mapping needs the page's size, and inventing one would put the seal
+    // somewhere arbitrary. Landing where it used to is at least predictable.
+    expect(new PageGeometry()->isRotated())->toBeFalse()
+        ->and(PageGeometry::of(90, null)->isRotated())->toBeFalse()
+        ->and(PageGeometry::of(90, null)->toUserSpace(60, 400, 120, 60))
+        ->toBe([60.0, 400.0, 180.0, 460.0]);
+});
+
+it('normalises a rotation expressed outside a single turn', function () {
+    expect(PageGeometry::of(450, [0.0, 0.0, 595.0, 842.0])->rotation)->toBe(90)
+        ->and(PageGeometry::of(-270, [0.0, 0.0, 595.0, 842.0])->rotation)->toBe(90)
+        ->and(PageGeometry::of(-90, [0.0, 0.0, 595.0, 842.0])->rotation)->toBe(270);
+});


### PR DESCRIPTION
Closes #276.

## The defect

`/Rotate` turns a page clockwise for display and leaves its coordinate system alone (ISO 32000-1 §7.7.3.3). `SealPlacement` is documented in terms of where the seal **appears**, and the caller giving those coordinates is looking at a reader.

`grep -rn "Rotate" src/` returned **nothing**. The key was read nowhere.

Measured on `/Rotate 90` with a placement of (60, 400):

```
Rect[60 400 180 460]
```

The caller's numbers, untouched. On screen the seal is somewhere else, reads sideways, and at 90 or 270 can fall outside the visible area entirely, because the displayed width and height have swapped.

`/Rotate 90` is how most scanners and many generators express landscape.

## Two halves

Doing only the first would look like a different bug: the seal would land correctly and read sideways.

- **`/Rect` is mapped into user space.** For a quarter turn clockwise the user-space origin, the bottom left, is displayed at the top left, so a displayed point (x, y) sits at user (width − y, x).
- **The appearance carries a `/Matrix`** turning it back, because a form XObject is drawn in user space and the display rotation applies to it too. No translation: the reader maps the transformed bounding box onto `/Rect` (§12.5.5).

## Read with inheritance, and per page

`/Rotate` and `/MediaBox` are both inheritable (§7.7.3.4, Table 30), and **one declaration on `/Pages` is the ordinary way to say a document is landscape**. Reading the page object alone would have missed the common case.

Geometry is resolved per page, since a file can carry a landscape scan beside a portrait cover and `SealPlacement` can stamp both.

## Confirmed with a reader, not with the arithmetic

The claim is about what a reader shows, so poppler was asked. Both documents rendered with `pdftoppm` at 40 dpi, ink located:

| | Asked for, as displayed | Rendered |
|---|---|---|
| No rotation | x 10-30%, y 45-52% | x 10-30%, y 45-51% |
| `/Rotate 90` | x 7-21%, y 23-33% | x 7-21%, y 24-33% |

The rotated page's ink spans 120 pt across and 60 pt down, so the seal is neither distorted nor turned.

## Nothing moves for an unrotated document

The mapping returns its input and no `/Matrix` is written, so every committed sample and every PDF/A and PDF/UA verdict measured against them is unaffected. There is a test asserting exactly that.

## Checks

`composer check` passes in the 8.4 image: 538 tests, 3435 assertions. Twelve new tests in `tests/PageRotationTest.php`, covering all four rotations plus 360 and −90, the inherited case, the matrix in both directions, and a page with no media box. `docs/decisions/0033-the-seal-honours-page-rotation.md` records the measurement.