### PR TITLE
Document 2.6, and correct what the site said about openssl

### DIFF
--- a/public/docs/2.x/auditing.md
+++ b/public/docs/2.x/auditing.md
@@ -1,0 +1,59 @@
+# Auditing
+
+Digital signatures in corporate systems are audited: who signed, when, at what level, and which documents failed to verify are questions somebody eventually has to answer.
+
+#### 1 - Off by default. <small>(since 2.6)</small>
+
+A package that logs unasked fills somebody's disk, so nothing is recorded until you bind a logger:
+
+```PHP
+use LSNepomuceno\LaravelA1PdfSign\Support\SigningLog;
+use Illuminate\Support\Facades\Log;
+
+// in a service provider
+$this->app->bind(SigningLog::class, fn () => new SigningLog(Log::channel('audit')));
+```
+
+Any PSR-3 logger works. It is injected rather than resolved from a facade inside the signer, because a dependency reached through a facade is invisible and untestable.
+
+#### 2 - The events.
+
+```PHP
+enum SigningEvent: string
+{
+    case SignatureApplied     = 'signature.applied';
+    case TimestampReceived    = 'timestamp.received';
+    case ValidationCompleted  = 'validation.completed';
+    case ValidationFailed     = 'validation.failed';
+}
+```
+
+Four, not one per internal step. **An audit trail and a debug trace want different retention**, and mixing them produces neither.
+
+A line looks like this:
+
+```
+signature.applied  {event: "signature.applied", profile: "pades-b-lt", field: "Signature1",
+                    certification: null, signer: "ACME LTDA:11222333000181"}
+```
+
+#### 3 - What can never appear in a line.
+
+This package handles PKCS#12 bundles, private keys and passwords. Every password argument is marked `#[\SensitiveParameter]`, which keeps the value out of a **stack trace** and has nothing to say about a line written to disk. A logger is a second channel, and it has its own answer.
+
+**The context is an allowlist**, not a denylist:
+
+```PHP
+SigningLog::ALLOWED;   // event, profile, field, certification, signer, serial,
+                       // signed_at, authority, valid, signatures, exception
+```
+
+Anything else is dropped, and values must be scalars, so an object cannot arrive under a permitted name and be serialised by whatever formats the line.
+
+> A denylist is how the next property added to a data object ends up in a log file: silently, because nobody remembered to forbid it.
+
+Absent on purpose, although they would be useful: the document, the CMS, the PFX bytes, any password, and **any file path**. A path is enough to find the bundle it names.
+
+#### 4 - Before you enable it on a public endpoint.
+
+`ValidationFailed` is the event most worth auditing and also the one an attacker can trigger in bulk, by feeding your application bad documents. If validation is publicly reachable, rate limit before you turn this on.

--- a/public/docs/2.x/commands.md
+++ b/public/docs/2.x/commands.md
@@ -49,4 +49,40 @@ php artisan pdf:validate-signature '/example/full/path/to/my/signed-file.pdf'
 
 It reports every signature in the document, the signer's common name and whether each one verified, not only the first. Documents carrying several signatures are listed in full.
 
-Both commands map a `Throwable` to a failure exit code, so they compose in a shell pipeline.
+<hr />
+
+#### Checking the environment: <small>(since 2.6)</small>
+##### Command signature:
+```Shell
+a1-pdf-sign:check
+                {--tsa : Also reach the configured timestamp authority}
+```
+
+##### Example:
+```Shell
+php artisan a1-pdf-sign:check
+```
+
+```
+  [ok] ext-openssl            PKCS#12 reading and CMS building
+  [ok] ext-bcmath             required by tc-lib-pdf through tc-lib-barcode
+  [ok] proc_open              validation shells out; often in disable_functions
+  [ok] openssl binary         validation and legacy PFX. Separate from ext-openssl
+  [ok] ext-gd or ext-imagick  only needed to draw a visible seal
+  [ok] temporary directory    every shell-out writes one
+  [ok] memory_limit           signing peaks at roughly 20 MB plus twice the document
+
+This environment can sign and validate.
+```
+
+**`ext-openssl` being loaded says nothing about the `openssl` binary being installed.** They are separate things, a minimal container commonly has the first without the second, and validation needs the second. Until 2.6 a host missing it reported every signature as invalid rather than saying so.
+
+It exits non-zero only for what makes signing or validation impossible, so a deployment pipeline can use it. A host with no image library is reported and not failed: that only matters if you draw a visible seal.
+
+**It does not touch the network unless asked.** `--tsa` opts in, and goes through the same transport contract everything else does.
+
+Nothing sensitive is printed, so the output is safe to paste into an issue.
+
+<hr />
+
+All three commands map a `Throwable` to a failure exit code, so they compose in a shell pipeline.

