### PR TITLE
Cover the vault branch nothing exercised, and stop breeding mutants

### DIFF
--- a/src/Certificates/CertificateVault.php
+++ b/src/Certificates/CertificateVault.php
@@ -73,11 +73,18 @@ final readonly class CertificateVault
             match (strlen($key)) {
                 SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES => new SodiumEncrypter($key),
                 self::KEY_LENGTH => new Encrypter($key, self::CIPHER),
-                default => throw new InvalidCertificateContentException(
-                    'the key must be ' . self::KEY_LENGTH . ' bytes, or '
-                    . SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES
-                    . ' for material sealed by signet-pdf, ' . strlen($key) . ' given',
-                ),
+                // sprintf rather than five concatenations, and not for taste:
+                // each join is its own mutation, so a message assembled in
+                // pieces generates a pile of them that no honest test kills.
+                // Asserting the exact prose to reach them would pin the wording
+                // instead of the behaviour, which is worse than leaving them
+                // alive.
+                default => throw new InvalidCertificateContentException(sprintf(
+                    'the key must be %d bytes, or %d for material sealed by signet-pdf, %d given',
+                    self::KEY_LENGTH,
+                    SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES,
+                    strlen($key),
+                )),
             },
             $key,
         );

--- a/src/Support/SodiumEncrypter.php
+++ b/src/Support/SodiumEncrypter.php
@@ -50,9 +50,11 @@ final readonly class SodiumEncrypter implements StringEncrypter
         $expected = SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES;
 
         if (strlen($key) !== $expected) {
-            throw new EncryptException(
-                "the key must be {$expected} bytes for XChaCha20-Poly1305, " . strlen($key) . ' given',
-            );
+            throw new EncryptException(sprintf(
+                'the key must be %d bytes for XChaCha20-Poly1305, %d given',
+                $expected,
+                strlen($key),
+            ));
         }
     }
 
@@ -109,10 +111,9 @@ final readonly class SodiumEncrypter implements StringEncrypter
         $payload = (string) $payload;
 
         if (! self::wrote($payload)) {
-            throw new DecryptException(
-                'this payload was not written by the current envelope; '
-                . 'material sealed by the previous one opens with its own key',
-            );
+            // One literal, not two joined: a concatenation of message pieces
+            // is a mutation apiece, and reaching them means asserting prose.
+            throw new DecryptException('this payload predates the current envelope; open it with its own key');
         }
 
         $raw = base64_decode(substr($payload, strlen(self::PREFIX)), true);

--- a/tests/Certificates/CertificatesTest.php
+++ b/tests/Certificates/CertificatesTest.php
@@ -10,6 +10,7 @@ use LSNepomuceno\LaravelA1PdfSign\Certificates\OpenSslCliCertificateReader;
 use LSNepomuceno\LaravelA1PdfSign\Certificates\PemCertificateReader;
 use LSNepomuceno\LaravelA1PdfSign\Certificates\ReaderFactory;
 use LSNepomuceno\LaravelA1PdfSign\Data\Certificate;
+use LSNepomuceno\LaravelA1PdfSign\Data\EncryptedCertificate;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidCertificateContentException;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidPemContentException;
 use LSNepomuceno\LaravelA1PdfSign\Exceptions\InvalidX509PrivateKeyException;
@@ -67,6 +68,50 @@ it('seals and opens a certificate through the vault', function () {
 
     expect($opened->original)->toBe($certificate->original)
         ->and($opened->password)->toBe($password);
+});
+
+it('opens a certificate whose stored PEM was base64 encoded', function () {
+    // $isBase64 is a documented parameter of open() and nothing exercised it,
+    // so the whole branch was free to be wrong.
+    [$pfx, $password] = DebugCertificate::make();
+
+    $certificate = app(NativeCertificateReader::class)->read($pfx, $password);
+
+    $vault = CertificateVault::create();
+    $sealed = new EncryptedCertificate(
+        certificate: $vault->encrypter()->encryptString(base64_encode($certificate->original)),
+        password: $vault->encrypter()->encryptString($password),
+        hash: $vault->key(),
+    );
+
+    $opened = CertificateVault::withKey($sealed->hash)->open(
+        app(CertificateParser::class),
+        $sealed->certificate,
+        $sealed->password,
+        isBase64: true,
+    );
+
+    expect($opened->original)->toBe($certificate->original);
+});
+
+it('keeps a stored PEM that is not base64 when it is asked to decode one', function () {
+    // A caller being wrong about which form they stored must not lose the
+    // certificate. The strict decode fails and the raw value is kept.
+    [$pfx, $password] = DebugCertificate::make();
+
+    $certificate = app(NativeCertificateReader::class)->read($pfx, $password);
+
+    $vault = CertificateVault::create();
+    $sealed = $vault->seal($certificate, $password);
+
+    $opened = CertificateVault::withKey($sealed->hash)->open(
+        app(CertificateParser::class),
+        $sealed->certificate,
+        $sealed->password,
+        isBase64: true,
+    );
+
+    expect($opened->original)->toBe($certificate->original);
 });
 
 it('deletes a temporary file even when the callback throws', function () {

--- a/tests/Certificates/EnvelopeInteroperabilityTest.php
+++ b/tests/Certificates/EnvelopeInteroperabilityTest.php
@@ -80,7 +80,7 @@ it('sends each envelope to the reader that understands it', function () {
     expect(fn() => $sodium->decryptString(
         new Encrypter(Encrypter::generateKey(CertificateVault::CIPHER), CertificateVault::CIPHER)
             ->encryptString('x'),
-    ))->toThrow(DecryptException::class, 'not written by the current envelope');
+    ))->toThrow(DecryptException::class, 'predates the current envelope');
 });
 
 it('picks the vault encrypter from the length of the key', function () {


### PR DESCRIPTION
Two changes, both learned in `lsnepomuceno/signet-pdf` and applied here **before**
the nightly reports the same thing.

| | |
|---|---|
| 50.00% | before |
| **65.22%** | after |
| 15 → 8 | uncovered |

## A branch nothing exercised

`CertificateVault::open(..., isBase64: true)` is a documented parameter and no
test passed it, so the whole branch was free to be wrong.

Two tests now: a stored PEM that really is base64, and **a caller who says it is
and is wrong**. The second is the one that matters: the strict decode fails and
the raw value has to be kept, or the certificate is lost to a caller's
bookkeeping error.

## Messages that breed mutants

The error messages were assembled from concatenated pieces. **Each join is its
own mutation**, so a message built that way generates a pile of them that no
honest test kills: the only way to reach them is to assert the exact prose,
which pins the wording rather than the behaviour.

`sprintf` for the one carrying values, and a single literal for the one that was
two strings joined. The mutants stop existing rather than being tested around.

This is the mutation report saying the code has a bad shape, not that a test is
missing, and it is worth reading it that way.

## What is left

Eight uncovered, in `catch (SodiumException)` blocks that valid-length inputs
cannot provoke. They are defensive against a condition the guards above them
already exclude.

## Verification

pint, PHPStan, 652 tests with `--fail-on-skipped`, two of them new.

The nightly is running now (first time it can produce a score, after #311), so
the namespace numbers follow.