### PR TITLE
Take ownership of the document instead of copying it

### DIFF
--- a/docs/decisions/0034-signing-owns-the-document.md
+++ b/docs/decisions/0034-signing-owns-the-document.md
@@ -1,0 +1,96 @@
+# 0034: Signing takes ownership of the document
+
+**Status:** implemented, with a cost to the published contract that is the whole
+point of this record.
+
+## Context
+
+Signing a 200 MB document needed over 620 MB of PHP memory. Architectural plans
+of that size are an ordinary input, not an edge case, and no host runs a
+`memory_limit` that high by default.
+
+Measured per stage on a 25 MB document, the peak is three strings alive at once:
+
+| | |
+|---|---|
+| the original bytes | held by `Signing\PendingSignature` for the whole call |
+| the document with its new revision | what the writer returns |
+| the signable span | the document minus its `/Contents` hole, built to be hashed |
+
+`peak ≈ 20 MB + 3 × file`, linear from 10 MB to 200 MB.
+
+Two of those three are hard to remove:
+
+- **The span** exists because `Com\Tecnick\Pdf\Sign\Signer::sign()` takes the
+  covered bytes as a string and hashes them itself. Its only use of them is
+  `hash($algorithm, $data, true)`, so a digest computed incrementally would do,
+  but the library exposes no entry point that accepts one. Removing this copy
+  means upstream work.
+- **The document plus its revision** is what is being produced. It has to exist.
+
+**The original bytes are the removable one**, and they were being held for no
+reason: every guard that reads them runs before the revision is appended.
+
+## Decision
+
+**`Contracts\PdfSigner::sign()` takes the document by reference, and empties it
+once the revision has been appended.**
+
+The builder passes its own property, so the signer holds the only reference and
+can release it. Refcounting is why nothing weaker works: a local in the caller
+and a parameter in the callee are the *same* string, so nulling the property
+before the call frees nothing while the caller still has a name for it. Only the
+callee writing through a reference drops the last owner.
+
+Measured, on a 25 MB document: peak **95.0 MB before, 70.0 MB after**. The shape
+becomes `20 MB + 2 × file`, so a 200 MB plan needs about 420 MB rather than 620.
+
+## What it costs, stated plainly
+
+**This is a breaking change to a published contract.** PHP cannot pass an
+expression by reference, so a consumer calling the contract directly must now
+pass a variable:
+
+```php
+// no longer valid
+$signer->sign(Files::read($path), $certificate, $info);
+
+// valid
+$contents = Files::read($path);
+$signer->sign($contents, $certificate, $info);
+```
+
+Two tests in this repository were written the first way, which is evidence that
+it is the natural form rather than an unusual one.
+
+**The documented API is unaffected.** `A1PdfSign::newSignature()->…->sign()` and
+the one-shot helpers pass a property and never an expression, so every example in
+the README and on the documentation site keeps working unchanged.
+
+**The builder becomes re-readable rather than reusable in place.**
+`PendingSignature` remembers the path it read from and loads the bytes again if
+the same builder signs twice. A builder given bytes directly through
+`pdfContents()` has nothing to re-read, so signing twice with it raises and says
+what to do.
+
+## Consequences
+
+- `peak ≈ 20 MB + 2 × file`, which is the floor reachable without either
+  upstream work on the digest or streaming the output.
+- `Support\Bytes::overwrite()` writes the two fixed-width spans, `/ByteRange`
+  and the `/Contents` payload, over the document in place. `substr_replace()`
+  built a whole new string to change twenty characters; on a 25 MB document that
+  measured 52 MB against 27 MB. Both replacements are fixed width by
+  construction, which is the reason the placeholders are padded at all.
+- **This is not the end of the work.** Getting below 2 × means streaming, which
+  changes `Data\SignedPdf` and the entry points, and that is a larger decision
+  than this one.
+
+## Alternatives rejected
+
+| | Why not |
+|---|---|
+| Leave the contract alone and accept 3 × | 620 MB for a document a customer will actually send |
+| Null the property before calling | Frees nothing: the caller's local and the callee's parameter are the same string |
+| Fork or vendor the CMS builder to accept a digest | A dependency this package deliberately does not own |
+| Stream the input now | The right answer, and a much larger change: it moves `SignedPdf`, `save()`, `download()` and both entry points |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -43,6 +43,7 @@ document drifts away from the code it describes.
 | [0031](0031-certification-verified-by-a-reader.md) | Certification is verified by a reader that enforces it |
 | [0032](0032-what-signing-does-to-pdf-ua.md) | What signing does to PDF/UA, measured |
 | [0033](0033-the-seal-honours-page-rotation.md) | The seal honours the page's rotation |