--- a/public/docs/2.x/home.md
+++ b/public/docs/2.x/home.md
@@ -23,4 +23,6 @@ $signed->save('path/to/signed.pdf');
 * [Usage](/docs/2.x/usage)
 * [Signature profiles](/docs/2.x/signature-profiles)
 * [ICP-Brasil](/docs/2.x/icp-brasil)
+* [Testing your application](/docs/2.x/testing)
+* [Auditing](/docs/2.x/auditing)
 * [Tests](/docs/2.x/tests)

--- a/public/docs/2.x/installation.md
+++ b/public/docs/2.x/installation.md
@@ -2,11 +2,25 @@
 
 * PHP: ^8.4 or ^8.5
 * Laravel: ^13
-* PHP Extensions: mbstring, dom, fileinfo, openssl, json, gd
+* PHP Extensions: mbstring, dom, fileinfo, openssl, json, bcmath, and gd or imagick
 
 Laravel 12 is **not** supported. It requires `symfony/process ^7.2` while the test stack requires `^8.1`, so the two cannot be installed together.
 
-The `openssl` **binary** is no longer required. Certificates are read through `ext-openssl`; the command line is used only as a fallback for legacy PFX files (see [Working with certificates](/docs/2.x/working-with-certificate)).
+`gd` or `imagick` is needed only to draw a visible seal. An invisible signature needs neither.
+
+### The `openssl` binary
+
+**Signing does not need it.** Certificates are read through `ext-openssl`, and the command line is a fallback for legacy PFX files only (see [Working with certificates](/docs/2.x/working-with-certificate)).
+
+**Validation does.** The CMS verdict comes from the binary, and `proc_open` has to be available to reach it, which much shared hosting disables.
+
+> `ext-openssl` being loaded says nothing about the binary being installed. They are separate things, and a minimal container commonly has the first without the second. Before 2.6 a host missing it reported every signature as **invalid** rather than saying so; it now raises `MissingBinaryException`.
+
+```Shell
+php artisan a1-pdf-sign:check
+```
+
+reports all of the above and exits non-zero when something makes signing or validation impossible, so a deployment pipeline can use it.
 
 # Install
 

