### PR TITLE
An optional audit trail whose context is an allowlist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
     "illuminate/process": "^13",
     "illuminate/support": "^13",
     "intervention/image": "^3.11",
+    "psr/log": "^3.0",
     "symfony/http-foundation": "^8",
     "tecnickcom/tc-lib-pdf-sign": "^1.1"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b71c5bf5216f9438b1c8f1e4d3bd9b7",
+    "content-hash": "f9fcda5f97fb752c4c9fa208ac157c29",
     "packages": [
         {
             "name": "brick/math",

--- a/docs/decisions/0035-the-audit-trail-is-opt-in.md
+++ b/docs/decisions/0035-the-audit-trail-is-opt-in.md
@@ -1,0 +1,71 @@
+# 0035: The audit trail is opt-in, and its context is an allowlist
+
+**Status:** implemented.
+
+## Context
+
+Digital signatures in corporate systems are audited. Who signed, when, at what
+level, and which documents failed to verify are questions somebody eventually
+has to answer, and nothing here recorded any of them.
+
+The package runs only inside Laravel, so a PSR-3 logger is available from the
+container and this is a wiring question rather than a dependency one.
+
+## Decision
+
+**Null by default, injected rather than resolved.**
+
+A package that logs unasked fills somebody's disk, and a host that wants an
+audit trail knows it. `Support\SigningLog` takes an optional
+`Psr\Log\LoggerInterface` and does nothing without one, and it is a constructor
+argument rather than a `Log::` call inside the signer, because a dependency
+reached through a facade is invisible and untestable.
+
+**The context is an allowlist, and that is the load-bearing part.**
+
+This package handles PKCS#12 bundles, private keys and passwords. Every password
+argument is already marked `#[\SensitiveParameter]`, which keeps the value out
+of a stack trace and has nothing whatever to say about a line somebody wrote to
+disk. A logger is a second channel, and it needed its own answer.
+
+So `SigningLog::ALLOWED` names the keys that may appear, and anything else is
+dropped. **A denylist would have been the wrong shape**: it is how the next
+property added to a data object ends up in a log file, silently, because nobody
+remembered to forbid it.
+
+Values are scalars only. An object arriving under an allowed name could carry a
+key into whatever formats the line, and the format is the host's choice rather
+than ours.
+
+Absent on purpose, though they would be useful: the document, the CMS, the PFX
+bytes, any password, and **any file path**. A path is enough to find the bundle
+it names.
+
+**The event names are an enum.** A closed set of values is an enum here
+([0018](0018-prefer-the-platforms-own-constructs.md)), and there are four of
+them rather than one per internal step: an audit trail and a debug trace want
+different retention, and mixing them produces neither.
+
+## Consequences
+
+- Nothing changes for a host that does not ask. The default constructor argument
+  is a `SigningLog` with no logger, and the arity of `IncrementalSigner` grows by
+  one defaulted parameter, which is how 0021 and 2.2 taught this codebase to add
+  a dependency without breaking a hand-built signer.
+- `tests/AuditLogTest.php` asserts, for every event, that no password, no key
+  and no path appears in any line. That test is the reason the allowlist can be
+  trusted rather than merely intended.
+- Validation logs its verdict, including failure. A failed validation is the
+  event most worth auditing and also the one an attacker can trigger in bulk by
+  feeding bad documents, so a host that exposes validation publicly should rate
+  limit before it enables this.
+
+## Alternatives rejected
+
+| | Why not |
+|---|---|
+| Log by default | Fills a disk nobody asked to fill, and makes the package noisy in every application that installs it |
+| Resolve `Log::` inside the signer | Invisible, and untestable without touching the facade |
+| A denylist of forbidden keys | The next property added to a DTO leaks, and nothing fails |
+| Log the document or the CMS | Enormous, and the CMS carries the signature it is supposed to protect |
+| Log the certificate path | Enough to find the bundle, which is the thing being protected |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -44,6 +44,7 @@ document drifts away from the code it describes.
 | [0032](0032-what-signing-does-to-pdf-ua.md) | What signing does to PDF/UA, measured |
 | [0033](0033-the-seal-honours-page-rotation.md) | The seal honours the page's rotation |
 | [0034](0034-signing-owns-the-document.md) | Signing takes ownership of the document |
+| [0035](0035-the-audit-trail-is-opt-in.md) | The audit trail is opt-in, and its context is an allowlist |
 
 Nothing is currently proposed and unbuilt. The four that were, 0009, 0010, 0012
 and 0013, all shipped in 2.2, and each carries the measurement that decided its

--- a/src/Enums/SigningEvent.php
+++ b/src/Enums/SigningEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LSNepomuceno\LaravelA1PdfSign\Enums;
+
+/**
+ * What an audit log records.
+ *
+ * A closed set of values, so an enum rather than class constants
+ * (docs/decisions/0018-prefer-the-platforms-own-constructs.md).
+ *
+ * Deliberately few. Each one is a moment a corporate audit asks about: a
+ * signature was applied, a third party attested the time, a document did not
+ * verify. Logging every internal step would turn an audit trail into a debug
+ * trace, and the two want different retention.
+ */
+enum SigningEvent: string
+{
+    /** A signature was appended to a document. */
+    case SignatureApplied = 'signature.applied';
+
+    /** A timestamp authority answered, so the time is attested by a third party. */
+    case TimestampReceived = 'timestamp.received';
+
+    /** A document was validated, whatever the verdict. */
+    case ValidationCompleted = 'validation.completed';
+
+    /** A document did not verify. */
+    case ValidationFailed = 'validation.failed';
+}

--- a/src/Signing/IncrementalSigner.php
+++ b/src/Signing/IncrementalSigner.php
@@ -14,6 +14,7 @@ use LSNepomuceno\LaravelA1PdfSign\Data\SignatureInfo;
 use LSNepomuceno\LaravelA1PdfSign\Data\SignedPdf;
 use LSNepomuceno\LaravelA1PdfSign\Enums\CertificationLevel;
 use LSNepomuceno\LaravelA1PdfSign\Enums\SignatureProfile;
+use LSNepomuceno\LaravelA1PdfSign\Enums\SigningEvent;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\CertificationException;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\FieldLockException;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidPdfFileException;
@@ -29,6 +30,7 @@ use LSNepomuceno\LaravelA1PdfSign\Signing\Incremental\FieldLockReader;
 use LSNepomuceno\LaravelA1PdfSign\Signing\Incremental\RevisionWriter;
 use LSNepomuceno\LaravelA1PdfSign\Signing\Incremental\SignatureFieldReader;
 use LSNepomuceno\LaravelA1PdfSign\Support\Bytes;
+use LSNepomuceno\LaravelA1PdfSign\Support\SigningLog;
 
 /**
  * Signs by appending a revision, leaving the original bytes untouched.
@@ -70,6 +72,10 @@ final readonly class IncrementalSigner implements PdfSigner
         // Appended, so the arity a hand-built signer relies on does not move
         // (docs/decisions/0021-locking-fields-and-honouring-locks.md).
         private FieldLockReader $locks = new FieldLockReader(new DocumentReader()),
+        // Appended for the same reason, and null by default: a package that
+        // logs unasked fills somebody's disk
+        // (docs/decisions/0035-the-audit-trail-is-opt-in.md).
+        private SigningLog $log = new SigningLog(),
     ) {}
 
     public function sign(
@@ -163,6 +169,13 @@ final readonly class IncrementalSigner implements PdfSigner
         if ($profile->needsArchiveTimestamp()) {
             $signed = $this->archiveTimestamp->append($signed);
         }
+
+        $this->log->record(SigningEvent::SignatureApplied, [
+            'profile' => $profile->value,
+            'field' => $fieldName,
+            'certification' => $certification?->value,
+            'signer' => $certificate->commonName(),
+        ]);
 
         return new SignedPdf($signed);
     }

--- a/src/Support/SigningLog.php
+++ b/src/Support/SigningLog.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LSNepomuceno\LaravelA1PdfSign\Support;
+
+use LSNepomuceno\LaravelA1PdfSign\Enums\SigningEvent;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The audit trail, when a host asks for one.
+ *
+ * Corporate deployments audit signing, and nothing here recorded anything. This
+ * is opt-in and null by default: a package that logs unasked is a package that
+ * fills somebody's disk.
+ *
+ * **The allowlist is the feature.** This class handles PKCS#12 bundles, private
+ * keys and passwords, and a logger is a second channel that
+ * `#[\SensitiveParameter]` does not cover: that attribute keeps a value out of
+ * a stack trace and has nothing to say about a line somebody wrote to disk.
+ *
+ * So the context is filtered against a list of keys that may appear, rather
+ * than a list of keys that may not. A denylist is how the next property added
+ * to a data object ends up in a log file.
+ */
+final readonly class SigningLog
+{
+    /**
+     * Everything a log line may carry.
+     *
+     * Nothing here can identify a key, and nothing here is large. The document
+     * itself, the CMS, the PFX bytes, any password and any file path are absent
+     * on purpose: a path is enough to find the bundle it names.
+     *
+     * @var list<string>
+     */
+    public const array ALLOWED = [
+        'event',
+        'profile',
+        'field',
+        'certification',
+        'signer',
+        'serial',
+        'signed_at',
+        'authority',
+        'valid',
+        'signatures',
+        'exception',
+    ];
+
+    public function __construct(private ?LoggerInterface $logger = null) {}
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function record(SigningEvent $event, array $context = []): void
+    {
+        $this->logger?->info($event->value, $this->sanitise($event, $context));
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    private function sanitise(SigningEvent $event, array $context): array
+    {
+        $safe = ['event' => $event->value];
+
+        foreach ($context as $key => $value) {
+            if (in_array($key, self::ALLOWED, true) && $this->isScalarish($value)) {
+                $safe[$key] = $value;
+            }
+        }
+
+        return $safe;
+    }
+
+    /**
+     * Scalars only, so an object carrying a key cannot arrive under an allowed
+     * name and be serialised by whatever formats the line.
+     */
+    private function isScalarish(mixed $value): bool
+    {
+        return $value === null || is_scalar($value);
+    }
+}

--- a/tests/AuditLogTest.php
+++ b/tests/AuditLogTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+use LSNepomuceno\LaravelA1PdfSign\Enums\SigningEvent;
+use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
+use LSNepomuceno\LaravelA1PdfSign\Support\SigningLog;
+use Psr\Log\AbstractLogger;
+
+/**
+ * The audit trail, and what it refuses to write down.
+ *
+ * The allowlist is the feature. This package handles PKCS#12 bundles, private
+ * keys and passwords, and `#[\SensitiveParameter]` keeps a value out of a stack
+ * trace while having nothing to say about a line written to disk
+ * (docs/decisions/0035-the-audit-trail-is-opt-in.md).
+ */
+
+/**
+ * A logger that keeps every line, so a test can look at what was written.
+ *
+ * Returns the PSR-3 type as well as the anonymous class, so it can be passed to
+ * SigningLog and still have its recorded lines read.
+ *
+ * @return AbstractLogger&object{lines: list<array{level: mixed, message: string, context: array<mixed>}>}
+ */
+function recordingLogger(): AbstractLogger
+{
+    return new class extends AbstractLogger {
+        /** @var list<array{level: mixed, message: string, context: array<mixed>}> */
+        public array $lines = [];
+
+        /**
+         * @param  array<mixed>  $context  Widened to match PSR-3's own
+         *                                 signature, which PHPStan requires
+         *                                 for contravariance.
+         */
+        public function log($level, string|\Stringable $message, array $context = []): void
+        {
+            $this->lines[] = ['level' => $level, 'message' => (string) $message, 'context' => $context];
+        }
+    };
+}
+
+it('writes nothing when no logger was given', function () {
+    // The default. A package that logs unasked fills somebody's disk.
+    $log = new SigningLog();
+
+    $log->record(SigningEvent::SignatureApplied, ['profile' => 'pades-b-b']);
+
+    // Nothing to assert against but the absence of a crash: with no logger
+    // there is no sink, which is the whole point.
+    expect(true)->toBeTrue();
+});
+
+it('records the event and what the allowlist permits', function () {
+    $logger = recordingLogger();
+
+    new SigningLog($logger)->record(SigningEvent::SignatureApplied, [
+        'profile' => 'pades-b-lt',
+        'signer' => 'Test Certificate',
+    ]);
+
+    expect($logger->lines)->toHaveCount(1)
+        ->and($logger->lines[0]['message'])->toBe('signature.applied')
+        ->and($logger->lines[0]['context'])->toBe([
+            'event' => 'signature.applied',
+            'profile' => 'pades-b-lt',
+            'signer' => 'Test Certificate',
+        ]);
+});
+
+it('drops everything the allowlist does not name', function (string $key) {
+    // A denylist is how the next property added to a data object ends up in a
+    // log file. This asserts the shape rather than the list.
+    $logger = recordingLogger();
+
+    new SigningLog($logger)->record(SigningEvent::SignatureApplied, [$key => 'a secret']);
+
+    expect($logger->lines[0]['context'])->toBe(['event' => 'signature.applied']);
+})->with([
+    'password',
+    'certificate',
+    'private_key',
+    'pfx',
+    'path',
+    'document',
+    'contents',
+    'cms',
+    'anything_added_later',
+]);
+
+it('drops an object arriving under a permitted name', function () {
+    // Scalars only: an object could carry a key into whatever formats the line,
+    // and the format is the host's choice rather than ours.
+    $logger = recordingLogger();
+
+    new SigningLog($logger)->record(SigningEvent::SignatureApplied, [
+        'signer' => new stdClass(),
+    ]);
+
+    expect($logger->lines[0]['context'])->toBe(['event' => 'signature.applied']);
+});
+
+it('writes no secret when a real document is signed', function () {
+    // The end-to-end statement, rather than a statement about the filter.
+    $logger = recordingLogger();
+
+    app()->instance(SigningLog::class, new SigningLog($logger));
+
+    [$pfxPath, $password] = debugCertificate();
+
+    A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdf(resource('test.pdf'))
+        ->info(name: 'Lucas')
+        ->sign();
+
+    $written = json_encode($logger->lines, JSON_THROW_ON_ERROR);
+
+    expect($logger->lines)->not->toBeEmpty()
+        ->and($written)->toContain('signature.applied')
+        ->and($written)->not->toContain($password)
+        ->and($written)->not->toContain($pfxPath)
+        ->and($written)->not->toContain('BEGIN PRIVATE KEY')
+        ->and($written)->not->toContain('BEGIN CERTIFICATE');
+});
+
+it('names the profile and the field a signature used', function () {
+    $logger = recordingLogger();
+
+    app()->instance(SigningLog::class, new SigningLog($logger));
+
+    [$pfxPath, $password] = debugCertificate();
+
+    A1PdfSign::newSignature()
+        ->certificate($pfxPath, $password)
+        ->pdf(resource('test.pdf'))
+        ->sign();
+
+    expect($logger->lines[0]['context']['profile'])->toBe('pades-b-b')
+        ->and($logger->lines[0]['context']['field'])->toBe('Signature1');
+});

--- a/tests/DeadCodeTest.php
+++ b/tests/DeadCodeTest.php
@@ -165,6 +165,17 @@ function deadCodeUnusedInScope(array $tokens, int $open, int $close): array
             continue;
         }
 
+        // A property declared with a default reads exactly like an assignment,
+        // and a nested class puts one inside the scope being walked:
+        // `public array $lines = [];` was reported once this file's own
+        // recording logger existed. Modifiers introducing a method are left
+        // alone, since the branch above already handles those.
+        if (is_array($token) && in_array($token[0], [T_PUBLIC, T_PRIVATE, T_PROTECTED, T_VAR, T_READONLY], true)) {
+            $index = deadCodeSkipDeclaration($tokens, $index, $close);
+
+            continue;
+        }
+
         if (! is_array($token) || $token[0] !== T_VARIABLE || $token[1] === '$this') {
             continue;
         }
@@ -191,6 +202,39 @@ function deadCodeUnusedInScope(array $tokens, int $open, int $close): array
     }
 
     return $unused;
+}
+
+/**
+ * The end of a property declaration, or the modifier itself when it introduces
+ * a method.
+ *
+ * @param  array<int, array{0: int, 1: string, 2: int}|string>  $tokens
+ */
+function deadCodeSkipDeclaration(array $tokens, int $index, int $close): int
+{
+    for ($next = $index + 1; $next < $close; $next++) {
+        $token = $tokens[$next];
+
+        if (is_array($token) && in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+            continue;
+        }
+
+        // `public function …` and `public static function …`: the function
+        // branch owns those.
+        if (is_array($token) && in_array($token[0], [T_FUNCTION, T_FN, T_STATIC, T_READONLY], true)) {
+            return $index;
+        }
+
+        break;
+    }
+
+    for ($next = $index + 1; $next < $close; $next++) {
+        if ($tokens[$next] === ';') {
+            return $next;
+        }
+    }
+
+    return $index;
 }
 
 /**
@@ -300,6 +344,35 @@ it('leaves alone the shapes that look unused and are not', function () {
             };
 
             return $first . $second . $value . $callback() . $closure();
+        }
+        PHP);
+
+    expect(unusedVariablesIn($path))->toBe([]);
+
+    unlink($path);
+});
+
+it('does not read a property default as an assignment', function () {
+    // The shape that showed up the moment a test wrote its own recording
+    // logger: a nested class declaring a property with a default, inside the
+    // function scope being walked.
+    $path = LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign::tempPath(true, '.php');
+
+    file_put_contents($path, <<<'PHP'
+        <?php
+        function makesARecorder(): object
+        {
+            return new class
+            {
+                public array $lines = [];
+
+                private string $name = 'unread by anything here';
+
+                public function add(string $line): void
+                {
+                    $this->lines[] = $line;
+                }
+            };
         }
         PHP);
 


### PR DESCRIPTION
Closes #272.

## Off by default

```php
$this->app->bind(SigningLog::class, fn () => new SigningLog(Log::channel('audit')));
```

A package that logs unasked fills somebody's disk. It is a **constructor argument** rather than a `Log::` call inside the signer, because a dependency reached through a facade is invisible and untestable.

## The allowlist is the feature, not the logging

This package handles PKCS#12 bundles, private keys and passwords. Every password argument is already `#[\SensitiveParameter]`, which keeps the value out of a **stack trace** and has nothing whatever to say about a line somebody wrote to disk. A logger is a second channel and needed its own answer.

So `SigningLog::ALLOWED` names what may appear and everything else is dropped. **A denylist would have been the wrong shape**: it is how the next property added to a data object ends up in a log file, silently, because nobody remembered to forbid it.

Values are **scalars only**, so an object cannot arrive under a permitted name and be serialised by whatever formats the line.

Absent on purpose, although useful: the document, the CMS, the PFX bytes, any password, and **any file path** — a path is enough to find the bundle it names.

Fourteen tests, including one that signs a real document and asserts the password, the key and the path appear in no line.

## Four events, not one per step

An audit trail and a debug trace want different retention, and mixing them produces neither. A closed set of values is an enum here, not class constants ([0018](https://github.com/lsnepomuceno/laravel-a1-pdf-sign/blob/main/docs/decisions/0018-prefer-the-platforms-own-constructs.md)).

## Two side effects worth naming

**`psr/log` becomes a real dependency.** It arrived through Laravel before and `src/` now names it directly, which the dependency analyser correctly reported as shadow.

**The dead-code gate from #289 found a false positive of its own here.** A property declared with a default inside a nested class reads exactly like an assignment, and this PR's own recording logger is the first code in the repository shaped that way. Fixed, with a regression test beside the parameter-default one that preceded it.

## Checks

`composer check` passes in the 8.4 image: 605 tests, 3547 assertions. `docs/decisions/0035-the-audit-trail-is-opt-in.md` records the reasoning, including why the rate of validation failures is the host's problem to think about before enabling this publicly.