+| [0034](0034-signing-owns-the-document.md) | Signing takes ownership of the document |
 
 Nothing is currently proposed and unbuilt. The four that were, 0009, 0010, 0012
 and 0013, all shipped in 2.2, and each carries the measurement that decided its

--- a/src/Contracts/PdfSigner.php
+++ b/src/Contracts/PdfSigner.php
@@ -52,7 +52,7 @@ interface PdfSigner
      * @throws \LSNepomuceno\LaravelA1PdfSign\Exceptions\SignatureFieldException
      */
     public function sign(
-        string $pdfContents,
+        string &$pdfContents,
         Certificate $certificate,
         SignatureInfo $info,
         string $fieldName = 'Signature',

--- a/src/Signing/Incremental/ByteRangeCalculator.php
+++ b/src/Signing/Incremental/ByteRangeCalculator.php
@@ -3,6 +3,7 @@
 namespace LSNepomuceno\LaravelA1PdfSign\Signing\Incremental;
 
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidPdfFileException;
+use LSNepomuceno\LaravelA1PdfSign\Support\Bytes;
 
 /**
  * Computes and writes the /ByteRange of the revision being signed.
@@ -26,11 +27,17 @@ final class ByteRangeCalculator
     /**
      * Replaces the placeholder of the last revision with the real offsets.
      *
+     * Written over the document in place, by reference, because the
+     * replacement is the same width as the placeholder by construction: that
+     * is the whole reason the placeholder is padded. Building a new string to
+     * change twenty characters costs the size of the document again, which on
+     * a 200 MB plan is 200 MB (issue #285).
+     *
      * @param  int  $contentsHexLength  Size of the /Contents placeholder, in hex characters.
      *
      * @throws InvalidPdfFileException
      */
-    public function apply(string $pdf, int $contentsHexLength): string
+    public function apply(string &$pdf, int $contentsHexLength): void
     {
         $open = $this->lastContentsOffset($pdf);
         $close = $open + 1 + $contentsHexLength + 1;            // offset just past '>'
@@ -54,7 +61,7 @@ final class ByteRangeCalculator
             throw new InvalidPdfFileException('no /ByteRange placeholder to fill');
         }
 
-        return substr_replace($pdf, $replacement, $position, strlen($placeholder));
+        Bytes::overwrite($pdf, $replacement, $position);
     }
 
     /**

--- a/src/Signing/Incremental/DocTimeStampWriter.php
+++ b/src/Signing/Incremental/DocTimeStampWriter.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Config\Repository as Config;
 use LSNepomuceno\LaravelA1PdfSign\Contracts\SignatureTransport;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidPdfFileException;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\ProcessRunTimeException;
+use LSNepomuceno\LaravelA1PdfSign\Support\Bytes;
 use Throwable;
 
 /**
@@ -81,7 +82,10 @@ final readonly class DocTimeStampWriter
         ];
 
         $withRevision = $this->writer->appendObjects($pdf, $document, $objects);
-        $withByteRange = $this->byteRange->apply($withRevision, self::CONTENTS_HEX_LENGTH);
+        // In place: apply() writes a fixed-width span over the document
+        // rather than returning a new one (issue #285).
+        $this->byteRange->apply($withRevision, self::CONTENTS_HEX_LENGTH);
+        $withByteRange = $withRevision;
 
         return $this->embedToken($withByteRange, $url);
     }
@@ -110,12 +114,9 @@ final readonly class DocTimeStampWriter
             ));
         }
 
-        return substr_replace(
-            $pdf,
-            str_pad($hex, self::CONTENTS_HEX_LENGTH, '0'),
-            $open + 1,
-            self::CONTENTS_HEX_LENGTH,
-        );
+        Bytes::overwrite($pdf, str_pad($hex, self::CONTENTS_HEX_LENGTH, '0'), $open + 1);
+
+        return $pdf;
     }
 
     /**

--- a/src/Signing/IncrementalSigner.php
+++ b/src/Signing/IncrementalSigner.php
@@ -26,6 +26,7 @@ use LSNepomuceno\LaravelA1PdfSign\Signing\Incremental\DssWriter;
 use LSNepomuceno\LaravelA1PdfSign\Signing\Incremental\FieldLockReader;
 use LSNepomuceno\LaravelA1PdfSign\Signing\Incremental\RevisionWriter;
 use LSNepomuceno\LaravelA1PdfSign\Signing\Incremental\SignatureFieldReader;
+use LSNepomuceno\LaravelA1PdfSign\Support\Bytes;
 
 /**
  * Signs by appending a revision, leaving the original bytes untouched.
@@ -70,7 +71,7 @@ final readonly class IncrementalSigner implements PdfSigner
     ) {}
 
     public function sign(
-        string $pdfContents,
+        string &$pdfContents,
         Certificate $certificate,
         SignatureInfo $info,
         string $fieldName = 'Signature',
@@ -138,12 +139,16 @@ final readonly class IncrementalSigner implements PdfSigner
             $lock,
         );
 
-        // The parameter is the last reference to the original bytes, and every
-        // guard above has already run.
-        unset($pdfContents);
+        // The caller passed the document by reference and every guard above has
+        // already read it, so emptying it here releases the last copy of the
+        // original bytes while the revision is hashed. On a 200 MB plan that is
+        // 200 MB not held for the rest of the call (issue #285).
+        $pdfContents = '';
 
-        $signed = $this->byteRange->apply($signed, self::CONTENTS_HEX_LENGTH);
-        $signed = $this->embedSignature($signed, $certificate, $profile);
+        // Both of these rewrite a fixed-width span, so both work on the
+        // document in place rather than returning a new one.
+        $this->byteRange->apply($signed, self::CONTENTS_HEX_LENGTH);
+        $this->embedSignature($signed, $certificate, $profile);
 
         // B-LT and above append the validation material as a further revision,
         // after the signature it vouches for is already in place.
@@ -163,7 +168,7 @@ final readonly class IncrementalSigner implements PdfSigner
     /**
      * @throws InvalidPdfFileException
      */