--- a/public/docs/2.x/release-notes.md
+++ b/public/docs/2.x/release-notes.md
@@ -1,3 +1,150 @@
+# 2.6.0
+
+## Three answers that were wrong, and silent about it
+
+Each of these produced a result rather than an error, which is the worst shape a defect can take in a package whose job is to answer a question about a document.
+
+### A missing `openssl` binary made every signature report as invalid
+
+Validation shells out. `Validation\SignatureVerifier` caught every throwable and returned `false`, on reasoning that was correct for the case it named: a non-zero exit from `openssl smime -verify` means the signature does not verify. The catch was wider than the reasoning.
+
+Measured on `samples/pades-b-b.pdf`, changing nothing but the environment:
+
+| Environment | Before | Now |
+|---|---|---|
+| `openssl` on `PATH` | valid | valid |
+| binary removed | **invalid** | `MissingBinaryException` |
+| `proc_open` disabled | **invalid** | `ProcessUnavailableException` |
+
+A caller could not tell that apart from a tampered document, and the natural response to "invalid" is to reject something legitimate.
+
+**`ext-openssl` being loaded says nothing about the command-line tool being installed.** A minimal container commonly has the first without the second, and that distinction is what costs people an afternoon.
+
+```Shell
+php artisan a1-pdf-sign:check
+```
+
+answers the same question before anything is signed.
+
+### Signature metadata was written as raw UTF-8
+
+`/Name`, `/Reason`, `/Location` and `/ContactInfo` are text strings, and ISO 32000-1 §7.9.2.2 allows two forms: PDFDocEncoding, or UTF-16BE with a byte order mark. Raw UTF-8 is neither.
+
+A conforming reader found no mark, decoded as PDFDocEncoding, and showed the two bytes of `ã` as two characters. **`João` displayed as `JoÃ£o`**, in a document that verified perfectly, which is why nothing caught it: every assertion was about the signature verifying, and it did.
+
+ASCII output is byte-identical to 2.5. Anything else is now a hex string with the mark.
+
+### The seal ignored page rotation
+
+`/Rotate` turns a page clockwise for display and leaves its coordinate system alone. `grep -rn "Rotate" src/` returned nothing: the key was read nowhere, so on a page carrying `/Rotate 90`, which is how most scanners express landscape, the seal landed elsewhere and read sideways.
+
+The rectangle is mapped into user space and the appearance carries a matrix turning it back. Confirmed by rendering with poppler rather than by arithmetic: asked for at 7-21% across and 23-33% down, rendered at 7-21% and 24-33%.
+
+### Validation could not read a signature this package did not write
+
+The `/ByteRange` pattern required the exact bytes this package emits. A document from another producer, which writes `/ByteRange [0 9875 15069 565]` with a space, found no signatures and raised as unsigned.
+
+Every validation test signed with this package first, so the defect was structurally invisible.
+
+<hr>
+
+## Signing a 200 MB document
+
+Peak memory was roughly 20 MB plus **four times** the document. It is now 20 MB plus **two**.
+
+| Document | Before | Now |
+|---|---|---|
+| 25 MB | 95 MB | 70 MB |
+| 100 MB | 320 MB | 220 MB |
+| 200 MB | 620 MB | **420 MB** |
+
+**One breaking change comes with it.** `Contracts\PdfSigner::sign()` takes the document by reference, so it can release it once the revision exists. PHP cannot pass an expression by reference:
+
+```PHP
+$signer->sign(Files::read($path), $certificate, $info);   // fatal
+$contents = Files::read($path);
+$signer->sign($contents, $certificate, $info);            // fine
+```
+
+`A1PdfSign::newSignature()` and the one-shot helpers pass a property and are unaffected, so this reaches only an application calling the contract directly.
+
+<hr>
+
+## Testing an application that signs
+
+```PHP
+$signing = A1PdfSign::fake();
+
+// … your application runs …
+
+$signing->assertSigned();
+$signing->assertSignedWithProfile(SignatureProfile::PadesBLT);
+$signing->assertCertified(CertificationLevel::NoChanges);
+$signing->assertSealed();
+```
+
+**No PKCS#12 bundle in your repository, and no CMS built** for a test that merely passes through the signing call. It replaces the signer and the certificate reader in the container, so `certificate()` accepts any path and nothing is parsed, rendered or signed.
+
+[Testing your application →](/docs/2.x/testing)
+
+<hr>
+
+## Catching failures as a group
+
+Every exception now implements `Exceptions\A1PdfSignException`:
+
+```PHP
+$exceptions->report(function (A1PdfSignException $e) { … });
+```
+
+The classes stay granular beneath it. **`InvalidCertificatePasswordException` is new**, for the failure a production application meets most, and it extends the class a wrong password used to arrive as, so existing catches still match.
+
+The distinction is evidence rather than a guess: OpenSSL answers a wrong password with a MAC verify failure and a broken file with an ASN.1 error, and the MAC is computed with a key derived from the password.
+
+<hr>
+
+## Auditing what was signed
+
+Off by default, because a package that logs unasked fills somebody's disk.
+
+```PHP
+$this->app->bind(SigningLog::class, fn () => new SigningLog(Log::channel('audit')));
+```
+
+**No password, key, document or file path can appear in a line**, whatever is passed: the context is filtered against the keys that may appear rather than the keys that may not. A denylist is how the next property added to a data object leaks. A path is excluded too, since it is enough to find the bundle it names.
+
+[Auditing →](/docs/2.x/auditing)
+
+<hr>
+
+## Smaller, and worth knowing
+
+**A document does not have to be a local file.**
+
+```PHP
+->pdfFromDisk('s3', 'contracts/deal.pdf')
+```
+
+**The seal renderer is swappable**, and always was. `Contracts\SealRenderer` is bound in the container, so one line in your own service provider replaces it with a QR code, a corporate logo or any layout of your own. `fromImage()` is the route for artwork produced elsewhere, Blade included.
+
+**Timestamp and revocation requests go through the framework's HTTP client**, so `Http::fake()` intercepts them, your proxy and middleware apply, and a transient failure retries instead of failing the signature. A network failure raises `SignatureTransportException` rather than an exception named after processes.
+
+**`psr/log` is a new runtime dependency.**
+
+**Signed documents declare the ETSI_PAdES extension** their sub-filter needs below PDF 2.0, so the bytes of every signed document change.
+
+<hr>
+
+## Measured rather than claimed
+
+**PDF/UA.** An invisible signature keeps an accessible document conformant; a visible seal costs it two clauses, ISO 14289-1 7.18.1 and 7.18.4. Measured with veraPDF, and the failures are asserted clause by clause so an improvement breaks the test rather than passing quietly.
+
+**Certification is enforced, not merely written.** pyHanko compares the appended revisions against the `/DocMDP` policy and reaches a verdict, which closes a caveat 0012 carried for two releases: a document certified at no-changes and then modified is now reported as violating its policy on every run.
+
+**What this package writes is checked against the specification's own grammar.** The Arlington PDF Model is the PDF Association's machine-readable ISO 32000, and it found a real disagreement in its first five minutes, which is what earned it a place.
+
+<hr>
+
 # 2.5.0
 
 ## A visible seal no longer costs PDF/A conformance

