### PR TITLE
Read a document from a Laravel disk, and say the seal is swappable

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ $signed->download('contract.pdf'); // BinaryFileResponse
 > needs. That is [TCPDF#430](https://github.com/tecnickcom/TCPDF/issues/430), open since 2021, and it is the single most
 > important behaviour in this package.
 
+### The document does not have to be a local file
+
+An application keeping contracts on `s3`, `minio` or any Flysystem disk does not have to download one first:
+
+```php
+A1PdfSign::newSignature()
+    ->certificate($pfx, $password)
+    ->pdfFromDisk('s3', 'contracts/deal.pdf')
+    ->sign();
+
+// or hand over the bytes yourself, from anywhere at all
+->pdfContents($bytes, 'deal.pdf')
+```
+
+Both hold the whole document in memory, so neither helps with a very large one.
+
 [Signing a document →](https://laravel-a1-pdf-sign.netlify.app/docs/2.x/sign-pdf-file)
 
 ## What it does
@@ -102,6 +118,23 @@ $signed->download('contract.pdf'); // BinaryFileResponse
 | **ICP-Brasil identity** | CPF, CNPJ and the rest, read from the certificate rather than parsed out of a name |
 | **PDF/A** | a signed document stays conformant, measured with veraPDF rather than assumed |
 | **PDF/UA** | measured too: an invisible signature keeps an accessible document conformant, a visible seal does not |
+
+## Bringing your own seal
+
+The seal is drawn by `Contracts\SealRenderer`, bound in the container, so replacing it is one line in your own
+service provider:
+
+```php
+$this->app->bind(SealRenderer::class, QrCodeSealRenderer::class);
+```
+
+That is the route for a corporate logo, a QR code linking to a validation page, or any layout of your own. The
+contract has two methods: `render()` builds a seal from the certificate, and `fromImage()` embeds artwork you
+already have.
+
+**`fromImage()` is also the answer to "can I draw the seal with Blade".** Render your view to an image however you
+like and hand the result over; the package stays out of the business of turning HTML into pixels, which would be a
+large dependency for a signing library.
 
 ## Certificates
 

--- a/docs/spec/public-api.md
+++ b/docs/spec/public-api.md
@@ -47,6 +47,25 @@ src/
 config/a1-pdf-sign.php
 ```
 
+## The contracts a consumer may replace
+
+Five contracts are bound in the service provider, and two of them are
+deliberately swappable by a consuming application:
+
+| | |
+|---|---|
+| `Contracts\SealRenderer` | replace to draw a different seal: a logo, a QR code, any layout |
+| `Contracts\SignatureTransport` | replace to own the TSA, OCSP and CRL calls, which is the SSRF surface (invariant 9) |
+
+**Writing that down makes their signatures public API**, which is the cost and
+is worth paying: they were already published contracts, and a consumer who
+cannot find out they may be replaced has an extension point that does not
+exist.
+
+`SealRenderer::fromImage()` is how artwork produced elsewhere gets in, Blade
+included. The package does not turn HTML into pixels
+([0004](../decisions/0004-in-memory-seal.md)).
+
 ## Exceptions
 
 One class per failure mode (0008), and **every one of them implements

--- a/src/Signing/PendingSignature.php
+++ b/src/Signing/PendingSignature.php
@@ -6,6 +6,7 @@ namespace LSNepomuceno\LaravelA1PdfSign\Signing;
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
 use LSNepomuceno\LaravelA1PdfSign\Certificates\PemCertificateReader;
 use LSNepomuceno\LaravelA1PdfSign\Contracts\CertificateReader;
 use LSNepomuceno\LaravelA1PdfSign\Contracts\PdfSigner;
@@ -192,6 +193,38 @@ final class PendingSignature
         $this->pdfContents = Files::read($pdfPath);
         $this->pdfPath = $pdfPath;
         $this->fileName = pathinfo($pdfPath, PATHINFO_BASENAME);
+        $this->documentPassword = $password;
+
+        return $this;
+    }
+
+    /**
+     * The document from a Laravel disk, rather than from a local path.
+     *
+     * An application keeping contracts on `s3` or `minio` appeared to have to
+     * download to a temporary file first. It never did: `pdfContents()` takes
+     * the bytes, and `Storage::disk('s3')->get(...)` returns them. This is that
+     * call with the file name carried across, so the signed document keeps a
+     * name rather than an ordered UUID.
+     *
+     * **It holds the whole document in memory**, the same as `pdfContents()`,
+     * so it does not help a very large one. Streaming is a different change
+     * (issue #285 measured it) and pretending otherwise here would be worse
+     * than the silence this replaces.
+     *
+     * @throws FileNotFoundException
+     */
+    public function pdfFromDisk(string $disk, string $path, #[SensitiveParameter] string $password = ''): self
+    {
+        $contents = Storage::disk($disk)->get($path);
+
+        if ($contents === null) {
+            throw new FileNotFoundException("{$disk}:{$path}");
+        }
+
+        $this->pdfContents = $contents;
+        $this->pdfPath = null;
+        $this->fileName = basename($path);
         $this->documentPassword = $password;
 
         return $this;

--- a/tests/DiskTest.php
+++ b/tests/DiskTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Storage;
+use LSNepomuceno\LaravelA1PdfSign\Contracts\SignatureValidator;
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\FileNotFoundException;
+use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
+use LSNepomuceno\LaravelA1PdfSign\Support\Files;
+
+/**
+ * Signing a document that lives on a Laravel disk.
+ *
+ * `pdf()` takes a local path, so an application keeping contracts on `s3` or
+ * `minio` appeared to be forced to download to a temporary file first. It never
+ * was: `pdfContents()` takes bytes and `Storage::disk(...)->get()` returns
+ * them. The gap was that nobody could find that out, since the README showed
+ * only the path form.
+ *
+ * `pdfFromDisk()` is that call with the file name carried across, and this file
+ * asserts both forms so the documented one and the underlying one cannot drift.
+ */
+it('signs a document read from a disk', function () {
+    Storage::fake('documents');
+    Storage::disk('documents')->put('contracts/deal.pdf', Files::read(resource('test.pdf')));
+
+    [$pfxPath, $password] = debugCertificate();
+
+    $signed = A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdfFromDisk('documents', 'contracts/deal.pdf')
+        ->sign();
+
+    expect(app(SignatureValidator::class)->validate($signed->contents)->isValid())->toBeTrue();
+});
+
+it('keeps the name the document had on the disk', function () {
+    Storage::fake('documents');
+    Storage::disk('documents')->put('contracts/deal.pdf', Files::read(resource('test.pdf')));
+
+    [$pfxPath, $password] = debugCertificate();
+
+    $signed = A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdfFromDisk('documents', 'contracts/deal.pdf')
+        ->sign();
+
+    // Without this the signed document is named after an ordered UUID, which is
+    // the whole reason this is not just a call to pdfContents().
+    expect($signed->fileName)->toContain('deal');
+});
+
+it('says which disk and which path when the document is not there', function () {
+    Storage::fake('documents');
+
+    [$pfxPath, $password] = debugCertificate();
+
+    expect(fn() => A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdfFromDisk('documents', 'contracts/missing.pdf'))
+        ->toThrow(FileNotFoundException::class);
+});
+
+it('signs the same document handed over as bytes, which is what it does underneath', function () {
+    // The form that already worked and was undocumented. Asserted beside the
+    // sugar so the two cannot drift apart.
+    Storage::fake('documents');
+    Storage::disk('documents')->put('deal.pdf', Files::read(resource('test.pdf')));
+
+    [$pfxPath, $password] = debugCertificate();
+
+    $signed = A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdfContents((string) Storage::disk('documents')->get('deal.pdf'), 'deal.pdf')
+        ->sign();
+
+    expect(app(SignatureValidator::class)->validate($signed->contents)->isValid())->toBeTrue();
+});


### PR DESCRIPTION
Closes #279.

Two extension points that **already existed and that nobody could find**.

## A document on S3

`pdf()` takes a local path, so an application keeping contracts on a Flysystem disk appeared to be forced to download one first.

It never was. `pdfContents()` takes the bytes and `Storage::disk('s3')->get()` returns them, and that combination appeared **nowhere in the README**.

```php
->pdfFromDisk('s3', 'contracts/deal.pdf')
```

is that call with the file name carried across, so the signed document keeps a name rather than an ordered UUID. There is a test for exactly that, since it is the only reason this is more than sugar.

**Both forms hold the whole document in memory**, and the docblock and the README say so. Streaming is #285, and implying otherwise here would be worse than the silence it replaces.

## A seal of your own

`Contracts\SealRenderer` is bound in the service provider, so a consumer replaces it in one line:

```php
$this->app->bind(SealRenderer::class, QrCodeSealRenderer::class);
```

`grep -rn SealRenderer README.md CONTRIBUTING.md` found **nothing**. The contract appeared in `public-api.md` only as a filename in a directory tree.

**`fromImage()` is also the answer to "can I draw the seal with Blade"**: render the view to an image however you like and hand the result over. The package stays out of turning HTML into pixels, which would be a large dependency for a signing library and would sit oddly beside [0004](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/blob/main/docs/decisions/0004-in-memory-seal.md).

## The cost, stated

Writing the swappable contracts into `docs/spec/public-api.md` **makes their signatures public API**. Worth paying: they were already published contracts, and an extension point nobody can find does not exist. `SignatureTransport` is listed beside `SealRenderer` for the same reason, since invariant 9 already makes the host the owner of that surface.

## Checks

`composer check` passes in the 8.4 image: 578 tests, 3497 assertions. Four new tests in `tests/DiskTest.php`, all against `Storage::fake()`, covering the disk form, the name, the missing file, and the bytes form beneath it so the two cannot drift.