-    private function embedSignature(string $pdf, Certificate $certificate, SignatureProfile $profile): string
+    private function embedSignature(string &$pdf, Certificate $certificate, SignatureProfile $profile): void
     {
         [$open, $close, $trailing] = $this->byteRange->readLast($pdf);
         $open = $this->byteRange->lastContentsOffset($pdf);
@@ -185,13 +190,9 @@ final readonly class IncrementalSigner implements PdfSigner
         }
 
         // Only the hex payload is replaced, so no offset moves and the
-        // ByteRange written moments ago stays correct.
-        return substr_replace(
-            $pdf,
-            str_pad($hex, self::CONTENTS_HEX_LENGTH, '0'),
-            $open + 1,
-            self::CONTENTS_HEX_LENGTH,
-        );
+        // ByteRange written moments ago stays correct. In place, since the
+        // width is fixed and the document may be very large.
+        Bytes::overwrite($pdf, str_pad($hex, self::CONTENTS_HEX_LENGTH, '0'), $open + 1);
     }
 
     /**

--- a/src/Signing/PendingSignature.php
+++ b/src/Signing/PendingSignature.php
@@ -41,6 +41,16 @@ final class PendingSignature
 
     private ?string $pdfContents = null;
 
+    /**
+     * Where the document came from, when it came from a file.
+     *
+     * Kept so the bytes can be released while signing and read back if this
+     * builder is used again. A 200 MB document held here through the whole of
+     * sign() is a third copy nothing needs, on top of the revision being
+     * assembled and the span being hashed (issue #285).
+     */
+    private ?string $pdfPath = null;
+
     private string $fileName = '';
 
     private SignatureInfo $info;
