### PR TITLE
Read the envelope signet-pdf writes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     "ext-json": "*",
     "ext-mbstring": "*",
     "ext-openssl": "*",
+    "ext-sodium": "*",
     "ext-zlib": "*",
     "illuminate/console": "^13",
     "illuminate/encryption": "^13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f9fcda5f97fb752c4c9fa208ac157c29",
+    "content-hash": "1a8b162e196f5e874a06ef641493b4ca",
     "packages": [
         {
             "name": "brick/math",
@@ -12715,6 +12715,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
+        "ext-sodium": "*",
         "ext-zlib": "*"
     },
     "platform-dev": {

--- a/docs/decisions/0038-the-envelope-is-versioned.md
+++ b/docs/decisions/0038-the-envelope-is-versioned.md
@@ -1,0 +1,87 @@
+# 0038: The envelope is versioned, so material sealed by signet-pdf still opens
+
+**Status:** implemented.
+
+## Context
+
+`Certificates\CertificateVault` seals a certificate and its password with
+`Illuminate\Encryption\Encrypter`, AES-128-CBC under a 16-byte key, in Laravel's
+envelope: `base64(json({iv, value, mac, tag}))`.
+
+`lsnepomuceno/signet-pdf`, the core extracted from this package, reproduced that
+format byte for byte for one reason: an application moving between the two
+cannot re-encrypt a certificate whose plaintext it no longer holds. Material
+sealed by either opened in the other, and that guarantee was stated in both
+codebases.
+
+**Its 2.0 moved new material onto XChaCha20-Poly1305 through `ext-sodium`**,
+under a 32-byte key and a `signet.v2.` envelope, on the grounds that a signing
+package should not be assembling encrypt-then-MAC by hand. That reasoning holds
+and the change was right there. What it did here was break the guarantee in one
+direction: what this package writes still opens there, and what that package now
+writes does not open here at all. `withKey()` would not even accept the key,
+because a 32-byte string is not a valid AES-128-CBC key.
+
+## Decision
+
+**Read both envelopes. Keep writing this one.**
+
+`Support\SodiumEncrypter` implements the `signet.v2.` scheme, and
+`CertificateVault::withKey()` picks the reader from the key's length: 16 bytes
+is this package's own, 32 is signet-pdf's. Those are the only two lengths either
+package has issued, so the mapping is total, and any other length is refused
+rather than padded into one of them.
+
+**`create()` is unchanged and still writes Laravel's envelope.** This is a
+compatibility fix, not a migration: every application storing material from this
+package keeps storing exactly what it stored, and nothing has to be re-encrypted
+or re-sized. Adopting the new scheme here is a separate decision with a
+storage-width consequence, and it can be taken later on its own terms.
+
+### Not the fuller contract
+
+The vault's property is typed `Illuminate\Contracts\Encryption\StringEncrypter`,
+which Laravel's `Encrypter` satisfies alongside the contract it also implements.
+
+The fuller `Encrypter` contract was rejected: satisfying it means implementing
+`decrypt($payload, $unserialize = true)`, and offering an `unserialize()` path
+over attacker-supplied bytes to solve a compatibility problem is a trade nobody
+should take. `StringEncrypter` is exactly the two methods the vault calls.
+
+That leaves `getKey()` unavailable, so **the vault holds its own key** rather
+than reading it back off the encrypter. It was always the vault's key: it is
+what `seal()` returns and what `withKey()` is given.
+
+### The marker is authenticated
+
+`signet.v2.` is passed as the AEAD additional data rather than merely prepended,
+so an envelope whose marker is edited fails to open instead of being routed to
+another reader. That is signet-pdf's decision reproduced byte for byte, and
+changing any detail of it on this side would break the thing it exists to
+preserve.
+
+## Consequences
+
+- **`ext-sodium` joins `require`.** It ships with PHP and has since 7.2, so on
+  most systems this changes nothing, but a build compiled without it now fails
+  at `composer install` rather than at runtime.
+
+- **`CertificateVault::encrypter()` returns `StringEncrypter`** where it
+  returned `Illuminate\Encryption\Encrypter`. Widening a return type is a
+  backward-compatibility break for anyone who type-hints the concrete class.
+  Nothing inside this package or its tests calls it, so the blast radius is
+  whatever consumers do with it, and this is the one thing in the change worth
+  arguing about.
+
+- `withKey()` now raises `InvalidCertificateContentException` for a key of any
+  other length, where it previously let Laravel's encrypter refuse it.
+
+## Alternatives rejected
+
+| | Why not |
+|---|---|
+| Move this package to the new envelope too | A second breaking change, with a storage-width consequence for every consumer, to solve a problem that reading solves |
+| Implement the full `Encrypter` contract | It requires `decrypt()` with an `unserialize()` path over supplied bytes. Not for a compatibility fix, not for anything |
+| A union type, `Encrypter\|SodiumEncrypter` | Says less than the contract does, and closes the type to a third implementation for no gain |
+| Leave it, and let signet-pdf's material stay unreadable here | It breaks a guarantee both codebases state in prose, and the direction it breaks is the one a migration needs |
+| Wait for this package to be rebuilt on signet-pdf | That decision is open and may not land for months. The material is unreadable now |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -47,6 +47,7 @@ document drifts away from the code it describes.
 | [0035](0035-the-audit-trail-is-opt-in.md) | The audit trail is opt-in, and its context is an allowlist |
 | [0036](0036-the-signed-artefacts-are-reproducible.md) | The signed artefacts are reproducible, and their coherence is a gate |
 | [0037](0037-what-we-write-against-the-grammar.md) | What we write, against the specification's own grammar |
+| [0038](0038-the-envelope-is-versioned.md) | The envelope is versioned, so material sealed by signet-pdf still opens |
 
 Nothing is currently proposed and unbuilt. The four that were, 0009, 0010, 0012
 and 0013, all shipped in 2.2, and each carries the measurement that decided its

--- a/src/Certificates/CertificateVault.php
+++ b/src/Certificates/CertificateVault.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace LSNepomuceno\LaravelA1PdfSign\Certificates;
 
+use Illuminate\Contracts\Encryption\StringEncrypter;
 use Illuminate\Encryption\Encrypter;
 use LSNepomuceno\LaravelA1PdfSign\Data\Certificate;
 use LSNepomuceno\LaravelA1PdfSign\Data\EncryptedCertificate;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidCertificateContentException;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidX509PrivateKeyException;
+use LSNepomuceno\LaravelA1PdfSign\Support\SodiumEncrypter;
 use SensitiveParameter;
 
 /**
@@ -16,37 +18,79 @@ use SensitiveParameter;
  *
  * Each vault carries its own key. seal() returns that key alongside the
  * ciphertext, and open() needs it: losing it means losing the certificate.
+ *
+ * **Two envelopes are readable, and the key's length says which.** Everything
+ * sealed by this package carries Laravel's, under a 16-byte AES-128-CBC key.
+ * `lsnepomuceno/signet-pdf` moved to XChaCha20-Poly1305 under a 32-byte key at
+ * its 2.0, and material sealed there has to open here: an application moving
+ * between the two cannot re-encrypt a certificate whose plaintext it no longer
+ * holds. Those are the only two lengths either package has issued, so the
+ * mapping is total (docs/decisions/0038-the-envelope-is-versioned.md).
  */
 final readonly class CertificateVault
 {
     public const string CIPHER = 'aes-128-cbc';
 
-    private function __construct(private Encrypter $encrypter) {}
+    /**
+     * What `self::CIPHER` requires, and therefore what a key written by this
+     * package measures.
+     */
+    public const int KEY_LENGTH = 16;
+
+    /**
+     * The key is held here rather than read back off the encrypter, because
+     * `StringEncrypter` does not expose one and asking for the fuller contract
+     * would mean implementing an `unserialize()` path to satisfy it.
+     */
+    private function __construct(
+        private StringEncrypter $encrypter,
+        #[SensitiveParameter]
+        private string $key,
+    ) {}
 
     /**
      * A vault with a freshly generated key.
      */
     public static function create(): self
     {
-        return new self(new Encrypter(Encrypter::generateKey(self::CIPHER), self::CIPHER));
+        $key = Encrypter::generateKey(self::CIPHER);
+
+        return new self(new Encrypter($key, self::CIPHER), $key);
     }
 
     /**
      * A vault bound to an existing key, as returned by seal().
+     *
+     * The length chooses the envelope: 16 bytes is this package's own, and 32
+     * is the one `signet-pdf` writes. A key of any other length belongs to
+     * neither and says so, rather than being padded into one of them.
+     *
+     * @throws InvalidCertificateContentException When the key is the wrong length.
      */
     public static function withKey(#[SensitiveParameter] string $key): self
     {
-        return new self(new Encrypter($key, self::CIPHER));
+        return new self(
+            match (strlen($key)) {
+                SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES => new SodiumEncrypter($key),
+                self::KEY_LENGTH => new Encrypter($key, self::CIPHER),
+                default => throw new InvalidCertificateContentException(
+                    'the key must be ' . self::KEY_LENGTH . ' bytes, or '
+                    . SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES
+                    . ' for material sealed by signet-pdf, ' . strlen($key) . ' given',
+                ),
+            },
+            $key,
+        );
     }
 
-    public function encrypter(): Encrypter
+    public function encrypter(): StringEncrypter
     {
         return $this->encrypter;
     }
 
     public function key(): string
     {
-        return $this->encrypter->getKey();
+        return $this->key;
     }
 
     public function seal(

--- a/src/Support/SodiumEncrypter.php
+++ b/src/Support/SodiumEncrypter.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LSNepomuceno\LaravelA1PdfSign\Support;
+
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Contracts\Encryption\EncryptException;
+use Illuminate\Contracts\Encryption\StringEncrypter;
+use SensitiveParameter;
+use SodiumException;
+
+/**
+ * Authenticated encryption over ext-sodium, in the envelope `signet-pdf` writes.
+ *
+ * **This exists for interoperability, and the format is not chosen here.**
+ * `lsnepomuceno/signet-pdf` moved certificate material onto XChaCha20-Poly1305
+ * at 2.0, so a certificate sealed there stopped opening in this package. The
+ * two have always been able to read each other's stored material, because an
+ * application moving between them cannot re-encrypt a certificate whose
+ * plaintext it no longer holds, and that guarantee is worth more than the
+ * consistency of using one cipher everywhere.
+ *
+ * The envelope is `signet.v2.` followed by base64 of the nonce and the sealed
+ * bytes. **The marker is the AEAD additional data rather than merely a
+ * prefix**, so an envelope whose marker is edited fails to open instead of
+ * being routed to another reader. That is signet-pdf's decision, reproduced
+ * here byte for byte, and changing any of it on this side would break exactly
+ * what it is here to preserve.
+ *
+ * `Illuminate\Contracts\Encryption\StringEncrypter` rather than the fuller
+ * `Encrypter` contract: this handles strings, and implementing `decrypt()`
+ * would mean offering an `unserialize()` path over attacker-supplied bytes to
+ * solve a compatibility problem.
+ */
+final readonly class SodiumEncrypter implements StringEncrypter
+{
+    /**
+     * What an envelope written by this scheme begins with.
+     */
+    public const string PREFIX = 'signet.v2.';
+
+    /**
+     * @throws EncryptException When the key is not the length libsodium requires.
+     */
+    public function __construct(
+        #[SensitiveParameter]
+        private string $key,
+    ) {
+        $expected = SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES;
+
+        if (strlen($key) !== $expected) {
+            throw new EncryptException(
+                "the key must be {$expected} bytes for XChaCha20-Poly1305, " . strlen($key) . ' given',
+            );
+        }
+    }
+
+    /**
+     * A key of the right length, from the CSPRNG.
+     */
+    public static function generateKey(): string
+    {
+        return random_bytes(SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES);
+    }
+
+    /**
+     * Whether this payload was written by this scheme.
+     *
+     * Reading the marker is not trusting it: it selects a reader, and the
+     * reader then authenticates the marker along with everything else.
+     */
+    public static function wrote(string $payload): bool
+    {
+        return str_starts_with($payload, self::PREFIX);
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * @throws EncryptException
+     */
+    public function encryptString(#[SensitiveParameter] $value): string
+    {
+        $nonce = random_bytes(SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES);
+
+        try {
+            $sealed = sodium_crypto_aead_xchacha20poly1305_ietf_encrypt(
+                (string) $value,
+                self::PREFIX,
+                $nonce,
+                $this->key,
+            );
+        } catch (SodiumException $exception) {
+            throw new EncryptException('the value could not be sealed: ' . $exception->getMessage());
+        }
+
+        return self::PREFIX . base64_encode($nonce . $sealed);
+    }
+
+    /**
+     * @throws DecryptException
+     */
+    public function decryptString($payload): string
+    {
+        $payload = (string) $payload;
+
+        if (! self::wrote($payload)) {
+            throw new DecryptException(
+                'this payload was not written by the current envelope; '
+                . 'material sealed by the previous one opens with its own key',
+            );
+        }
+
+        $raw = base64_decode(substr($payload, strlen(self::PREFIX)), true);
+        $nonceLength = SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES;
+
+        // A payload shorter than a nonce plus a tag cannot carry either, and
+        // splitting it would hand libsodium a nonce assembled out of the tag.
+        if ($raw === false || strlen($raw) < $nonceLength + SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES) {
+            throw new DecryptException('the payload is not a valid envelope');
+        }
+
+        try {
+            $opened = sodium_crypto_aead_xchacha20poly1305_ietf_decrypt(
+                substr($raw, $nonceLength),
+                self::PREFIX,
+                substr($raw, 0, $nonceLength),
+                $this->key,
+            );
+        } catch (SodiumException $exception) {
+            throw new DecryptException('the payload could not be opened: ' . $exception->getMessage());
+        }
+
+        if ($opened === false) {
+            // One answer for a wrong key, an edited ciphertext and an edited
+            // marker, because the tag does not distinguish them and inventing
+            // a distinction here would leak which one it was.
+            throw new DecryptException('the payload was sealed with a different key, or has been tampered with');
+        }
+
+        return $opened;
+    }
+}

--- a/tests/Certificates/EnvelopeInteroperabilityTest.php
+++ b/tests/Certificates/EnvelopeInteroperabilityTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Contracts\Encryption\EncryptException;
+use Illuminate\Encryption\Encrypter;
+use LSNepomuceno\LaravelA1PdfSign\Certificates\CertificateVault;
+use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidCertificateContentException;
+use LSNepomuceno\LaravelA1PdfSign\Support\SodiumEncrypter;
+
+/**
+ * A certificate sealed by `lsnepomuceno/signet-pdf` has to open here.
+ *
+ * An application moving between the two packages cannot re-encrypt material
+ * whose plaintext it no longer holds, which is why both have always read each
+ * other's storage. signet-pdf 2.0 moved new material onto XChaCha20-Poly1305,
+ * and this is the reader that keeps the guarantee true
+ * (docs/decisions/0038-the-envelope-is-versioned.md).
+ */
+it('opens a payload sealed by signet-pdf itself', function () {
+    // Not a round-trip through this class, which would pass even if both
+    // halves were wrong together. These bytes were produced by
+    // `LSNepomuceno\Signet\Support\SodiumEncrypter` in signet-pdf 2.0 and
+    // pasted here, so the test fails if either package moves.
+    $key = base64_decode('bamDDgPD9Ge8TS2z4BNFEIef/a9RBdy6WBRzUoWYamY=', true);
+    $payload = 'signet.v2.7PhSd7EHWJ2J21M5lp84yIvWSNoGG6Ege0omBNxjsxen'
+        . 'IuTKhTHfym37mK3I/jl4h/4KfI/BM9h5KQfRC7J1mA==';
+
+    expect($key)->toBeString()
+        ->and(new SodiumEncrypter((string) $key)->decryptString($payload))
+        ->toBe('sealed by signet-pdf 2.0')
+        // And through the vault, which is how an application reaches it.
+        ->and(CertificateVault::withKey((string) $key)->encrypter()->decryptString($payload))
+        ->toBe('sealed by signet-pdf 2.0');
+});
+
+it('round-trips the envelope signet-pdf writes', function () {
+    $encrypter = new SodiumEncrypter(SodiumEncrypter::generateKey());
+    $sealed = $encrypter->encryptString('a certificate, notionally');
+
+    expect($sealed)->toStartWith(SodiumEncrypter::PREFIX)
+        ->and($encrypter->decryptString($sealed))->toBe('a certificate, notionally');
+});
+
+it('authenticates the version marker rather than merely carrying it', function () {
+    // The marker is the additional data, so relabelling has to fail the tag. A
+    // prefix outside the tag would be the downgrade the versioning prevents.
+    $key = SodiumEncrypter::generateKey();
+    $sealed = new SodiumEncrypter($key)->encryptString('secret');
+
+    $relabelled = 'signet.v9.' . substr($sealed, strlen(SodiumEncrypter::PREFIX));
+
+    expect(fn() => new SodiumEncrypter($key)->decryptString($relabelled))
+        ->toThrow(DecryptException::class);
+});
+
+it('refuses a payload sealed under another key', function () {
+    $sealed = new SodiumEncrypter(SodiumEncrypter::generateKey())->encryptString('secret');
+
+    expect(fn() => new SodiumEncrypter(SodiumEncrypter::generateKey())->decryptString($sealed))
+        ->toThrow(DecryptException::class, 'sealed with a different key, or has been tampered with');
+});
+
+it('refuses a payload too short to hold a nonce and a tag', function () {
+    $encrypter = new SodiumEncrypter(SodiumEncrypter::generateKey());
+
+    expect(fn() => $encrypter->decryptString(SodiumEncrypter::PREFIX . base64_encode('short')))
+        ->toThrow(DecryptException::class, 'not a valid envelope');
+});
+
+it('refuses a key that is not the length libsodium requires', function () {
+    expect(fn() => new SodiumEncrypter('too short'))
+        ->toThrow(EncryptException::class, 'must be 32 bytes');
+});
+
+it('sends each envelope to the reader that understands it', function () {
+    $sodium = new SodiumEncrypter(SodiumEncrypter::generateKey());
+
+    expect(fn() => $sodium->decryptString(
+        new Encrypter(Encrypter::generateKey(CertificateVault::CIPHER), CertificateVault::CIPHER)
+            ->encryptString('x'),
+    ))->toThrow(DecryptException::class, 'not written by the current envelope');
+});
+
+it('picks the vault encrypter from the length of the key', function () {
+    expect(CertificateVault::withKey(SodiumEncrypter::generateKey())->encrypter())
+        ->toBeInstanceOf(SodiumEncrypter::class)
+        ->and(CertificateVault::withKey(Encrypter::generateKey(CertificateVault::CIPHER))->encrypter())
+        ->toBeInstanceOf(Encrypter::class);
+});
+
+it('keeps writing the envelope this package has always written', function () {
+    // A compatibility fix, not a migration: what an application stores today
+    // it keeps storing, at the same width.
+    $vault = CertificateVault::create();
+
+    expect($vault->encrypter())->toBeInstanceOf(Encrypter::class)
+        ->and(strlen($vault->key()))->toBe(CertificateVault::KEY_LENGTH);
+});
+
+it('refuses a vault key belonging to neither envelope', function () {
+    expect(fn() => CertificateVault::withKey(random_bytes(24)))
+        ->toThrow(InvalidCertificateContentException::class, '24 given');
+});
+
+it('reports the key it was built with, not one read back off the encrypter', function () {
+    $key = SodiumEncrypter::generateKey();
+
+    expect(CertificateVault::withKey($key)->key())->toBe($key);
+});


### PR DESCRIPTION
`lsnepomuceno/signet-pdf` reproduced this package's encryption envelope byte for
byte, for one reason: an application moving between the two cannot re-encrypt a
certificate whose plaintext it no longer holds. Material sealed by either opened
in the other, and both codebases state that guarantee in prose.

**Its 2.0 moved new material onto XChaCha20-Poly1305** through `ext-sodium`, on
the grounds that a signing package should not be assembling encrypt-then-MAC by
hand. That reasoning holds and the change was right there.

What it did here was break the guarantee in one direction. What this package
writes still opens there; what that package now writes does not open here at
all. `withKey()` would not even accept the key, a 32-byte string not being a
valid AES-128-CBC key.

## What this does

`Support\SodiumEncrypter` implements the `signet.v2.` scheme, and
`CertificateVault::withKey()` picks the reader from the key's length: 16 bytes is
this package's own, 32 is signet-pdf's. Those are the only two lengths either has
issued, so the mapping is total and any other length is refused rather than
padded into one of them.

**`create()` is unchanged and still writes this package's envelope.** This is a
compatibility fix, not a migration. Every application keeps storing exactly what
it stored, at the same width, and nothing has to be re-encrypted. Adopting the
new scheme here is a separate decision with a storage consequence, and it can be
taken later on its own terms.

## The test that matters

Not a round-trip through the new class, which would pass even if both halves were
wrong together. It opens a payload **produced by signet-pdf** and pasted in, so
it fails if either package moves:

```php
$key = base64_decode('bamDDgPD9Ge8TS2z4BNFEIef/a9RBdy6WBRzUoWYamY=', true);
$payload = 'signet.v2.7PhSd7EHWJ2J21M5lp84yIvWSNoGG6Ege0omBNxjsxen…';
```

## The one thing worth arguing about

**`CertificateVault::encrypter()` returns `StringEncrypter` where it returned
`Illuminate\Encryption\Encrypter`.** Widening a return type is a break for
anyone type-hinting the concrete class. Nothing inside this package or its tests
calls it, so the blast radius is entirely what consumers do with it.

The alternative was implementing the fuller `Encrypter` contract, which requires
`decrypt($payload, $unserialize = true)`. Offering an `unserialize()` path over
attacker-supplied bytes to solve a compatibility problem is not a trade worth
making, so the property is typed to the two methods the vault actually calls.
That leaves `getKey()` unavailable, so the vault holds its own key, which was
always the vault's: it is what `seal()` returns and what `withKey()` is given.

**Left unmerged deliberately.** That return type is your API to decide about, not
mine.

## Also

`ext-sodium` joins `require`. It ships with PHP and has since 7.2, so on most
systems this changes nothing, but a build compiled without it now fails at
`composer install` rather than at runtime.

The lock's `content-hash` and `platform` block were updated by hand: the
container has no egress here, and the hash was recomputed with
`Locker::getContentHash()`'s algorithm, verified by reproducing the existing hash
from the previous `composer.json` first.

## Verification

pint, PHPStan, and 650 tests with `--fail-on-skipped`, eleven of them new.

Context: `lsnepomuceno/signet-pdf#17`.