### PR TITLE
a1-pdf-sign:check, so the environment answers before signing

### DIFF
--- a/docs/spec/public-api.md
+++ b/docs/spec/public-api.md
@@ -39,7 +39,8 @@ src/
 ├── Seal/InterventionSealRenderer.php
 ├── Support/                              # Files, ProcessRunner, TemporaryFile,
 │                                         # PdfFilters, PngReader, SrgbProfile
-├── Commands/                             # pdf:sign, pdf:validate-signature
+├── Commands/                             # pdf:sign, pdf:validate-signature,
+│                                         # a1-pdf-sign:check
 ├── Exceptions/                           # one class per failure mode, all sharing
 │                                         # the A1PdfSignException interface
 └── Testing/                              # test-only: certificates, a local timestamp

--- a/src/Commands/CheckEnvironmentCommand.php
+++ b/src/Commands/CheckEnvironmentCommand.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LSNepomuceno\LaravelA1PdfSign\Commands;
+
+use Illuminate\Console\Command;
+use LSNepomuceno\LaravelA1PdfSign\Contracts\SignatureTransport;
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\A1PdfSignException;
+use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
+use LSNepomuceno\LaravelA1PdfSign\Support\ProcessRunner;
+use Throwable;
+
+/**
+ * What this package needs from the environment, answered before anything is
+ * signed.
+ *
+ * Every check here is a real failure this package has had. The sharpest is the
+ * openssl binary: ext-openssl being loaded says nothing about the command-line
+ * tool being installed, and without it validation used to report every
+ * signature as invalid in silence. That is fixed at the point of failure, and
+ * this answers the same question in advance.
+ *
+ * **The TSA check is opt-in.** Invariant 9 keeps network access behind the
+ * injected transport, and a diagnostic that reached a third party by default
+ * would make `artisan` calls do it too.
+ *
+ * **Nothing sensitive is printed.** The output of this command is what gets
+ * pasted into an issue.
+ */
+class CheckEnvironmentCommand extends Command
+{
+    protected $signature = 'a1-pdf-sign:check
+                                {--tsa : Also reach the configured timestamp authority}
+        ';
+
+    protected $description = 'Reports whether this environment can sign and validate';
+
+    /** @var list<string> */
+    private array $fatal = [];
+
+    public function handle(ProcessRunner $processes): int
+    {
+        $this->line('Checking what laravel-a1-pdf-sign needs from this environment.', 'info');
+        $this->newLine();
+
+        $this->requirement('ext-openssl', extension_loaded('openssl'), 'PKCS#12 reading and CMS building');
+        $this->requirement('ext-bcmath', extension_loaded('bcmath'), 'required by tc-lib-pdf through tc-lib-barcode');
+        $this->requirement('proc_open', function_exists('proc_open'), 'validation shells out; often in disable_functions');
+
+        $this->requirement(
+            'openssl binary',
+            $this->binaryExists($processes),
+            'validation and legacy PFX. Separate from ext-openssl',
+        );
+
+        $this->optional(
+            'ext-gd or ext-imagick',
+            extension_loaded('gd') || extension_loaded('imagick'),
+            'only needed to draw a visible seal',
+        );
+
+        $this->requirement('temporary directory', $this->temporaryDirectoryIsWritable(), 'every shell-out writes one');
+
+        $this->optional(
+            'memory_limit',
+            $this->memoryLimitIsGenerous(),
+            'signing peaks at roughly 20 MB plus twice the document',
+        );
+
+        if ($this->option('tsa') === true) {
+            $this->timestampAuthority();
+        }
+
+        $this->newLine();
+
+        if ($this->fatal !== []) {
+            $this->line('This environment cannot sign or validate: ' . implode(', ', $this->fatal), 'error');
+
+            return self::FAILURE;
+        }
+
+        $this->line('This environment can sign and validate.', 'info');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Something without which the package cannot do its job.
+     */
+    private function requirement(string $name, bool $met, string $why): void
+    {
+        $this->line(sprintf('  %s %-22s %s', $met ? '[ok]' : '[NO]', $name, $why), $met ? 'info' : 'error');
+
+        if (! $met) {
+            $this->fatal[] = $name;
+        }
+    }
+
+    /**
+     * Something a host may legitimately not have.
+     *
+     * Reported and never fatal: a host that only signs invisibly needs no image
+     * library, and exiting non-zero over it would make this command unusable in
+     * a deployment pipeline, which is the one place it is worth running.
+     */
+    private function optional(string $name, bool $met, string $why): void
+    {
+        $this->line(sprintf('  %s %-22s %s', $met ? '[ok]' : '[--]', $name, $why), $met ? 'info' : 'comment');
+    }
+
+    private function binaryExists(ProcessRunner $processes): bool
+    {
+        try {
+            // Through the runner, so it is faked with everything else and the
+            // arch rule about processes still holds.
+            $processes->run('openssl version');
+
+            return true;
+        } catch (A1PdfSignException) {
+            return false;
+        }
+    }
+
+    private function temporaryDirectoryIsWritable(): bool
+    {
+        try {
+            return is_writable(A1PdfSign::tempPath());
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    private function memoryLimitIsGenerous(): bool
+    {
+        $limit = ini_get('memory_limit');
+
+        if ($limit === false || $limit === '-1') {
+            return true;
+        }
+
+        return $this->bytes($limit) >= 256 * 1024 * 1024;
+    }
+
+    private function bytes(string $limit): int
+    {
+        $value = (int) $limit;
+
+        return match (strtolower(substr($limit, -1))) {
+            'g' => $value * 1024 * 1024 * 1024,
+            'm' => $value * 1024 * 1024,
+            'k' => $value * 1024,
+            default => $value,
+        };
+    }
+
+    private function timestampAuthority(): void
+    {
+        $url = config('a1-pdf-sign.signature.timestamp.url');
+
+        if (! is_string($url) || $url === '') {
+            $this->optional('timestamp authority', false, 'none configured; pades-b-t and above need one');
+
+            return;
+        }
+
+        try {
+            // Through the contract, so this cannot become a second place that
+            // opens a connection (invariant 9).
+            app(SignatureTransport::class)->timestamp($url)('');
+
+            $this->optional('timestamp authority', true, 'answered');
+        } catch (Throwable $exception) {
+            $this->optional('timestamp authority', false, 'did not answer: ' . $exception->getMessage());
+        }
+    }
+}

--- a/src/LaravelA1PdfSignServiceProvider.php
+++ b/src/LaravelA1PdfSignServiceProvider.php
@@ -7,7 +7,7 @@ namespace LSNepomuceno\LaravelA1PdfSign;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use LSNepomuceno\LaravelA1PdfSign\Certificates\ReaderFactory;
-use LSNepomuceno\LaravelA1PdfSign\Commands\{SignPdfCommand, ValidatePdfSignatureCommand};
+use LSNepomuceno\LaravelA1PdfSign\Commands\{CheckEnvironmentCommand, SignPdfCommand, ValidatePdfSignatureCommand};
 use LSNepomuceno\LaravelA1PdfSign\Contracts\A1PdfSign;
 use LSNepomuceno\LaravelA1PdfSign\Contracts\CertificateReader;
 use LSNepomuceno\LaravelA1PdfSign\Contracts\PdfSigner;
@@ -65,6 +65,7 @@ class LaravelA1PdfSignServiceProvider extends ServiceProvider
             ], 'a1-pdf-sign-config');
 
             $this->commands([
+                CheckEnvironmentCommand::class,
                 SignPdfCommand::class,
                 ValidatePdfSignatureCommand::class,
             ]);

--- a/tests/CheckEnvironmentTest.php
+++ b/tests/CheckEnvironmentTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Process;
+use LSNepomuceno\LaravelA1PdfSign\Contracts\SignatureTransport;
+
+/**
+ * The diagnostic, and what it refuses to do.
+ *
+ * #269 established that a missing `openssl` binary made validation report every
+ * signature as invalid, in silence. That is fixed where it happens, which is
+ * necessary and reactive: the operator still learns about it from a signature
+ * that came back wrong. This answers the same question before anything is
+ * signed.
+ */
+it('reports a healthy environment and exits zero', function () {
+    // Asserted against the whole output rather than through
+    // expectsOutputToContain(), which matches one line at a time and cannot see
+    // a report written as several.
+    $this->withoutMockingConsoleOutput();
+
+    expect(Artisan::call('a1-pdf-sign:check'))->toBe(0)
+        ->and(Artisan::output())
+        ->toContain('ext-openssl')
+        ->toContain('openssl binary')
+        ->toContain('temporary directory')
+        ->toContain('This environment can sign and validate.');
+});
+
+it('exits non-zero when the openssl binary is missing, so a pipeline can use it', function () {
+    // Faked rather than uninstalled: the binary is present in the image, and
+    // the point is what the command does when it is not.
+    Process::fake(['openssl*' => Process::result(exitCode: 127, errorOutput: 'not found')]);
+
+    $this->withoutMockingConsoleOutput();
+
+    expect(Artisan::call('a1-pdf-sign:check'))->toBe(1)
+        ->and(Artisan::output())
+        ->toContain('[NO] openssl binary')
+        ->toContain('cannot sign or validate');
+});
+
+it('does not reach the network unless it is asked to', function () {
+    // Invariant 9 keeps network access behind the injected transport, and a
+    // diagnostic that reached a third party by default would make every artisan
+    // call do it too.
+    //
+    // Asserted through the output rather than with a spy: the line exists only
+    // when the authority is contacted, so its absence is the statement.
+    config()->set('a1-pdf-sign.signature.timestamp.url', 'https://tsa.example/tsr');
+
+    $this->withoutMockingConsoleOutput();
+
+    expect(Artisan::call('a1-pdf-sign:check'))->toBe(0)
+        ->and(Artisan::output())->not->toContain('timestamp authority');
+});
+
+it('reaches the authority through the contract when asked', function () {
+    config()->set('a1-pdf-sign.signature.timestamp.url', 'https://tsa.example/tsr');
+
+    // Through the contract, so this cannot become a second place that opens a
+    // connection, and so the test touches no real authority.
+    app()->instance(SignatureTransport::class, new class implements SignatureTransport {
+        public function timestamp(string $url, ?string $username = null, ?string $password = null): callable
+        {
+            return static fn(string $request): string => 'a token';
+        }
+
+        public function ocsp(): callable
+        {
+            return static fn(string $url, string $request): false => false;
+        }
+
+        public function crl(): callable
+        {
+            return static fn(string $url): false => false;
+        }
+    });
+
+    $this->withoutMockingConsoleOutput();
+
+    expect(Artisan::call('a1-pdf-sign:check', ['--tsa' => true]))->toBe(0)
+        ->and(Artisan::output())->toContain('timestamp authority')
+        ->toContain('answered');
+});
+
+it('says nothing a person would mind pasting into an issue', function () {
+    // The output of this command is what ends up in a bug report.
+    config()->set('a1-pdf-sign.signature.timestamp.password', 'hunter2');
+
+    $this->withoutMockingConsoleOutput();
+
+    expect(Artisan::call('a1-pdf-sign:check'))->toBe(0)
+        ->and(Artisan::output())->not->toContain('hunter2');
+});


### PR DESCRIPTION
Closes #278.

```
$ php artisan a1-pdf-sign:check

  [ok] ext-openssl            PKCS#12 reading and CMS building
  [ok] ext-bcmath             required by tc-lib-pdf through tc-lib-barcode
  [ok] proc_open              validation shells out; often in disable_functions
  [ok] openssl binary         validation and legacy PFX. Separate from ext-openssl
  [ok] ext-gd or ext-imagick  only needed to draw a visible seal
  [ok] temporary directory    every shell-out writes one
  [ok] memory_limit           signing peaks at roughly 20 MB plus twice the document

This environment can sign and validate.
```

## Why it earns its place

#269 established that a missing `openssl` **binary** made validation report every signature as invalid, in silence. That is fixed at the point of failure, which is necessary and **reactive**: the operator still learns about it from a signature that came back wrong.

Every line above is a real failure this package has had or would have, and the distinction that costs people an afternoon is stated in the output itself: `ext-openssl` being loaded says nothing about the command-line tool being installed.

## Three deliberate choices

**Non-zero only for the fatal.** A host that never draws a seal needs no image library, and exiting non-zero over it would make the command unusable in the one place it is worth running.

**The network is opt-in.** [Invariant 9](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/blob/main/docs/spec/invariants.md) keeps network access behind the injected transport, so a diagnostic that reached a third party by default would make every `artisan` call do it too. `--tsa` opts in, and goes through `Contracts\SignatureTransport` so this cannot become a second place that opens a connection.

**Nothing sensitive is printed.** The output of this command is what gets pasted into an issue, and there is a test asserting a configured TSA password does not appear in it.

The binary check goes through `Support\ProcessRunner`, so it is faked with everything else and invariant 8 still holds.

## A note on the tests

They assert against `Artisan::output()` rather than `expectsOutputToContain()`, which matches one line at a time and cannot see a report written as several. The spy objects the network tests started with are gone too: the "did not reach" case is asserted by the **absence** of the line that only exists when it is reached, which needs no double at all.

## Checks

`composer check` passes in the 8.4 image: 595 tests, 3539 assertions.