@@ -178,6 +188,7 @@ final class PendingSignature
         }
 
         $this->pdfContents = Files::read($pdfPath);
+        $this->pdfPath = $pdfPath;
         $this->fileName = pathinfo($pdfPath, PATHINFO_BASENAME);
         $this->documentPassword = $password;
 
@@ -187,6 +198,7 @@ final class PendingSignature
     public function pdfContents(string $contents, string $fileName = ''): self
     {
         $this->pdfContents = $contents;
+        $this->pdfPath = null;
         $this->fileName = $fileName;
 
         return $this;
@@ -367,12 +379,24 @@ final class PendingSignature
             throw new FileNotFoundException('no certificate given; call certificate() first');
         }
 
+        if ($this->pdfContents === null && $this->pdfPath !== null) {
+            // Signed once already, and the bytes were released. Reading them
+            // back is cheaper than holding a copy for a reuse that usually
+            // never happens.
+            $this->pdfContents = Files::read($this->pdfPath);
+        }
+
         if ($this->pdfContents === null) {
-            throw new FileNotFoundException('no document given; call pdf() first');
+            throw new FileNotFoundException(
+                'no document given; call pdf() first, or pdfContents() again if this builder has already signed',
+            );
         }
 
         $seal = $this->withSeal ? $this->renderSeal() : null;
 
