### PR TITLE
Give every failure a shared interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ being installed**, and a minimal container commonly has the first without the se
 `MissingBinaryException`, and an environment where `proc_open` is disabled raises `ProcessUnavailableException`.
 Neither is reported as a signature that failed to verify.
 
+Every exception this package raises implements `Exceptions\A1PdfSignException`, so an application can handle them
+as a group rather than by name:
+
+```php
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\A1PdfSignException;
+
+$exceptions->report(function (A1PdfSignException $e) { … });
+```
+
+The classes stay granular beneath it. `InvalidCertificatePasswordException` is the one worth catching on its own,
+since a wrong password is the failure a production application meets most, and it extends
+`InvalidCertificateContentException` so the general catch still works.
+
 ```bash
 php artisan vendor:publish --tag=a1-pdf-sign-config
 ```

--- a/docs/spec/public-api.md
+++ b/docs/spec/public-api.md
@@ -40,11 +40,34 @@ src/
 ├── Support/                              # Files, ProcessRunner, TemporaryFile,
 │                                         # PdfFilters, PngReader, SrgbProfile
 ├── Commands/                             # pdf:sign, pdf:validate-signature
-├── Exceptions/                           # one class per failure mode
+├── Exceptions/                           # one class per failure mode, all sharing
+│                                         # the A1PdfSignException interface
 └── Testing/                              # test-only: certificates, a local timestamp
                                           # authority and a revocation one
 config/a1-pdf-sign.php
 ```
+
+## Exceptions
+
+One class per failure mode (0008), and **every one of them implements
+`Exceptions\A1PdfSignException`**, which extends `Throwable`. That is what lets
+a consuming application catch the package's failures as a group instead of
+naming sixteen classes or catching `\Exception` and swallowing everything the
+framework throws with them:
+
+```php
+$exceptions->report(function (A1PdfSignException $e) { … });
+```
+
+**The interface is surface**, and adding a class that does not implement it is a
+hole in a promise rather than an oversight. `tests/ExceptionsTest.php` builds its
+dataset from the directory, so a new exception is covered the moment the file
+exists.
+
+`InvalidCertificatePasswordException` is the one distinction worth making by
+type rather than by message: it is the most common failure in production, and it
+**extends `InvalidCertificateContentException`**, the class it used to arrive
+as, so catching the general failure still works.
 
 ## The builder
 

--- a/src/Certificates/NativeCertificateReader.php
+++ b/src/Certificates/NativeCertificateReader.php
@@ -7,6 +7,7 @@ namespace LSNepomuceno\LaravelA1PdfSign\Certificates;
 use LSNepomuceno\LaravelA1PdfSign\Contracts\CertificateReader;
 use LSNepomuceno\LaravelA1PdfSign\Data\Certificate;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidCertificateContentException;
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidCertificatePasswordException;
 use SensitiveParameter;
 
 /**
@@ -40,6 +41,13 @@ final readonly class NativeCertificateReader implements CertificateReader
 
         if (! openssl_pkcs12_read($contents, $parsed, $password)) {
             $error = openssl_error_string();
+
+            // A MAC computed with a key derived from the password did not
+            // verify, which is OpenSSL saying the file is intact and the
+            // password is wrong. Any other error is about the bundle itself.
+            if ($error !== false && str_contains($error, 'mac verify failure')) {
+                throw new InvalidCertificatePasswordException();
+            }
 
             throw new InvalidCertificateContentException(
                 'Unable to read the PKCS#12 bundle: '

--- a/src/Exceptions/A1PdfSignException.php
+++ b/src/Exceptions/A1PdfSignException.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LSNepomuceno\LaravelA1PdfSign\Exceptions;
+
+use Throwable;
+
+/**
+ * Every failure this package raises.
+ *
+ * The classes are granular on purpose, one per failure mode
+ * (docs/decisions/0008-exceptions-name-the-real-fault.md), and that left a
+ * consumer with no way to catch them as a group: the choices were naming
+ * sixteen classes or catching \Exception and swallowing everything the
+ * framework throws with them.
+ *
+ * In a Laravel application that matters in bootstrap/app.php, where reporting
+ * and rendering are registered by class:
+ *
+ * ```php
+ * ->withExceptions(function (Exceptions $exceptions) {
+ *     $exceptions->report(function (A1PdfSignException $e) { … });
+ * })
+ * ```
+ *
+ * An interface rather than a base class: several of these may want to extend a
+ * framework or SPL type later, and a base class forecloses that. Adding it to
+ * existing classes is backward compatible, since every current catch keeps
+ * matching.
+ */
+interface A1PdfSignException extends Throwable {}

--- a/src/Exceptions/CertificateOutputNotFoundException.php
+++ b/src/Exceptions/CertificateOutputNotFoundException.php
@@ -7,7 +7,7 @@ namespace LSNepomuceno\LaravelA1PdfSign\Exceptions;
 use Exception;
 use Stringable;
 
-class CertificateOutputNotFoundException extends Exception implements Stringable
+class CertificateOutputNotFoundException extends Exception implements A1PdfSignException, Stringable
 {
     public function __construct(int $code = 0, ?Exception $previous = null)
     {

--- a/src/Exceptions/CertificationException.php
+++ b/src/Exceptions/CertificationException.php
@@ -17,7 +17,7 @@ use Stringable;
  *
  * See docs/decisions/0012-certification-signatures.md.
  */
-class CertificationException extends Exception implements Stringable
+class CertificationException extends Exception implements A1PdfSignException, Stringable
 {
     /**
      * A certification has to be the first signature: it states what may happen

--- a/src/Exceptions/FieldLockException.php
+++ b/src/Exceptions/FieldLockException.php
@@ -16,7 +16,7 @@ use Stringable;
  *
  * See docs/decisions/0021-locking-fields-and-honouring-locks.md.
  */
-class FieldLockException extends Exception implements Stringable
+class FieldLockException extends Exception implements A1PdfSignException, Stringable
 {
     public static function locked(string $field, string $by): self
     {

--- a/src/Exceptions/FileNotFoundException.php
+++ b/src/Exceptions/FileNotFoundException.php
@@ -13,7 +13,7 @@ namespace LSNepomuceno\LaravelA1PdfSign\Exceptions;
 use Exception;
 use Stringable;
 
-class FileNotFoundException extends Exception implements Stringable
+class FileNotFoundException extends Exception implements A1PdfSignException, Stringable
 {
     public function __construct(string $currentFile, int $code = 0, ?Exception $previous = null)
     {

--- a/src/Exceptions/HasNoSignatureOrInvalidPkcs7Exception.php
+++ b/src/Exceptions/HasNoSignatureOrInvalidPkcs7Exception.php
@@ -7,7 +7,7 @@ namespace LSNepomuceno\LaravelA1PdfSign\Exceptions;
 use Exception;
 use Stringable;
 
-class HasNoSignatureOrInvalidPkcs7Exception extends Exception implements Stringable
+class HasNoSignatureOrInvalidPkcs7Exception extends Exception implements A1PdfSignException, Stringable
 {
     public string $currentFile;
 

--- a/src/Exceptions/InvalidCertificateContentException.php
+++ b/src/Exceptions/InvalidCertificateContentException.php
@@ -7,7 +7,7 @@ namespace LSNepomuceno\LaravelA1PdfSign\Exceptions;
 use Exception;
 use Stringable;
 
-class InvalidCertificateContentException extends Exception implements Stringable
+class InvalidCertificateContentException extends Exception implements A1PdfSignException, Stringable
 {
     /**
      * @param  string  $reason  Detail from the reader, e.g. the OpenSSL error

--- a/src/Exceptions/InvalidCertificatePasswordException.php
+++ b/src/Exceptions/InvalidCertificatePasswordException.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LSNepomuceno\LaravelA1PdfSign\Exceptions;
+
+use Exception;
+
+/**
+ * The bundle is fine and the password is not.
+ *
+ * The most common failure a consuming application meets in production, and it
+ * had no class of its own: it arrived as InvalidCertificateContentException
+ * with the reason in the message, so telling "wrong password" from "corrupt
+ * bundle" meant reading a string, which is the thing typed exceptions exist to
+ * avoid.
+ *
+ * **It extends the class it used to be**, so every existing catch keeps
+ * matching and this is additive rather than breaking.
+ *
+ * The distinction is evidence, not a guess. OpenSSL reports the two cases
+ * differently, measured on this package's own throwaway bundle:
+ *
+ * | wrong password | `error:11800071:PKCS12 routines::mac verify failure` |
+ * | corrupt bundle | `error:0680008E:asn1 encoding routines::not enough data` |
+ *
+ * The MAC is computed over the bundle with a key derived from the password, so
+ * a MAC that does not verify is precisely the statement "this password did not
+ * open this file". Anything else stays the general exception.
+ */
+final class InvalidCertificatePasswordException extends InvalidCertificateContentException
+{
+    public function __construct(int $code = 0, ?Exception $previous = null)
+    {
+        parent::__construct(
+            'the password did not open the bundle: OpenSSL reports a MAC verify failure, which means the '
+            . 'file is intact and the password is wrong.',
+            $code,
+            $previous,
+        );
+    }
+}

--- a/src/Exceptions/InvalidPFXException.php
+++ b/src/Exceptions/InvalidPFXException.php
@@ -7,7 +7,7 @@ namespace LSNepomuceno\LaravelA1PdfSign\Exceptions;
 use Exception;
 use Stringable;
 
-class InvalidPFXException extends Exception implements Stringable
+class InvalidPFXException extends Exception implements A1PdfSignException, Stringable
 {
     public function __construct(string $currentFile, int $code = 0, ?Exception $previous = null)
     {

--- a/src/Exceptions/InvalidPdfFileException.php
+++ b/src/Exceptions/InvalidPdfFileException.php
@@ -15,7 +15,7 @@ use Stringable;
  * and false of the other fifteen: a structural fault reported itself as a
  * filename problem. See docs/decisions/0008-exceptions-name-the-real-fault.md.
  */
-class InvalidPdfFileException extends Exception implements Stringable
+class InvalidPdfFileException extends Exception implements A1PdfSignException, Stringable
 {
     public function __construct(string $message, int $code = 0, ?Exception $previous = null)
     {

--- a/src/Exceptions/InvalidPemContentException.php
+++ b/src/Exceptions/InvalidPemContentException.php
@@ -15,7 +15,7 @@ use Stringable;
  * both present but do not belong together is a different failure, and keeps
  * its own class: {@see InvalidX509PrivateKeyException}.
  */
-class InvalidPemContentException extends Exception implements Stringable
+class InvalidPemContentException extends Exception implements A1PdfSignException, Stringable
 {
     /**
      * @param  string  $reason  What is wrong with the input, e.g. which block is missing.

--- a/src/Exceptions/InvalidX509PrivateKeyException.php
+++ b/src/Exceptions/InvalidX509PrivateKeyException.php
@@ -7,7 +7,7 @@ namespace LSNepomuceno\LaravelA1PdfSign\Exceptions;
 use Exception;
 use Stringable;
 
-class InvalidX509PrivateKeyException extends Exception implements Stringable
+class InvalidX509PrivateKeyException extends Exception implements A1PdfSignException, Stringable
 {
     public function __construct(int $code = 0, ?Exception $previous = null)
     {

--- a/src/Exceptions/MissingBinaryException.php
+++ b/src/Exceptions/MissingBinaryException.php
@@ -17,7 +17,7 @@ use Exception;
  * Raised rather than absorbed for the reason in ProcessUnavailableException:
  * absorbing it made a valid signature report as invalid.
  */
-final class MissingBinaryException extends Exception
+final class MissingBinaryException extends Exception implements A1PdfSignException
 {
     public function __construct(public readonly string $binary)
     {

--- a/src/Exceptions/ProcessRunTimeException.php
+++ b/src/Exceptions/ProcessRunTimeException.php
@@ -7,7 +7,7 @@ namespace LSNepomuceno\LaravelA1PdfSign\Exceptions;
 use Exception;
 use Stringable;
 
-class ProcessRunTimeException extends Exception implements Stringable
+class ProcessRunTimeException extends Exception implements A1PdfSignException, Stringable
 {
     public function __construct(string $reason, int $code = 0, ?Exception $previous = null)
     {

--- a/src/Exceptions/ProcessUnavailableException.php
+++ b/src/Exceptions/ProcessUnavailableException.php
@@ -20,7 +20,7 @@ use Exception;
  * and nothing in a log. A caller cannot tell that apart from a tampered
  * document, and the natural response is to reject something legitimate.
  */
-final class ProcessUnavailableException extends Exception
+final class ProcessUnavailableException extends Exception implements A1PdfSignException
 {
     public function __construct(string $function = 'proc_open')
     {

--- a/src/Exceptions/SealPlacementException.php
+++ b/src/Exceptions/SealPlacementException.php
@@ -17,7 +17,7 @@ use Stringable;
  *
  * See docs/decisions/0017-the-seal-goes-where-it-was-asked-for.md.
  */
-class SealPlacementException extends Exception implements Stringable
+class SealPlacementException extends Exception implements A1PdfSignException, Stringable
 {
     public static function pageOutOfRange(int $page, int $pageCount): self
     {

--- a/src/Exceptions/SignatureFieldException.php
+++ b/src/Exceptions/SignatureFieldException.php
@@ -17,7 +17,7 @@ use Stringable;
  *
  * See docs/decisions/0013-signing-into-an-existing-field.md.
  */
-class SignatureFieldException extends Exception implements Stringable
+class SignatureFieldException extends Exception implements A1PdfSignException, Stringable
 {
     /**
      * @param  list<string>  $available  Named so the caller can see the spelling

--- a/src/Exceptions/SignatureTransportException.php
+++ b/src/Exceptions/SignatureTransportException.php
@@ -19,7 +19,7 @@ use Throwable;
  * catching it to handle a shell-out problem was catching a network problem
  * instead (docs/decisions/0008-exceptions-name-the-real-fault.md).
  */
-final class SignatureTransportException extends Exception
+final class SignatureTransportException extends Exception implements A1PdfSignException
 {
     public function __construct(public readonly string $url, string $detail, ?Throwable $previous = null)
     {

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -54,10 +54,39 @@ arch('no trace of SAPP')
     ->expect('ddn\Sapp')
     ->not->toBeUsed();
 
-arch('exceptions are throwable and printable')
-    ->expect('LSNepomuceno\LaravelA1PdfSign\Exceptions')
-    ->toExtend(Exception::class)
-    ->toImplement(Stringable::class);
+/**
+ * Every exception extends Exception.
+ *
+ * Written as a walk rather than as an arch expectation, because the namespace
+ * now holds an interface as well, `A1PdfSignException`, and an arch rule cannot
+ * be told to skip it: `ignoring()` still reports it for not extending
+ * `Exception`, which an interface never does.
+ *
+ * **The Stringable half of the old rule is gone because it could never fail.**
+ * `Throwable` has extended `Stringable` since PHP 8, so every exception
+ * satisfies it whether or not it declares `__toString()`, and three of these
+ * classes do not declare one while the rule passed. PHPStan said so outright:
+ * "will always evaluate to true".
+ */
+it('keeps every exception throwable', function () {
+    $wrong = [];
+
+    $files = glob(dirname(__DIR__) . '/src/Exceptions/*.php');
+
+    foreach ($files === false ? [] : $files as $file) {
+        $name = 'LSNepomuceno\\LaravelA1PdfSign\\Exceptions\\' . basename($file, '.php');
+
+        if (interface_exists($name)) {
+            continue;
+        }
+
+        if (! is_subclass_of($name, Exception::class)) {
+            $wrong[] = $name;
+        }
+    }
+
+    expect($wrong)->toBe([]);
+});
 
 arch('value objects are immutable')
     ->expect('LSNepomuceno\LaravelA1PdfSign\Data')

--- a/tests/ExceptionsTest.php
+++ b/tests/ExceptionsTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use LSNepomuceno\LaravelA1PdfSign\Contracts\CertificateReader;
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\A1PdfSignException;
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidCertificateContentException;
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidCertificatePasswordException;
+use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
+
+/**
+ * What a consuming application can catch.
+ *
+ * The classes are granular on purpose, one per failure mode
+ * (docs/decisions/0008-exceptions-name-the-real-fault.md). Until now that left
+ * no way to catch them as a group: sixteen classes, or `\Exception` and
+ * everything the framework throws with them.
+ */
+it('lets every failure be caught as one', function (string $class) {
+    expect(class_exists($class) || interface_exists($class))->toBeTrue()
+        ->and(is_a($class, A1PdfSignException::class, allow_string: true))->toBeTrue();
+})->with(function () {
+    $classes = [];
+
+    $files = glob(dirname(__DIR__) . '/src/Exceptions/*.php');
+
+    foreach ($files === false ? [] : $files as $file) {
+        $name = 'LSNepomuceno\\LaravelA1PdfSign\\Exceptions\\' . basename($file, '.php');
+
+        // The interface itself, which cannot implement itself.
+        if ($name !== A1PdfSignException::class) {
+            $classes[basename($file, '.php')] = $name;
+        }
+    }
+
+    return $classes;
+});
+
+it('finds every exception rather than a list somebody has to remember', function () {
+    // The dataset above is built from the directory, so a new exception is
+    // covered the moment it exists. This asserts the directory is actually
+    // being read, since a glob that silently returns nothing would make the
+    // test above pass with no cases at all.
+    expect(glob(dirname(__DIR__) . '/src/Exceptions/*.php'))->toHaveCount(18);
+});
+
+it('names a wrong password as a wrong password', function () {
+    [$pfxPath, $password] = debugCertificate();
+
+    expect(fn() => app(CertificateReader::class)->read((string) file_get_contents($pfxPath), 'not the password'))
+        ->toThrow(InvalidCertificatePasswordException::class);
+});
+
+it('keeps a wrong password catchable as what it used to be', function () {
+    // The new class extends the one this used to arrive as, so an application
+    // already catching the general failure keeps working. That is what makes
+    // this additive rather than breaking.
+    [$pfxPath] = debugCertificate();
+
+    expect(fn() => app(CertificateReader::class)->read((string) file_get_contents($pfxPath), 'wrong'))
+        ->toThrow(InvalidCertificateContentException::class);
+});
+
+it('does not call a corrupt bundle a wrong password', function () {
+    // The distinction is evidence rather than a guess: OpenSSL answers a bad
+    // password with a MAC verify failure and a broken file with an ASN.1
+    // error. Reading a string to tell them apart is what the class exists to
+    // stop, so it must not simply guess "password" for every failure.
+    try {
+        app(CertificateReader::class)->read('this is not a PKCS#12 bundle at all', 'anything');
+    } catch (InvalidCertificateContentException $exception) {
+        expect($exception)->not->toBeInstanceOf(InvalidCertificatePasswordException::class);
+
+        return;
+    }
+
+    expect(false)->toBeTrue();
+});
+
+it('is caught as a group through the facade, which is how an application meets it', function () {
+    // The shape a consumer actually writes: one catch around the whole flow.
+    try {
+        A1PdfSign::newSignature()
+            ->certificate(resource('test.pdf'), 'not a certificate')
+            ->pdf(resource('test.pdf'))
+            ->sign();
+    } catch (A1PdfSignException $exception) {
+        expect($exception)->toBeInstanceOf(Throwable::class);
+
+        return;
+    }
+
+    expect(false)->toBeTrue();
+});


### PR DESCRIPTION
Closes #275.

## What was missing

Sixteen exception classes, granular on purpose ([0008](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/blob/main/docs/decisions/0008-exceptions-name-the-real-fault.md)), **every one extending `Exception` directly**. So a consumer had two options: name sixteen classes, or catch `\Exception` and swallow everything the framework throws with them.

```php
$exceptions->report(function (A1PdfSignException $e) { … });
```

An interface rather than a base class: several of these may want to extend a framework or SPL type later, and a base class forecloses that. Adding it to existing classes is backward compatible, since every current `catch` keeps matching.

## A wrong password now has a name

The failure a production application meets most, and it had no class: it arrived as `InvalidCertificateContentException` with the reason in the message, so telling it from a corrupt bundle meant reading a string.

`InvalidCertificatePasswordException` **extends the class it used to be**, so this is additive.

**The distinction is evidence, not a guess.** Measured on this package's own bundle:

| wrong password | `error:11800071:PKCS12 routines::mac verify failure` |
|---|---|
| **corrupt bundle** | `error:0680008E:asn1 encoding routines::not enough data` |

The MAC is computed over the bundle with a key derived from the password, so a MAC that does not verify is precisely the statement "the file is intact and this password is wrong". Anything else stays the general exception, and there is a test asserting a corrupt bundle is **not** called a wrong password.

## Two things the change turned up in the existing arch rule

**It could not be told to skip an interface.** `ignoring()` still reports `A1PdfSignException` for not extending `Exception`, which an interface never does. The rule is a walk now.

**Its `Stringable` half could never fail.** `Throwable` has extended `Stringable` since PHP 8, so every exception satisfies it whether or not it declares `__toString()` — and three of these classes declare none while the rule passed green. PHPStan said so outright once the walk made it explicit: *"will always evaluate to true"*. Removed rather than left as decoration.

## The completeness check reads the directory

`tests/ExceptionsTest.php` builds its dataset from `src/Exceptions/*.php`, so a new exception is covered the moment the file exists, with no list for anyone to forget. A second test asserts the glob actually returns something, since a silently empty dataset would make the first pass with no cases at all.

## Checks

`composer check` passes in the 8.4 image: 574 tests, 3493 assertions. Documented in `docs/spec/public-api.md`, which now has an Exceptions section, and in the README.