--- a/public/docs/2.x/sign-pdf-file.md
+++ b/public/docs/2.x/sign-pdf-file.md
@@ -395,3 +395,44 @@ Encrypted documents were refused until 2.5, and the refusal was correct rather t
 | A non-standard security handler | Its key comes from somewhere this package cannot reach |
 | An encrypted document packed into object streams | Reachable, not implemented |
 | `pades-b-lt` and above, while encrypted | They append streams this does not encrypt |
+
+<hr />
+
+#### 13 - A document that is not a local file. <small>(since 2.6)</small>
+
+An application keeping contracts on `s3`, `minio` or any Flysystem disk does not have to download one first:
+
+```PHP
+$signed = A1PdfSign::newSignature()
+    ->certificate($pfxPath, $password)
+    ->pdfFromDisk('s3', 'contracts/deal.pdf')
+    ->sign();
+```
+
+The file name is carried across, so the signed document keeps a name rather than a generated one.
+
+If the bytes come from somewhere else entirely, an API response or a database column, hand them over directly:
+
+```PHP
+->pdfContents($bytes, 'deal.pdf')
+```
+
+> Both hold the whole document in memory. Signing peaks at roughly 20 MB plus twice the document, so a 200 MB file needs around 420 MB, and neither of these changes that.
+
+<hr />
+
+#### 14 - A seal of your own. <small>(since 2.6, and true before)</small>
+
+The seal is drawn by `Contracts\SealRenderer`, bound in the container, so replacing it is one line in your own service provider:
+
+```PHP
+use LSNepomuceno\LaravelA1PdfSign\Contracts\SealRenderer;
+
+$this->app->bind(SealRenderer::class, QrCodeSealRenderer::class);
+```
+
+That is the route for a corporate logo, a QR code linking to a validation page, or any layout of your own. The contract has two methods: `render()` builds a seal from the certificate, and `fromImage()` embeds artwork you already have.
+
+**`fromImage()` is also the answer to drawing the seal with Blade.** Render your view to an image however you like and hand the result over. The package stays out of turning HTML into pixels, which would be a large dependency for a signing library.
+
+This was always possible and was documented nowhere, which is the same as not existing.