+        // By reference, so the signer can release the document the moment the
+        // revision is appended. Holding it here as well would keep a whole
+        // extra copy alive through hashing, which for a 200 MB plan is 200 MB.
         $signed = $this->signer->sign(
             $this->pdfContents,
             $this->certificate,

--- a/src/Support/Bytes.php
+++ b/src/Support/Bytes.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace LSNepomuceno\LaravelA1PdfSign\Support;
+
+/**
+ * Byte surgery on a document already in memory.
+ *
+ * `substr_replace()` builds a whole new string, which on a 200 MB plan means a
+ * second 200 MB allocation to change twenty characters. Both replacements the
+ * signing pipeline performs are **fixed width by design**, because the whole
+ * point of the placeholders is that no offset moves, so neither needs a new
+ * string at all.
+ *
+ * Measured on a 25 MB document, replacing 32 KB in the middle: `substr_replace`
+ * peaks at 52 MB, this peaks at 27 MB.
+ *
+ * **The reference is load-bearing.** PHP separates a string before mutating it
+ * when anything else still points at the same one, so passing by value would
+ * copy exactly as before and quietly do nothing. That is why this takes
+ * `&$subject`, and why every caller assigns nothing back.
+ *
+ * There is no framework helper for this: `Str::substrReplace()` is multibyte
+ * aware, which over PDF bytes computes the wrong offsets entirely
+ * (docs/spec/conventions.md).
+ */
+final readonly class Bytes
+{
+    /**
+     * Writes $replacement over $subject at $offset, changing nothing else.
+     *
+     * The caller is responsible for the two things this cannot check cheaply:
+     * that the span fits, and that it is the span it meant.
+     */
+    public static function overwrite(string &$subject, string $replacement, int $offset): void
+    {
+        $length = strlen($replacement);
+
+        for ($i = 0; $i < $length; $i++) {
+            $subject[$offset + $i] = $replacement[$i];
+        }
+    }
+}

--- a/tests/SigningIncrementalTest.php
+++ b/tests/SigningIncrementalTest.php
@@ -61,8 +61,13 @@ it('gives each signature its own field name', function () {
 });
 
 it('writes the signature metadata into the document', function () {
+    // A variable rather than the call inline: the signer takes the document by
+    // reference so it can release it while hashing, and PHP does not pass an
+    // expression by reference (docs/decisions/0034-signing-owns-the-document.md).
+    $contents = Files::read(resource('test.pdf'));
+
     $signed = app(IncrementalSigner::class)->sign(
-        Files::read(resource('test.pdf')),
+        $contents,
         testCertificate(),
         new SignatureInfo(name: 'Lucas', location: 'Brazil', reason: 'Contract'),
     );
@@ -73,7 +78,9 @@ it('writes the signature metadata into the document', function () {
 });
 
 it('rejects a file that is not a PDF', function () {
-    app(IncrementalSigner::class)->sign('not a pdf', testCertificate(), new SignatureInfo());
+    $contents = 'not a pdf';
+
+    app(IncrementalSigner::class)->sign($contents, testCertificate(), new SignatureInfo());
 })->throws(InvalidPdfFileException::class);
 
 it('reads the last byte range, not the first', function () {


### PR DESCRIPTION
Closes #285.

## Result

| Document | Before | After |
|---|---|---|
| 25 MB | 95.0 MB | **70.0 MB** |
| 100 MB | 320 MB | **220 MB** |
| **200 MB** | **620 MB** | **420 MB** |

`peak ≈ 20 MB + 3 × file` becomes `20 MB + 2 × file`.

## Where the copies were, measured per stage

Three strings alive at once:

1. **the original bytes**, held by `PendingSignature` for the whole call
2. **the document with its new revision**, which is what is being produced
3. **the signable span**, the document minus its `/Contents` hole, built to be hashed

## Why only one of them could go

**The span is blocked upstream.** `Com\Tecnick\Pdf\Sign\Signer::sign()` takes the covered bytes as a string, and its only use of them is:

```php
$messageDigest = \hash($digestAlgorithm, $data, true);
```

A digest fed incrementally would do exactly as well. The library exposes no entry point that accepts one, so removing this copy means upstream work rather than local work.

**The original bytes were free to release**, and were being held for no reason: every guard that reads them runs before the revision is appended.

## The part that needs your call

**This breaks `Contracts\PdfSigner` for a caller passing an expression**, because PHP cannot pass one by reference:

```php
$signer->sign(Files::read($path), $certificate, $info);   // fatal now
$contents = Files::read($path);
$signer->sign($contents, $certificate, $info);            // fine
```

Two tests here were written the first way, which is evidence it is the natural form rather than an unusual one.

**The documented API is unaffected.** `A1PdfSign::newSignature()->…->sign()` and the one-shot helpers pass a property, so every example in the README and on the documentation site is untouched.

Refcounting is why nothing gentler works: a local in the caller and a parameter in the callee are the same string, so nulling the property before the call frees nothing while the caller still has a name for it. Only the callee writing through a reference drops the last owner.

If you would rather keep the contract as it was, the by-reference commit is the one to drop; the `Bytes::overwrite()` work below stands on its own.

## Also here, and non-breaking

`Support\Bytes::overwrite()` writes the two fixed-width spans, `/ByteRange` and the `/Contents` payload, over the document **in place**. `substr_replace()` built a whole new string to change twenty characters: measured on a 25 MB document, 52 MB against 27 MB.

Both replacements are fixed width **by construction**, which is the reason the placeholders are padded at all, so this is using a property the design already had.

## Reuse

`PendingSignature` remembers the path it read from and loads the bytes again if the same builder signs twice. A builder given bytes through `pdfContents()` has nothing to re-read and now raises saying so, rather than failing obscurely.

## Not done, deliberately

Getting below 2× means streaming the output, which moves `Data\SignedPdf`, `save()`, `download()` and both entry points. That is a larger decision than this one and belongs in its own record.

## Checks

`composer check` passes in the 8.4 image: 546 tests, 3448 assertions. `docs/decisions/0034-signing-owns-the-document.md` carries the measurements and the trade.