--- a/public/docs/2.x/testing.md
+++ b/public/docs/2.x/testing.md
@@ -1,0 +1,69 @@
+# Testing your application
+
+An application that signs PDFs has to test the code path that signs them. Doing that for real means a PKCS#12 bundle in your repository, a real PDF, and a full CMS built for every test that merely passes through the flow.
+
+#### 1 - Sign nothing, and assert what would have been signed. <small>(since 2.6)</small>
+
+```PHP
+use LSNepomuceno\LaravelA1PdfSign\Facades\A1PdfSign;
+
+it('signs the contract when the deal is accepted', function () {
+    $signing = A1PdfSign::fake();
+
+    $this->post('/deals/42/accept')->assertOk();
+
+    $signing->assertSigned();
+});
+```
+
+`fake()` returns the recorder. It replaces `Contracts\PdfSigner` and `Contracts\CertificateReader` in the container, so `certificate()` accepts any path, nothing is parsed, no key is generated and no document is written.
+
+> It replaces those two rather than the facade itself, deliberately. The builder is the documented way in and depends on both, so faking only the facade would leave `newSignature()->…->sign()` reaching the real signer.
+
+#### 2 - The assertions.
+
+```PHP
+$signing->assertSigned();                     // something was signed
+$signing->assertSigned('CONTRACT-42');        // a document containing this
+$signing->assertSignedTimes(2);               // how many
+$signing->assertNothingSigned();              // the negative
+$signing->assertSignedWithProfile(SignatureProfile::PadesBLT);
+$signing->assertCertified();                  // any certification
+$signing->assertCertified(CertificationLevel::NoChanges);
+$signing->assertSealed();                     // a visible seal was asked for
+```
+
+`assertSigned()` takes a **fragment of the document** rather than a path, because the signer is handed bytes and never learns where they came from. In practice you assert on something the document says.
+
+**`assertNothingSigned()` is usually the one that catches a bug**: a flow that signs when it should not is harder to notice than one that does not sign at all.
+
+#### 3 - The result is usable.
+
+```PHP
+$signed = A1PdfSign::newSignature()
+    ->usingCertificate(A1PdfSignFake::certificate())
+    ->pdfContents($bytes)
+    ->sign();
+
+$signed->contents;   // a small valid PDF
+$signed->size();     // an integer
+$signed->save($path);
+```
+
+Application code calls those, so the fake hands back a real `SignedPdf` rather than a null that would fail somewhere unhelpful.
+
+#### 4 - What it does not fake.
+
+**Validation.** `A1PdfSign::validate()` still reads the document you give it. Dictating a `SignatureReport` is a different feature from recording what was signed, and it is not here yet.
+
+If your application only needs a document that validates, sign one for real in a fixture and read it back: that path is fast, since it builds no timestamp and reaches no network.
+
+#### 5 - Checking the environment instead. <small>(since 2.6)</small>
+
+A test suite proves your code is right. It says nothing about whether the machine can sign at all, and the failure there used to be silent:
+
+```Shell
+php artisan a1-pdf-sign:check
+```
+
+See [Commands](/docs/2.x/commands).

--- a/public/docs/2.x/validating-signature.md
+++ b/public/docs/2.x/validating-signature.md
@@ -255,3 +255,44 @@ Our validator shares its assumptions with the code that produced the signature, 
 ```Shell
 pdfsig path/to/signed.pdf
 ```
+
+<hr />
+
+#### 14 - When validation cannot answer at all. <small>(since 2.6)</small>
+
+Validation shells out to `openssl`, and until 2.6 an environment that could not run it reported **every signature as invalid**. Not an error: a verdict, which a caller could not tell from a tampered document.
+
+```PHP
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\{MissingBinaryException, ProcessUnavailableException};
+
+try {
+    $report = A1PdfSign::validate($path);
+} catch (MissingBinaryException $e) {
+    // the openssl binary is not on the PATH
+} catch (ProcessUnavailableException $e) {
+    // proc_open is disabled, as on much shared hosting
+}
+```
+
+**`ext-openssl` being loaded is a different thing from the binary being installed.** A signature that genuinely does not verify still returns a report with `verified` false, unchanged.
+
+`php artisan a1-pdf-sign:check` answers this before you sign anything.
+
+<hr />
+
+#### 15 - Catching this package's failures as a group. <small>(since 2.6)</small>
+
+Every exception implements `Exceptions\A1PdfSignException`, so an application no longer has to name sixteen classes or catch `\Exception` and swallow everything the framework throws with them:
+
+```PHP
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\A1PdfSignException;
+
+// bootstrap/app.php
+->withExceptions(function (Exceptions $exceptions) {
+    $exceptions->report(function (A1PdfSignException $e) {
+        // anything this package considers its own failure
+    });
+})
+```
+
+The classes stay granular beneath it. **`InvalidCertificatePasswordException`** is the one worth catching on its own, since a wrong password is the failure a production application meets most, and it extends `InvalidCertificateContentException`, the class it used to arrive as, so an existing catch still matches.

--- a/src/documentationLinks/v2x.ts
+++ b/src/documentationLinks/v2x.ts
@@ -80,6 +80,22 @@ export default <Doc>{
                     url: "icp-brasil",
                     footerActions: {
                         previousLink: "validating-signature",
+                        nextLink: "testing",
+                    },
+                },
+                {
+                    title: "Testing your application",
+                    url: "testing",
+                    footerActions: {
+                        previousLink: "icp-brasil",
+                        nextLink: "auditing",
+                    },
+                },
+                {
+                    title: "Auditing",
+                    url: "auditing",
+                    footerActions: {
+                        previousLink: "testing",
                         nextLink: "commands",
                     },
                 },
@@ -94,7 +110,7 @@ export default <Doc>{
             url: "commands",
             icon: "fa-terminal",
             footerActions: {
-                previousLink: "icp-brasil",
+                previousLink: "auditing",
                 nextLink: "not-laravel-or-lumen",
             },
         },


### PR DESCRIPTION
2.6.0 is tagged and on Packagist, so the site can describe it.

## Release notes, ordered by what a reader is exposed to

The three defects that produced a **wrong answer rather than an error** lead, because that is what an upgrading application actually meets:

- a missing `openssl` binary reported **every signature as invalid**, silently
- metadata written as raw UTF-8, so `João` displayed as `JoÃ£o`
- the seal ignored `/Rotate`, so on a landscape scan it landed elsewhere and read sideways

Then the one breaking change, narrowly scoped, then the additive work, then what is now measured rather than claimed.

## A correction, not just an addition

The installation page said the `openssl` binary **"is no longer required"**. That was false, and it is the same confusion that made the silent-invalid defect expensive to find: **signing** does not need it, **validation** does.

It now says which is which, and names the exception a host missing it now gets instead of a false negative.

## Two pages that did not exist

**Testing your application** — `A1PdfSign::fake()`, the assertions, and **what it deliberately does not fake**. A reader who assumes validation is faked too would find out the hard way, so that is stated rather than left implied.

**Auditing** — the PSR-3 events, led by the allowlist rather than by the wiring, because that is the part that decides whether the feature is safe to turn on. Including the note that `ValidationFailed` is the event an attacker can trigger in bulk.

Both are wired into the navigation and the home page's fast links.

## Existing pages

- **Sign PDF file**: reading a document from a Laravel disk, and the custom seal renderer, which was always possible and documented nowhere.
- **Validating a signature**: the environment failures, and catching this package's failures as a group.
- **Commands**: `a1-pdf-sign:check`.

## About the build

`yarn build` fails on `type-check`, for a `tsconfig.vitest.json` include that matches a generated `.vue.jsx`. **That failure predates this change**: it reproduces on the branch with these commits stashed. `vite build` alone produces the site, and the new pages are in the output.

Worth a separate issue rather than being fixed inside a docs update.